### PR TITLE
ROX-30421: Create a bpf bootstrap test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "log",
  "prost",
  "prost-types",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ tonic-build = "0.13.1"
 uuid = { version = "1.17.0", features = ["v4"] }
 which = { version = "6.0.0", default-features = false }
 bindgen = "0.72.0"
+tempfile = { version = "3.20.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ cargo run --release --config 'target."cfg(all())".runner="sudo -E"'
 Cargo build scripts are used to automatically build the eBPF correctly
 and include it in the program.
 
+## Running eBPF unit tests
+
+There is some specific unit tests that execute just the eBPF code and
+the worker retrieving events from them. In order to run these, root
+privileges are required, so a feature is used to exclude them when
+running `cargo test`.
+
+In order to run these tests as part of the unit test suite y use the
+following command:
+
+```shell
+cargo test --config 'target."cfg(all())".runner="sudo -E" --features=bpf-test
+```
+
 ## License
 
 With the exception of eBPF code, fact is distributed under the terms

--- a/fact-ebpf/process.h
+++ b/fact-ebpf/process.h
@@ -45,8 +45,9 @@ __always_inline static const char* get_cpu_cgroup(struct helper_t* helper) {
   int offset = 0;
   for (; i >= 0 && offset < PATH_MAX; i--) {
     // Skip empty directories
-    if (helper->array[i] == NULL)
+    if (helper->array[i] == NULL) {
       continue;
+    }
 
     helper->buf[offset & (PATH_MAX - 1)] = '/';
     if (++offset >= PATH_MAX) {
@@ -99,7 +100,7 @@ __always_inline static int64_t process_fill(process_t* p) {
   p->uid = uid_gid & 0xFFFFFFFF;
   p->gid = (uid_gid >> 32) & 0xFFFFFFFF;
   p->login_uid = BPF_CORE_READ(task, loginuid.val);
-  p->pid = bpf_get_current_pid_tgid() & 0xFFFFFFFF;
+  p->pid = (bpf_get_current_pid_tgid() >> 32) & 0xFFFFFFFF;
   u_int64_t err = bpf_get_current_comm(p->comm, TASK_COMM_LEN);
   if (err != 0) {
     bpf_printk("Failed to fill task comm");
@@ -146,7 +147,7 @@ __always_inline static int64_t process_fill(process_t* p) {
 }
 
 __always_inline static unsigned long get_mnt_namespace() {
-  struct task_struct* task = (struct task_struct*) bpf_get_current_task();
+  struct task_struct* task = (struct task_struct*)bpf_get_current_task();
   struct ns_common ns = BPF_CORE_READ(task, nsproxy, mnt_ns, ns);
 
   return ns.inum;

--- a/fact/Cargo.toml
+++ b/fact/Cargo.toml
@@ -24,6 +24,9 @@ uuid = { workspace = true }
 fact-api = { path = "../fact-api" }
 http-body-util = "0.1.3"
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [build-dependencies]
 anyhow = { workspace = true }
 bindgen = { workspace = true }
@@ -31,3 +34,6 @@ bindgen = { workspace = true }
 [[bin]]
 name = "fact"
 path = "src/main.rs"
+
+[features]
+bpf-test = []

--- a/fact/src/bpf/mod.rs
+++ b/fact/src/bpf/mod.rs
@@ -146,7 +146,7 @@ mod bpf_tests {
         let monitored_path = env!("CARGO_MANIFEST_DIR");
         let monitored_path = PathBuf::from(monitored_path);
         let paths = vec![monitored_path.clone()];
-        let is_external_mount = true;
+        let is_external_mount = false;
 
         executor.block_on(async {
             let bpf = Bpf::new(&paths).expect("Failed to load BPF code");

--- a/fact/src/event.rs
+++ b/fact/src/event.rs
@@ -1,5 +1,4 @@
 use std::{
-    env,
     ffi::CStr,
     path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
@@ -69,10 +68,9 @@ pub struct Process {
 impl Process {
     /// Create a representation of the current process as best as
     /// possible.
-    ///
-    /// Useful for testing.
+    #[cfg(test)]
     pub fn current() -> Self {
-        let exe_path = env::current_exe()
+        let exe_path = std::env::current_exe()
             .expect("Failed to get current exe")
             .into_os_string()
             .into_string()

--- a/fact/src/lib.rs
+++ b/fact/src/lib.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
 use anyhow::Context;
 use bpf::Bpf;
 use log::{info, debug};
 use tokio::{
     signal::unix::{signal, SignalKind},
-    sync::watch::channel,
+    sync::{broadcast, watch},
 };
 
 mod bpf;
@@ -19,7 +21,8 @@ use config::FactConfig;
 use pre_flight::pre_flight;
 
 pub async fn run(config: FactConfig) -> anyhow::Result<()> {
-    let (tx, rx) = channel(true);
+    let (run_tx, run_rx) = watch::channel(true);
+    let (output_tx, mut output_rx) = broadcast::channel(100);
 
     if !config.skip_pre_flight {
         debug!("Performing pre-flight checks");
@@ -37,14 +40,37 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
     }
 
     // Create the gRPC client
-    let client = if let Some(url) = config.url.as_ref() {
+    let mut client = if let Some(url) = config.url.as_ref() {
         Some(Client::start(url, config.certs)?)
     } else {
         None
     };
 
+    let mut running = run_rx.clone();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                event = output_rx.recv() => {
+                    let event = Arc::unwrap_or_clone(event.expect("Failed to receive event"));
+
+                    println!("{event:?}");
+                    if let Some(client) = client.as_mut() {
+                         client.send(event).await.unwrap();
+                    }
+                },
+                _ = running.changed() => {
+                    if !*running.borrow() {
+                        info!("Stopping output worker...");
+                        return;
+                    }
+                }
+            }
+        }
+    });
+
     // Gather events from the ring buffer and print them out.
-    Bpf::start_worker(client, bpf.fd, config.paths, rx.clone());
+    Bpf::start_worker(output_tx, bpf.fd, config.paths, run_rx.clone());
 
     let mut sigterm = signal(SignalKind::terminate())?;
     tokio::select! {
@@ -52,7 +78,7 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
         _ = sigterm.recv() => {}
     }
 
-    tx.send(false)?;
+    run_tx.send(false)?;
     info!("Exiting...");
 
     Ok(())


### PR DESCRIPTION
## Description

The newly added test focuses solely in the bpf implementation, bypassing any additional higher level logic that might be added in the future.

In order to achieve this, the BPF worker task is re-worked to use a broadcast channel, which should also allow us to implement extendable outputs by simply having subscriber tasks that will retrieve events from the same broadcast channel.

The only test implemented thus far simply runs the BPF worker monitoring a temporary directory, creates a file in said directory and checks the generated event as best as possible.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

For the time being the new test can only be run locally, since GHA runners are based on Ubuntu and don't have the bpf capability for LSM. That said, I run the unit test on my machine and it works.
