### PR TITLE
Allow to configure pre-flight checks

### DIFF
--- a/fact/src/config.rs
+++ b/fact/src/config.rs
@@ -20,4 +20,8 @@ pub struct FactConfig {
     /// Whether a small health_check probe should be run
     #[arg(long)]
     pub health_check: bool,
+
+    /// Whether to perform a pre flight check
+    #[arg(long)]
+    pub skip_pre_flight: bool,
 }

--- a/fact/src/lib.rs
+++ b/fact/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use bpf::Bpf;
-use log::info;
+use log::{info, debug};
 use tokio::{
     signal::unix::{signal, SignalKind},
     sync::watch::channel,
@@ -21,7 +21,12 @@ use pre_flight::pre_flight;
 pub async fn run(config: FactConfig) -> anyhow::Result<()> {
     let (tx, rx) = channel(true);
 
-    pre_flight().context("Pre-flight checks failed")?;
+    if !config.skip_pre_flight {
+        debug!("Performing pre-flight checks");
+        pre_flight().context("Pre-flight checks failed")?;
+    } else {
+        debug!("Skipping pre-flight checks");
+    }
 
     let bpf = Bpf::new(&config.paths)?;
 


### PR DESCRIPTION
## Description

`securityfs` might not be always mounted, but it's not a strict requirement. Thus make pre-flight check configurable.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Not tested yet.