### PR TITLE
fix(build): pin clang version used in the image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream9 as builder
 
 RUN dnf install --enablerepo=crb -y \
-        clang \
+        clang-20.1.8-1.el9 \
         libbpf-devel \
         protobuf-compiler \
         protobuf-devel \


### PR DESCRIPTION
## Description

A recent update of clang on CentOS seems to have made the version incompatible with rust-1.84.1, so we can pin it to one that is compatible.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI building the image successfully should be enough.
