### PR TITLE
refactor: Make logging closer to the collector log lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "env_filter",
+ "jiff",
  "log",
 ]
 
@@ -699,6 +700,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +892,21 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "prettyplease"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ aya = { version = "0.13.1", default-features = false }
 
 anyhow = { version = "1", default-features = false, features = ["std", "backtrace"] }
 clap = { version = "4.5.41", features = ["derive", "env"] }
-env_logger = { version = "0.11.5", default-features = false }
+env_logger = { version = "0.11.5", default-features = false, features = ["humantime"] }
 libc = { version = "0.2.159", default-features = false }
 log = { version = "0.4.22", default-features = false }
 prost = "0.13.5"

--- a/fact/src/main.rs
+++ b/fact/src/main.rs
@@ -1,9 +1,28 @@
+use std::io::Write;
+use std::str::FromStr;
+
 use clap::Parser;
-use env_logger::Env;
+use log::LevelFilter;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::Builder::from_env(Env::default().filter_or("FACT_LOGLEVEL", "info")).init();
+    let log_level = std::env::var("FACT_LOGLEVEL").unwrap_or("info".to_owned());
+    let log_level = LevelFilter::from_str(&log_level)?;
+    env_logger::Builder::new()
+        .filter_level(log_level)
+        .format(move |buf, record| {
+            write!(buf, "[{:<5} {}] ", record.level(), buf.timestamp_seconds())?;
+            if matches!(log_level, LevelFilter::Debug | LevelFilter::Trace) {
+                write!(
+                    buf,
+                    "({}:{}) ",
+                    record.file().unwrap_or_default(),
+                    record.line().unwrap_or_default()
+                )?;
+            }
+            writeln!(buf, "{}", record.args())
+        })
+        .init();
 
     let config = fact::config::FactConfig::try_parse()?;
 


### PR DESCRIPTION
## Description

Aside from the logs looking more like the collector logs, it also provides a bit more useful information, like the timestamp in which the log message was generated and a full file path and line if running on debug or trace levels.

<details>
  <summary>Log generated when running in info level (default)</summary>

```
[INFO  2025-08-08T12:11:38Z] Monitoring: "/home/XXXXX/go/src/github.com/molter73/fact"
[INFO  2025-08-08T12:11:39Z] Waiting for Ctrl-C...
^C[INFO  2025-08-08T12:11:40Z] Exiting...
```

</details>

<details>
  <summary>Log generated when running in debug level</summary>

```
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-0.13.1/src/bpf.rs:101) BPF Feature Detection: Features {
    bpf_name: true,
    bpf_probe_read_kernel: true,
    bpf_perf_link: true,
    bpf_global_data: true,
    bpf_cookie: true,
    cpumap_prog_id: true,
    devmap_prog_id: true,
    prog_info_map_ids: true,
    prog_info_gpl_compatible: true,
    btf: Some(
        BtfFeatures {
            btf_func: true,
            btf_func_global: true,
            btf_datasec: true,
            btf_float: true,
            btf_decl_tag: true,
            btf_type_tag: true,
            btf_enum64: true,
        },
    ),
}
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:582) [DATASEC] .bss: fixup size to 4
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:613) [DATASEC] .bss: VAR paths_len: fixup offset 0
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:582) [DATASEC] .maps: fixup size to 80
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:613) [DATASEC] .maps: VAR helper_map: fixup offset 0
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:613) [DATASEC] .maps: VAR paths_map: fixup offset 32
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:613) [DATASEC] .maps: VAR rb: fixup offset 64
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:582) [DATASEC] .rodata: fixup size to 250
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:597) [DATASEC] .rodata: VAR ____trace_file_open.____fmt: fixup not required
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:597) [DATASEC] .rodata: VAR ____trace_file_open.____fmt.1: fixup not required
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:597) [DATASEC] .rodata: VAR ____trace_file_open.____fmt.2: fixup not required
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:597) [DATASEC] .rodata: VAR ____trace_file_open.____fmt.3: fixup not required
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:597) [DATASEC] .rodata: VAR is_monitored.____fmt: fixup not required
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:597) [DATASEC] .rodata: VAR process_fill.____fmt: fixup not required
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:597) [DATASEC] .rodata: VAR process_fill.____fmt.4: fixup not required
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:597) [DATASEC] .rodata: VAR process_fill.____fmt.5: fixup not required
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:597) [DATASEC] .rodata: VAR process_fill.____fmt.6: fixup not required
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:582) [DATASEC] license: fixup size to 13
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/btf/btf.rs:613) [DATASEC] license: VAR _license: fixup offset 0
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 8, kind Rodata at insn 39 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:227) relocating map by symbol index Some(24), kind BtfMaps at insn 17 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 8, kind Rodata at insn 24 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 7, kind Bss at insn 44 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 8, kind Rodata at insn 188 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 8, kind Rodata at insn 12 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:227) relocating map by symbol index Some(23), kind BtfMaps at insn 176 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:227) relocating map by symbol index Some(23), kind BtfMaps at insn 8 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 8, kind Rodata at insn 168 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 7, kind Bss at insn 52 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 8, kind Rodata at insn 181 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:227) relocating map by symbol index Some(26), kind BtfMaps at insn 76 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 8, kind Rodata at insn 271 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 8, kind Rodata at insn 164 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:245) relocating map by section index 8, kind Rodata at insn 120 in section 3
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:344) relocating program `trace_file_open` function `trace_file_open` size 796
[DEBUG 2025-08-08T12:09:13Z] (/home/XXXXX/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-obj-0.2.1/src/relocation.rs:443) finished relocating program `trace_file_open` function `trace_file_open`
[INFO  2025-08-08T12:09:13Z] (/home/XXXXX/go/src/github.com/molter73/fact/fact/src/lib.rs:56) Monitoring: "/home/XXXXX/go/src/github.com/molter73/fact"
[INFO  2025-08-08T12:09:13Z] (/home/XXXXX/go/src/github.com/molter73/fact/fact/src/lib.rs:94) Waiting for Ctrl-C...
^C[INFO  2025-08-08T12:09:17Z] (/home/XXXXX/go/src/github.com/molter73/fact/fact/src/lib.rs:96) Exiting...
```

</details>

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run fact manually and checked the new log lines.
