### PR TITLE
ROX-30436:Use memory cgroup instead of cpu

### DIFF
--- a/fact-ebpf/types.h
+++ b/fact-ebpf/types.h
@@ -19,7 +19,7 @@ typedef struct process_t {
   char comm[TASK_COMM_LEN];
   char args[4096];
   char exe_path[PATH_MAX];
-  char cpu_cgroup[PATH_MAX];
+  char memory_cgroup[PATH_MAX];
   unsigned int uid;
   unsigned int gid;
   unsigned int login_uid;

--- a/fact/src/event.rs
+++ b/fact/src/event.rs
@@ -93,8 +93,8 @@ impl TryFrom<process_t> for Process {
     fn try_from(value: process_t) -> Result<Self, Self::Error> {
         let comm = slice_to_string(value.comm.as_slice())?;
         let exe_path = slice_to_string(value.exe_path.as_slice())?;
-        let cpu_cgroup = unsafe { CStr::from_ptr(value.cpu_cgroup.as_ptr()) }.to_str()?;
-        let container_id = Process::extract_container_id(cpu_cgroup);
+        let memory_cgroup = unsafe { CStr::from_ptr(value.memory_cgroup.as_ptr()) }.to_str()?;
+        let container_id = Process::extract_container_id(memory_cgroup);
 
         let lineage = value.lineage[..value.lineage_len as usize]
             .iter()


### PR DESCRIPTION
## Description

Currently the cpu cgroup is used to extract the container id. It turns out that on openshift cpu controller is not present in the container cgroup, only io, memory and pid. This can lead to BPF program not setting any cgroup value. Switch to the memory cgroup, assuming it's present more often.

As a side note, there is another approach to find out the container id. We could extract cgroup_id directly inside the BPF program (there is a helper for that), and keep a cache of all cgroups found on the system (via iterating over them at start, then update on demand). When cgroup_id is received, we should be able to match it with the cgroup path (cgroup_id == inode of the cgroup path) and use the path to get the container id. This is similar how bpftrace does it.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Manual testing on openshift:
* Spin up a 4.19 cluster
* Create a single pod running fact
* Observe ContainerId captured on the main vs on the PR