### PR TITLE
Skip emptry dentry when evaluating cgroup path

### DIFF
--- a/fact-ebpf/process.h
+++ b/fact-ebpf/process.h
@@ -37,6 +37,10 @@ __always_inline static const char* get_cpu_cgroup(struct helper_t* helper) {
 
   int offset = 0;
   for (; i >= 0 && offset < PATH_MAX; i--) {
+    // Skip empty directories
+    if (helper->array[i] == NULL)
+      continue;
+
     helper->buf[offset & (PATH_MAX - 1)] = '/';
     if (++offset >= PATH_MAX) {
       return NULL;
@@ -44,6 +48,8 @@ __always_inline static const char* get_cpu_cgroup(struct helper_t* helper) {
 
     int len = bpf_probe_read_kernel_str(&helper->buf[offset & (PATH_MAX - 1)], PATH_MAX, helper->array[i]);
     if (len < 0) {
+      // We should have skipped all empty entries, any other error is a genuine
+      // problem, stop processing.
       return NULL;
     }
 


### PR DESCRIPTION
## Description

Currently if faced an empty string in the cgroup path get_cpu_cgroup bails out without taking into account at which point in processing we are. It turns out that at least on openshift every cgroup path ends with an empty segment, meaning that we need to filter them out first.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Manual testing on openshift.