### PR TITLE
fix(ci): Use master branch of collector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       with:
         repository: stackrox/collector
         path: collector
-        ref: mauro/fact/adjust-workflows
+        ref: master
     - uses: actions/setup-python@v5
       with:
         python-version: "3.10"


### PR DESCRIPTION
## Description

After we merged stackrox/collector#2307 we should reference the master branch.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
