### PR TITLE
chore: Push upstream images to quay.io/stackrox-io/fact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,12 @@ jobs:
       with:
         submodules: true
     - run: make image
-    - name: Login to quay.io/rhacs-eng
+    - name: Login to quay.io/stackrox-io
       uses: docker/login-action@v3
       with:
         registry: quay.io
-        username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-        password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+        username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+        password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
     - run: docker push "$(make image-name)"
 
   integration-tests:
@@ -119,16 +119,16 @@ jobs:
       env:
         FACT_VERSION: ${{ github.head_ref || github.ref_name }}
       run: |
-        FACT_TAG="$(make -sC "${GITHUB_WORKSPACE}/fact")"
+        FACT_IMAGE_NAME="$(make -sC "${GITHUB_WORKSPACE}/fact" image-name)"
         cat << EOF > vars.yml
         ---
         job_id: ${JOB_ID}
         fact:
-          tag: ${FACT_TAG}
+          image: ${FACT_IMAGE_NAME}
           version: ${FACT_VERSION}
         quay:
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
         EOF
 
     - name: Create Test VMs

--- a/ansible/run-tests.yml
+++ b/ansible/run-tests.yml
@@ -2,7 +2,7 @@
 - name: Run integration tests
   hosts: "job_id_{{ job_id }}"
   environment:
-    FACT_TAG: "{{ fact.tag | default(None) }}"
+    FACT_IMAGE_NAME: "{{ fact.image | default(None) }}"
 
   tasks:
     - name: Install dependencies

--- a/constants.mk
+++ b/constants.mk
@@ -1,2 +1,3 @@
 FACT_TAG ?= $(shell git describe --always --tags --abbrev=10 --dirty)
-FACT_IMAGE_NAME ?= quay.io/rhacs-eng/fact:$(FACT_TAG)
+FACT_REGISTRY ?= quay.io/stackrox-io/fact
+FACT_IMAGE_NAME ?= $(FACT_REGISTRY):$(FACT_TAG)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@ include ../constants.mk
 all: pytest
 
 pytest: grpc-gen
-	pytest --tag="${FACT_TAG}" --junit-xml=results.xml
+	pytest --image="${FACT_IMAGE_NAME}" --junit-xml=results.xml
 
 PYOUT = $(CURDIR)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,8 +54,7 @@ def logs_dir(request):
 
 @pytest.fixture(scope='session', autouse=True)
 def get_image(request, docker_client):
-    tag = request.config.getoption('--tag')
-    image = f'quay.io/rhacs-eng/fact:{tag}'
+    image = request.config.getoption('--image')
     try:
         docker_client.images.get(image)
     except docker.errors.ImageNotFound:
@@ -78,9 +77,9 @@ def fact(request, docker_client, temp_dir, server, logs_dir):
         '-p', temp_dir,
         '--health-check',
     ]
-    tag = request.config.getoption('--tag')
+    image = request.config.getoption('--image')
     container = docker_client.containers.run(
-        f'quay.io/rhacs-eng/fact:{tag}',
+        image,
         command=command,
         detach=True,
         environment={
@@ -141,5 +140,5 @@ def executor():
 
 
 def pytest_addoption(parser):
-    parser.addoption('--tag', action='store', default='latest',
-                     help='The tag to be used for testing')
+    parser.addoption('--image', action='store', default='quay.io/stackrox-io/fact:latest',
+                     help='The image to be used for testing')


### PR DESCRIPTION
## Description

This is related to the efforts to build fact on konflux. After some discussion, we have made the decision to push upstream images (those built on GHA) to quay.io/stackrox-io/fact and quay.io/rhacs-eng/fact will hold the downstream images (konflux built)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
