### PR TITLE
fix: Userspace properly parses arguments

### DIFF
--- a/fact-ebpf/process.h
+++ b/fact-ebpf/process.h
@@ -109,9 +109,9 @@ __always_inline static int64_t process_fill(process_t* p) {
 
   unsigned long arg_start = BPF_CORE_READ(task, mm, arg_start);
   unsigned long arg_end = BPF_CORE_READ(task, mm, arg_end);
-  unsigned int len = (arg_end - arg_start) & 0xFFF;
+  p->args_len = (arg_end - arg_start) & 0xFFF;
   p->args[4095] = '\0';  // Ensure string termination at end of buffer
-  err = bpf_probe_read_user(p->args, len, (const char*)arg_start);
+  err = bpf_probe_read_user(p->args, p->args_len, (const char*)arg_start);
   if (err != 0) {
     bpf_printk("Failed to fill task args");
     return err;

--- a/fact-ebpf/types.h
+++ b/fact-ebpf/types.h
@@ -18,6 +18,7 @@ typedef struct lineage_t {
 typedef struct process_t {
   char comm[TASK_COMM_LEN];
   char args[4096];
+  unsigned int args_len;
   char exe_path[PATH_MAX];
   char cpu_cgroup[PATH_MAX];
   unsigned int uid;

--- a/fact/src/event.rs
+++ b/fact/src/event.rs
@@ -153,8 +153,9 @@ impl TryFrom<process_t> for Process {
             .collect::<Result<Vec<_>, _>>()?;
 
         let mut converted_args = Vec::new();
+        let args_len = value.args_len as usize;
         let mut offset = 0;
-        while offset < 4096 {
+        while offset < args_len {
             let arg = unsafe { CStr::from_ptr(value.args.as_ptr().add(offset)) }
                 .to_str()?
                 .to_owned();


### PR DESCRIPTION
## Description

Argument parsing was working under the wrong assumption that the kernel kept an empty string after all the arguments. Instead, we should send the length that has actually been copied from the kernel to userspace and use that to stop parsing.

Closes #19 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run fact for quite some time locally and did not get a UTF error that was happening before.
