### PR TITLE
chore(build): improve error messages

### DIFF
--- a/fact-api/build.rs
+++ b/fact-api/build.rs
@@ -1,9 +1,12 @@
+use anyhow::Context;
+
 fn main() -> anyhow::Result<()> {
     tonic_build::configure()
         .build_server(false)
         .compile_protos(
             &["../third_party/stackrox/proto/internalapi/sensor/sfa_iservice.proto"],
             &["../third_party/stackrox/proto"],
-        )?;
+        )
+        .context("Failed to compile protos. Please makes sure you update your git submodules!")?;
     Ok(())
 }


### PR DESCRIPTION
## Description

Adds context messages to errors bubbled up during the Cargo build scripts.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - ~~[ ] Added unit tests~~
  - ~~[ ] Added integration tests~~
  - ~~[ ] Added regression tests~~

N/A.

## Testing Performed

Example if the developer doesn't have `clang` installed:

Before:
```
Caused by:
    process didn't exit successfully: `fact/target/debug/build/fact-311825a73a6c6d02/build-script-build` (exit status: 1)
    --- stdout
    cargo::rerun-if-changed=../fact-ebpf/
    --- stderr
    Error: No such file or directory (os error 2)
```
After:
```
Caused by:
    process didn't exit successfully: `fact/target/debug/build/fact-311825a73a6c6d02/build-script-build` (exit status: 1)
    --- stdout
    cargo::rerun-if-changed=../fact-ebpf/
    --- stderr
    Error: Failed to compile eBPF
    Caused by:
        Failed to execute clang: No such file or directory (os error 2)
```