### PR TITLE
chore: bump fact version to 0.2.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "fact"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "aya",

--- a/fact/Cargo.toml
+++ b/fact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fact"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2021"
 
 license.workspace = true


### PR DESCRIPTION
## Description

Given the `release-0.1` branch is already in place, this PR bumps the fact version for the application to `0.2.0`. The `-dev` suffix is added to make it clear this is a version in active development, this suffix should be dropped when creating the `release-0.2` branch.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
