### PR TITLE
fix: Ignore vmlinux in GH stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-vmlinux.h linguist-generated
+fact-ebpf/vmlinux/** linguist-generated


### PR DESCRIPTION
## Description

This was an oversight on #30.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Commited the changes to my local `main` branch and run the `github-linguist` container, got the following output:
```
54.68%  32225      Rust
19.57%  11534      C
19.02%  11207      Python
3.85%   2270       Dockerfile
2.88%   1695       Makefile
```
