### PR TITLE
ROX-30439: Fixes for Linux 6.6

### DIFF
--- a/fact-ebpf/process.h
+++ b/fact-ebpf/process.h
@@ -104,7 +104,8 @@ __always_inline static int64_t process_fill(process_t* p) {
   p->uid = uid_gid & 0xFFFFFFFF;
   p->gid = (uid_gid >> 32) & 0xFFFFFFFF;
   p->login_uid = BPF_CORE_READ(task, loginuid.val);
-  p->pid = (bpf_get_current_pid_tgid() >> 32) & 0xFFFFFFFF;
+  // bpf_get_current_pid_tgid() is not available for LSM programs prior to 6.8
+  p->pid = BPF_CORE_READ(task, tgid) & 0xFFFFFFFF;
   u_int64_t err = bpf_get_current_comm(p->comm, TASK_COMM_LEN);
   if (err != 0) {
     bpf_printk("Failed to fill task comm");


### PR DESCRIPTION
## Description

When deploying GKE with image flavor==COS_CONTAINERD, the 6.6 kernel refuses to load the probe.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests
 
fixes #34 
