### PR TITLE
fix(konflux): update sha digest of broken tasks

### DIFF
--- a/.tekton/fact-component-pipeline.yaml
+++ b/.tekton/fact-component-pipeline.yaml
@@ -382,7 +382,7 @@ spec:
       - name: name
         value: deprecated-image-check
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:c49732039f105de809840be396f83ead8c46f6a6948e1335b76d37e9eb469574
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:1f57224c21021b2d497bac73312386d7421ec949241280a20102192acf1d01d3
       - name: kind
         value: task
       resolver: bundles
@@ -402,7 +402,7 @@ spec:
       - name: name
         value: clair-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:076d5cde62b55bbfcdda2b4782392256bbda5ad38f839013b4330b3aba70a973
+        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:c5cb2e44d2b98eeb8f3a8edb39f3684e6d2342e8f080a7e1d9b0d6ecfb071d94
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Description

Konflux builds are failing with the following message:
```
Pipeline rh-acs-tenant/fact-on-push-pv2l2 can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "resolver type bundles\nname = deprecated-image-check\n": error requesting remote resource: error getting "bundleresolver" "rh-acs-tenant/bundles-7f3141b552b07f8a5bd55b7a854886ab": cannot retrieve the oci image: GET https://quay.io/v2/konflux-ci/tekton-catalog/task-deprecated-image-check/manifests/sha256:c49732039f105de809840be396f83ead8c46f6a6948e1335b76d37e9eb469574: MANIFEST_UNKNOWN: manifest unknown; map[] 
```

Updating the digest for the image manually yielded a similar error on the clair-scan task, so updating that SHA as well.

Currently asking around to see why this might have happened, for now I think we can just do this manual update in order to get the builds back to a working state.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
