### PR TITLE
ROX-30835: make ringbuffer size configurable

### DIFF
--- a/fact-ebpf/maps.h
+++ b/fact-ebpf/maps.h
@@ -31,7 +31,6 @@ uint32_t paths_len;
 
 struct {
   __uint(type, BPF_MAP_TYPE_RINGBUF);
-  __uint(max_entries, 256 * sizeof(struct event_t));
 } rb SEC(".maps");
 
 struct {

--- a/fact/src/lib.rs
+++ b/fact/src/lib.rs
@@ -32,7 +32,7 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
         debug!("Skipping pre-flight checks");
     }
 
-    let mut bpf = Bpf::new(config.paths())?;
+    let mut bpf = Bpf::new(&config)?;
 
     if config.health_check() {
         // At this point the BPF code is in the kernel, we can start our


### PR DESCRIPTION
## Description

This makes it easier to accommodate fact on systems with constrained memory and might prevent events being dropped on higher demanding environments.

It should also be a nice tool for performance testing once we get that setup.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Manually checked changing the size of the ringbuffer causes event drops when set too low.
```
# HELP stackrox_fact_bpf_events Events processed by the BPF worker.
# TYPE stackrox_fact_bpf_events counter
stackrox_fact_bpf_events_total{label="Added"} 4
stackrox_fact_bpf_events_total{label="Dropped"} 0
stackrox_fact_bpf_events_total{label="Ignored"} 266
# HELP stackrox_fact_output_stdout_events Events processed by the stdout output component.
# TYPE stackrox_fact_output_stdout_events counter
stackrox_fact_output_stdout_events_total{label="Added"} 4
stackrox_fact_output_stdout_events_total{label="Dropped"} 0
# HELP stackrox_fact_output_grpc_events Events processed by the grpc output component.
# TYPE stackrox_fact_output_grpc_events counter
stackrox_fact_output_grpc_events_total{label="Dropped"} 0
stackrox_fact_output_grpc_events_total{label="Added"} 0
# HELP stackrox_fact_kernel_file_open_events Events processed by the file_open LSM hook.
# TYPE stackrox_fact_kernel_file_open_events counter
stackrox_fact_kernel_file_open_events_total{label="Added"} 270
stackrox_fact_kernel_file_open_events_total{label="Total"} 35625
stackrox_fact_kernel_file_open_events_total{label="RingbufferFull"} 4
stackrox_fact_kernel_file_open_events_total{label="Error"} 0
stackrox_fact_kernel_file_open_events_total{label="Ignored"} 35351
# EOF
```
