### PR TITLE
feat: Add a basic k8s manifest

### DIFF
--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: fact
+  name: fact
+spec:
+  selector:
+    matchLabels:
+      app: fact
+  template:
+    metadata:
+      labels:
+        app: fact
+    spec:
+      containers:
+      - name: fact
+        image: quay.io/stackrox-io/fact:0.1.0
+        imagePullPolicy: IfNotPresent
+        args:
+            - --paths
+            - /etc:/bin:/sbin:/usr/bin:/usr/sbin
+        ports:
+          - containerPort: 9001
+            name: monitoring
+        env:
+        - name: FACT_LOGLEVEL
+          value: 'debug'
+        securityContext:
+          capabilities:
+            drop:
+            - NET_RAW
+          privileged: true
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /sys
+          name: sys-ro
+          readOnly: true
+          mountPropagation: HostToContainer
+      volumes:
+      - hostPath:
+          path: /sys/
+        name: sys-ro


### PR DESCRIPTION
## Description

The added manifest is based off of the work done on stackrox/stackrox#16627 by Dmitrii. All it does is spin up a DaemonSet with fact as its only container, mounting the required `/sys` directory and configuring it to monitor some paths that should be relatively quite.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Deployed fact on a local kind cluster.
- [ ] Deployed fact on an OCP cluster.