### PR TITLE
ROX-30440: ensure code is properly formatted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
         key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ steps.args.outputs.args }}-${{ hashFiles('**/Cargo.lock') }}
     - run: cargo ${{ matrix.args }}
 
+  format-check:
+    runs-on: ubuntu-24.04
+    env:
+      CLANG_FMT: clang-format-18
+    steps:
+    - uses: actions/checkout@v4
+    - run: make format-check
+
   vars:
     runs-on: ubuntu-24.04
     outputs:

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,12 @@ integration-tests:
 clean:
 	make -C tests clean
 
+format-check:
+	cargo fmt --check
+	make -C fact-ebpf format-check
+
+format:
+	cargo fmt
+	make -C fact-ebpf format
+
 .PHONY: tag mock-server integration-tests image image-name clean

--- a/constants.mk
+++ b/constants.mk
@@ -1,3 +1,5 @@
 FACT_TAG ?= $(shell git describe --always --tags --abbrev=10 --dirty)
 FACT_REGISTRY ?= quay.io/stackrox-io/fact
 FACT_IMAGE_NAME ?= $(FACT_REGISTRY):$(FACT_TAG)
+
+CLANG_FMT ?= $(shell which clang-format)

--- a/fact-ebpf/Makefile
+++ b/fact-ebpf/Makefile
@@ -1,0 +1,13 @@
+include ../constants.mk
+
+format-check:
+	find . \
+		-iname 'vmlinux' -type d -prune -or \
+		-type f \( -iname '*.h' -or -iname '*.c' \) -print \
+	| xargs $(CLANG_FMT) -Werror --style=file -n
+
+format:
+	find . \
+		-iname 'vmlinux' -type d -prune -or \
+		-type f \( -iname '*.h' -or -iname '*.c' \) -print \
+	| xargs $(CLANG_FMT) -Werror --style=file -i

--- a/fact-ebpf/src/bpf/file.h
+++ b/fact-ebpf/src/bpf/file.h
@@ -172,4 +172,3 @@ __always_inline static bool is_monitored(const char* s) {
   }
   return false;
 }
-

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,1 @@
-group_imports = "StdExternalCrate"
-imports_granularity = "Crate"
 reorder_imports = true
-unstable_features = true


### PR DESCRIPTION


## Description

This patch adds a few make targets that should help keep our code nicely formatted. The targets allow checking for proper formatting of both the rust code as well as the C code for BPF.

A new CI job is added to enforce formatting broadly.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
