### PR TITLE
fix: adjust gitattributes to ignore vmlinux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-fact-ebpf/vmlinux/** linguist-generated
+**/vmlinux/** linguist-generated


### PR DESCRIPTION
## Description

Since #72 moved the `vmlinux` directory, we need to adjust the `.gitattributes` file again, hopefully this time for good.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Committed the change to the main branch on my local clone of the repository and run linguist on it, got the following output:
```
68.52%  75868      Rust
16.38%  18138      Python
11.48%  12708      C
2.06%   2283       Dockerfile
1.56%   1732       Makefile
```