### PR TITLE
refactor: move log startup logic to lib.rs and simplify uname handling

### DIFF
--- a/fact/src/main.rs
+++ b/fact/src/main.rs
@@ -1,42 +1,12 @@
-use std::io::Write;
-use std::str::FromStr;
-
-use fact::{
-    config::FactConfig,
-    host_info::{get_architecture, get_distro, get_kernel_version},
-};
-use log::{info, LevelFilter};
-
-mod version {
-    include!(concat!(env!("OUT_DIR"), "/version.rs"));
-}
+use fact::config::FactConfig;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let log_level = std::env::var("FACT_LOGLEVEL").unwrap_or("info".to_owned());
-    let log_level = LevelFilter::from_str(&log_level)?;
-    env_logger::Builder::new()
-        .filter_level(log_level)
-        .format(move |buf, record| {
-            write!(buf, "[{:<5} {}] ", record.level(), buf.timestamp_seconds())?;
-            if matches!(log_level, LevelFilter::Debug | LevelFilter::Trace) {
-                write!(
-                    buf,
-                    "({}:{}) ",
-                    record.file().unwrap_or_default(),
-                    record.line().unwrap_or_default()
-                )?;
-            }
-            writeln!(buf, "{}", record.args())
-        })
-        .init();
+    fact::init_log()?;
 
     // Log system information as early as possible so we have it
     // available in case of a crash
-    info!("fact version: {}", version::FACT_VERSION);
-    info!("OS: {}", get_distro());
-    info!("Kernel version: {}", get_kernel_version());
-    info!("Architecture: {}", get_architecture());
+    fact::log_system_information();
 
     let config = FactConfig::new(&[
         "/etc/stackrox/fact.yml",


### PR DESCRIPTION
## Description

Cleanup the main function by moving the log initialization and logging of system information to lib.rs as functions.

Additionally, the get_kernel_version and get_architecture functions from the host_info module have been replaced with a SystemInfo type. This means the underlying LazyLock<HashMap> that was originally used is no longer needed, the caller can decide what the lifetime of the object should be and, therefore, we don't need to hang on to that information for the entire time fact is running.

Finally, the hostname has also been added to the list of information being logged at start up.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Output from running fact locally:
```
[INFO  2025-09-19T09:16:12Z] fact version: 0.1.x-38-g93d65e08e4-dirty
[INFO  2025-09-19T09:16:12Z] OS: Fedora Linux 42 (Workstation Edition)
[INFO  2025-09-19T09:16:12Z] Kernel version: 6.16.7-200.fc42.x86_64
[INFO  2025-09-19T09:16:12Z] Architecture: x86_64
[INFO  2025-09-19T09:16:12Z] Hostname: XXXXX
[INFO  2025-09-19T09:16:12Z] FactConfig {
    paths: Some(
        [
            "/etc",
        ],
    ),
    url: None,
    certs: None,
    health_check: None,
    skip_pre_flight: None,
    json: None,
    ringbuf_size: None,
}
[INFO  2025-09-19T09:16:12Z] Starting metrics server
[INFO  2025-09-19T09:16:12Z] Starting BPF worker...
^C[INFO  2025-09-19T09:16:15Z] Exiting...
[INFO  2025-09-19T09:16:15Z] Stopping stdout output...
[INFO  2025-09-19T09:16:15Z] Stopping BPF worker...
```
