### PR TITLE
fix: log the correct versions in CI built containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 0
 
     - id: vars
       run: |
@@ -100,6 +101,7 @@ jobs:
     runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
     env:
       FACT_TAG: ${{ needs.vars.outputs.tag }}-${{ matrix.arch }}
+      FACT_VERSION: ${{ needs.vars.outputs.tag }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 
 COPY . .
 
-ARG FACT_TAG
+ARG FACT_VERSION
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/app/target \
     cargo build --release && \

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ include constants.mk
 tag:
 	@echo "$(FACT_TAG)"
 
+version:
+	@echo "$(FACT_VERSION)"
+
 image-name:
 	@echo "$(FACT_IMAGE_NAME)"
 
@@ -12,7 +15,7 @@ mock-server:
 image:
 	docker build \
 		-f Containerfile \
-		--build-arg FACT_TAG=$(FACT_TAG) \
+		--build-arg FACT_VERSION=$(FACT_VERSION) \
 		-t $(FACT_IMAGE_NAME) \
 		$(CURDIR)
 

--- a/constants.mk
+++ b/constants.mk
@@ -1,4 +1,5 @@
 FACT_TAG ?= $(shell git describe --always --tags --abbrev=10 --dirty)
+FACT_VERSION ?= $(FACT_TAG)
 FACT_REGISTRY ?= quay.io/stackrox-io/fact
 FACT_IMAGE_NAME ?= $(FACT_REGISTRY):$(FACT_TAG)
 

--- a/fact/build.rs
+++ b/fact/build.rs
@@ -7,12 +7,14 @@ fn main() -> anyhow::Result<()> {
     let out_dir: PathBuf = std::env::var("OUT_DIR")
         .context("Failed to interpret OUT_DIR environment variable")?
         .into();
-    let cmd = Command::new("make").args(["-sC", "..", "tag"]).output()?;
+    let cmd = Command::new("make")
+        .args(["-sC", "..", "version"])
+        .output()?;
 
     if !cmd.status.success() {
         eprintln!("Captured stdout: {}", String::from_utf8_lossy(&cmd.stdout));
         eprintln!("Captured stderr: {}", String::from_utf8_lossy(&cmd.stderr));
-        bail!("Failed to run `make tag`: {:?}", cmd.status.code());
+        bail!("Failed to run `make version`: {:?}", cmd.status.code());
     }
 
     let version = String::from_utf8(cmd.stdout)?;

--- a/konflux.Containerfile
+++ b/konflux.Containerfile
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi9/ubi@sha256:7ff0b510498fa9f368a58e735e0c57f3497fd3205dbc2ea5e6e8ddf84f48752f AS builder
 
+ARG FACT_TAG
+RUN echo "Checking required FACT_TAG"; [[ "${FACT_TAG}" != "" ]]
+
 RUN dnf install -y \
         clang \
         libbpf-devel \
@@ -17,7 +20,6 @@ RUN cargo build --release
 FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:f5c5213d2969b7b11a6666fc4b849d56b48d9d7979b60a37bb853dff0255c14b
 
 ARG FACT_TAG
-RUN echo "Checking required FACT_TAG"; [[ "${FACT_TAG}" != "" ]]
 
 LABEL \
     com.redhat.license_terms="https://www.redhat.com/agreements" \


### PR DESCRIPTION
## Description

After inspecting the test logs from CI it became apparent there are a few issues. On GHA built containers, the version looks like this:
```
[INFO  2025-09-19T09:37:46Z] (fact/src/lib.rs:53) fact version: 47c1a04967-arm64
```

There are two problems with that version:
* It includes the architecture information as part of the version, which it shouldn't do.
* The actual version is the commit SHA instead of the rev-parse digest.

These are fixed by having independent FACT_TAG and FACT_VERSION variables in the build and checking out the full git history when determining the version respectively.

On konflux built containers, the version looks like this:
```
[INFO  2025-09-19T09:46:00Z] (fact/src/lib.rs:53) fact version:
```

This is because the `FACT_TAG` argument is only being set on the final stage of the Containerfile.


## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Verify the generated images log the proper versions.
