### PR TITLE
fix: install rust toolchain via rustup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         sudo apt-get install -y \
           libbpf-dev \
           protobuf-compiler
+
+        rustup component add clippy
+
     - shell: python
       id: args
       run: |
@@ -69,7 +72,10 @@ jobs:
       CLANG_FMT: clang-format-18
     steps:
     - uses: actions/checkout@v4
-    - run: make format-check
+    - name: Check code format
+      run: |
+        rustup component add rustfmt
+        make format-check
 
   vars:
     runs-on: ubuntu-24.04

--- a/Containerfile
+++ b/Containerfile
@@ -4,9 +4,11 @@ RUN dnf install --enablerepo=crb -y \
         clang-19.1.7 \
         libbpf-devel \
         protobuf-compiler \
-        protobuf-devel \
-        cargo-1.84.1 \
-        rust-1.84.1
+        protobuf-devel && \
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+            sh -s -- -y --default-toolchain 1.84 --profile minimal
+
+ENV PATH=/root/.cargo/bin:${PATH}
 
 WORKDIR /app
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.84"
-components = ["rustfmt", "rust-analyzer", "clippy"]


### PR DESCRIPTION
## Description

CentOS Stream 9 has removed rust 1.84 from its toolchain and our image builds are failing to install the package. Because we are not building upstream in an airtight environment, we can work around this by installing rustup and installing the 1.84 toolchain with it.

The components removed from the `rust-toolchain.toml` file make it possible for the image build to run with the minimal set of dependencies, meaning the intermediate image is smaller and the build is faster, The downside being we now have to manually install clippy and rustfmt on CI.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
