### PR TITLE
refactor: use new type for C enum bindings

### DIFF
--- a/fact-ebpf/build.rs
+++ b/fact-ebpf/build.rs
@@ -44,6 +44,10 @@ fn generate_bindings(out_dir: &Path) -> anyhow::Result<()> {
         .header("src/bpf/types.h")
         .derive_default(true)
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .default_enum_style(bindgen::EnumVariation::NewType {
+            is_bitfield: false,
+            is_global: false,
+        })
         .generate()
         .context("Failed to generate bindings")?;
     bindings

--- a/fact-ebpf/src/lib.rs
+++ b/fact-ebpf/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, non_camel_case_types, non_upper_case_globals)]
+#![allow(dead_code, non_camel_case_types)]
 
 use std::{ffi::c_char, path::PathBuf};
 

--- a/fact/src/bpf.rs
+++ b/fact/src/bpf.rs
@@ -143,7 +143,7 @@ mod bpf_tests {
     use std::{env, path::PathBuf, time::Duration};
 
     use anyhow::Context;
-    use fact_ebpf::file_activity_type_t_FILE_ACTIVITY_CREATION;
+    use fact_ebpf::file_activity_type_t;
     use tempfile::NamedTempFile;
     use tokio::{sync::watch, time::timeout};
 
@@ -182,7 +182,7 @@ mod bpf_tests {
             println!("Created {file:?}");
 
             let expected = Event::new(
-                file_activity_type_t_FILE_ACTIVITY_CREATION,
+                file_activity_type_t::FILE_ACTIVITY_CREATION,
                 host_info::get_hostname(),
                 file.path().to_path_buf(),
                 file.path().to_path_buf(),

--- a/fact/src/event.rs
+++ b/fact/src/event.rs
@@ -6,12 +6,7 @@ use fact_api::FileActivity;
 use serde::Serialize;
 use uuid::Uuid;
 
-#[cfg(test)]
-use fact_ebpf::file_activity_type_t;
-use fact_ebpf::{
-    event_t, file_activity_type_t_FILE_ACTIVITY_CREATION, file_activity_type_t_FILE_ACTIVITY_OPEN,
-    lineage_t, process_t,
-};
+use fact_ebpf::{event_t, file_activity_type_t, lineage_t, process_t};
 
 use crate::host_info;
 
@@ -262,7 +257,6 @@ pub enum Event {
 
 impl Event {
     #[cfg(test)]
-    #[allow(non_upper_case_globals)]
     pub fn new(
         event_type: file_activity_type_t,
         hostname: &'static str,
@@ -271,13 +265,13 @@ impl Event {
         process: Process,
     ) -> Self {
         match event_type {
-            file_activity_type_t_FILE_ACTIVITY_OPEN => {
+            file_activity_type_t::FILE_ACTIVITY_OPEN => {
                 EventOpen::new(hostname, filename, host_file, process).into()
             }
-            file_activity_type_t_FILE_ACTIVITY_CREATION => {
+            file_activity_type_t::FILE_ACTIVITY_CREATION => {
                 EventCreation::new(hostname, filename, host_file, process).into()
             }
-            invalid => unreachable!("Invalid event type: {invalid}"),
+            invalid => unreachable!("Invalid event type: {invalid:?}"),
         }
     }
 
@@ -292,14 +286,13 @@ impl Event {
 impl TryFrom<&event_t> for Event {
     type Error = anyhow::Error;
 
-    #[allow(non_upper_case_globals)]
     fn try_from(value: &event_t) -> Result<Self, Self::Error> {
         match value.type_ {
-            file_activity_type_t_FILE_ACTIVITY_OPEN => Ok(EventOpen::try_from(value)?.into()),
-            file_activity_type_t_FILE_ACTIVITY_CREATION => {
+            file_activity_type_t::FILE_ACTIVITY_OPEN => Ok(EventOpen::try_from(value)?.into()),
+            file_activity_type_t::FILE_ACTIVITY_CREATION => {
                 Ok(EventCreation::try_from(value)?.into())
             }
-            id => unreachable!("Invalid event type: {id}"),
+            id => unreachable!("Invalid event type: {id:?}"),
         }
     }
 }


### PR DESCRIPTION

## Description

This change makes it so the generated bindings for enums uses a new type with constants defined in the type's impl block instead of generating global constants with the type concatenated with the variant name.

In practice, this means we go from having:
```rust
file_activity_type_t_FILE_ACTIVITY_CREATION
```

To:
```rust
file_activity_type_t::FILE_ACTIVITY_CREATION
```

Which seems little, but is more idiomatic and lets us get rid of some allow(non_upper_case_globals) linting exclusions.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
