### PR TITLE
ci: automerge konflux update PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,15 +76,13 @@
     "matchPackageNames": ["/.*/"],
     "groupName": "All updates",
     "automerge": true,
-    // A known issue is that some non-Konflux CI jobs in currently fail, which may prevent successful auto-merging with a "branch" auto-merge setting.
-    // Therefore, we use PR merge type and have automation approve PRs.
-    "automergeType": "pr",
+    // PRs can't be actually automerged because we require approval from CODEOWNERS which Renovate can't bypass,
+    // therefore, we set automerge type to branch.
+    "automergeType": "branch",
     "automergeStrategy": "squash",
     // Tell Renovate that it can automerge branches at any time of the day.
     "automergeSchedule": [
       "at any time"
     ],
-    "platformAutomerge": true,
   }],
-  "labels": ["auto-approve"],
 }


### PR DESCRIPTION
## Description

Change the renovate configuration so that the konflux update PRs can be auto merged.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

None.
