### PR TITLE
ci: Run checks against konflux/ branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - main
     - release-*
+    - konflux/**
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/konflux-tests.yml
+++ b/.github/workflows/konflux-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - main
     - release-*
+    - konflux/**
     tags:
     - '*'
   pull_request:

--- a/.tekton/fact-build.yaml
+++ b/.tekton/fact-build.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "pull_request" && body.action != "ready_for_review") || (
-        event == "push" && target_branch.matches("^(main|release-.*|refs/tags/.*)$")
+        event == "push" && target_branch.matches("^(main|release-.*|refs/tags/.*|konflux/.*)$")
       )
   labels:
     appstudio.openshift.io/application: acs


### PR DESCRIPTION
## Description

This is the prefix used by the updates that konflux makes, the checks need to run on push since we no longer require a PR for it and the renovate bot requires the checks to run. This is explained here: https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging

Followup from #88 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Will check the changes are applied and the checks run against the branches once the PR is merge.
