### PR TITLE
fix(konflux): miscellaneous konflux fixes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,17 +59,11 @@
       ],
     },
   },
-  "rpm": {
-    "schedule": [
-      // Override Konflux custom schedule for this manager to our intended one.
-      "after 3am and before 7am",
-    ],
-  },
   "enabledManagers": [
     // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.
     "tekton",
     "dockerfile",
-    "rpm",
+    "rpm-lockfile",
     "cargo",
   ],
   "packageRules": [{

--- a/.tekton/fact-component-pipeline.yaml
+++ b/.tekton/fact-component-pipeline.yaml
@@ -138,8 +138,8 @@ spec:
     params:
     - name: image-url
       # We can't provide a StackRox-style tag because it is not known at this time (requires cloning source, etc.)
-      # As a workaround, we still provide a unique tag that's based on a revision to this task to comply with its
-      # expected input. We later actually add this tag on a built image with build-image-index-extra task.
+      # As a workaround, we still provide a unique tag that's based on a revision in order for this task to comply with
+      # its expected input. We later actually add this tag on a built image with the apply-index-image-tag task.
       value: $(params.output-image-repo):konflux-$(params.revision)
     - name: rebuild
       value: $(params.rebuild)
@@ -319,23 +319,21 @@ spec:
       operator: in
       values: [ "true" ]
 
-  - name: build-image-index-extra
+  - name: apply-index-image-tag
     params:
-    - name: IMAGE
-      value: $(params.output-image-repo):konflux-$(params.revision)
-    - name: COMMIT_SHA
-      value: $(tasks.clone-repository.results.commit)
-    - name: IMAGES
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: ADDITIONAL_TAGS
       value:
-      - $(tasks.build-containers.results.IMAGE_REF[*])
-    - name: IMAGE_EXPIRES_AFTER
-      value: $(tasks.determine-image-expiration.results.IMAGE_EXPIRES_AFTER)
+      - konflux-$(params.revision)
     taskRef:
       params:
       - name: name
-        value: build-image-index
+        value: apply-tags
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:8e5dfb2fac011148f8715bbe0b99415f88297683d269eae0dfcad52562195d45
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:f44be1bf0262471f2f503f5e19da5f0628dcaf968c86272a2ad6b4871e708448
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Description

* Replace `rpm` package manager with `rpm-lockfile`.
* Use `apply-tags` instead of `image-index-extra`.

Closes #93

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

--
