### PR TITLE
feat: implement basic pipelining of modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "aya",
  "bindgen",
  "libc",
+ "serde",
 ]
 
 [[package]]

--- a/fact-ebpf/Cargo.toml
+++ b/fact-ebpf/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 [dependencies]
 aya = { workspace = true }
 libc = { workspace = true }
+serde = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/fact-ebpf/src/bpf/builtins.h
+++ b/fact-ebpf/src/bpf/builtins.h
@@ -1,7 +1,0 @@
-#pragma once
-
-// clang-format off
-#ifndef memcpy
-#define memcpy __builtin_memcpy
-#endif
-// clang-format on

--- a/fact-ebpf/src/bpf/events.h
+++ b/fact-ebpf/src/bpf/events.h
@@ -1,13 +1,21 @@
 #pragma once
 
-#include <bpf/bpf_helpers.h>
+// clang-format off
+#include "vmlinux.h"
 
+#include "inode.h"
 #include "maps.h"
 #include "process.h"
 #include "types.h"
-#include "vmlinux.h"
 
-__always_inline static void submit_event(struct metrics_by_hook_t* m, file_activity_type_t event_type, const char filename[PATH_MAX], struct dentry* dentry, bool use_bpf_d_path) {
+#include <bpf/bpf_helpers.h>
+// clang-format on
+
+__always_inline static void submit_event(struct metrics_by_hook_t* m,
+                                         file_activity_type_t event_type,
+                                         const char filename[PATH_MAX],
+                                         inode_key_t* inode,
+                                         bool use_bpf_d_path) {
   struct event_t* event = bpf_ringbuf_reserve(&rb, sizeof(struct event_t), 0);
   if (event == NULL) {
     m->ringbuffer_full++;
@@ -16,16 +24,12 @@ __always_inline static void submit_event(struct metrics_by_hook_t* m, file_activ
 
   event->type = event_type;
   event->timestamp = bpf_ktime_get_boot_ns();
+  inode_copy_or_reset(&event->inode, inode);
   bpf_probe_read_str(event->filename, PATH_MAX, filename);
 
   struct helper_t* helper = get_helper();
   if (helper == NULL) {
     goto error;
-  }
-
-  const char* p = get_host_path(helper->buf, dentry);
-  if (p != NULL) {
-    bpf_probe_read_str(event->host_file, PATH_MAX, p);
   }
 
   int64_t err = process_fill(&event->process, use_bpf_d_path);

--- a/fact-ebpf/src/bpf/file.h
+++ b/fact-ebpf/src/bpf/file.h
@@ -3,60 +3,13 @@
 // clang-format off
 #include "vmlinux.h"
 
-#include "bound_path.h"
 #include "builtins.h"
-#include "d_path.h"
 #include "types.h"
 #include "maps.h"
 
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 // clang-format on
-
-__always_inline static char* get_host_path(char buf[PATH_MAX * 2], struct dentry* d) {
-  int offset = PATH_MAX - 1;
-  buf[PATH_MAX - 1] = '\0';
-
-  for (int i = 0; i < 16 && offset > 0; i++) {
-    struct qstr d_name;
-    BPF_CORE_READ_INTO(&d_name, d, d_name);
-    if (d_name.name == NULL) {
-      break;
-    }
-
-    int len = d_name.len;
-    if (len <= 0 || len >= PATH_MAX) {
-      return NULL;
-    }
-
-    offset -= len;
-    if (offset <= 0) {
-      return NULL;
-    }
-
-    if (bpf_probe_read_kernel(&buf[offset], len, d_name.name) != 0) {
-      return NULL;
-    }
-
-    if (len == 1 && buf[offset] == '/') {
-      // Reached the root
-      offset++;
-      break;
-    }
-
-    offset--;
-    buf[offset] = '/';
-
-    struct dentry* parent = BPF_CORE_READ(d, d_parent);
-    // if we reached the root
-    if (parent == NULL || d == parent) {
-      break;
-    }
-    d = parent;
-  }
-
-  return &buf[offset];
-}
 
 __always_inline static bool is_monitored(struct bound_path_t* path) {
   if (!filter_by_prefix()) {

--- a/fact-ebpf/src/bpf/inode.h
+++ b/fact-ebpf/src/bpf/inode.h
@@ -1,0 +1,97 @@
+#pragma once
+
+// clang-format off
+#include "vmlinux.h"
+
+#include "kdev.h"
+#include "types.h"
+#include "maps.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+// clang-format on
+
+#define BTRFS_SUPER_MAGIC 0x9123683E
+
+/**
+ * Retrieve the inode and device numbers and return them as a new key.
+ *
+ * Different filesystems may `stat` files in different ways, if support
+ * for a new filesystem is needed, add it here.
+ *
+ * Most Linux filesystems use the following generic function to fill
+ * these fields when running `stat`:
+ * https://github.com/torvalds/linux/blob/7d0a66e4bb9081d75c82ec4957c50034cb0ea449/fs/stat.c#L82
+ *
+ * The method used to retrieve the device is different in btrfs and can
+ * be found here:
+ * https://github.com/torvalds/linux/blob/7d0a66e4bb9081d75c82ec4957c50034cb0ea449/fs/btrfs/inode.c#L8038
+ */
+__always_inline static inode_key_t inode_to_key(struct inode* inode) {
+  inode_key_t key = {0};
+  if (inode == NULL) {
+    return key;
+  }
+
+  unsigned long magic = inode->i_sb->s_magic;
+  switch (magic) {
+    case BTRFS_SUPER_MAGIC:
+      if (bpf_core_type_exists(struct btrfs_inode)) {
+        struct btrfs_inode* btrfs_inode = container_of(inode, struct btrfs_inode, vfs_inode);
+        key.inode = inode->i_ino;
+        key.dev = BPF_CORE_READ(btrfs_inode, root, anon_dev);
+        break;
+      }
+    // If the btrfs_inode does not exist, most likely it is not
+    // supported on the system. Fallback to the generic implementation
+    // just in case.
+    default:
+      key.inode = inode->i_ino;
+      key.dev = inode->i_sb->s_dev;
+      break;
+  }
+
+  // Encode the device so it matches with the result of `stat` in
+  // userspace
+  key.dev = new_encode_dev(key.dev);
+
+  return key;
+}
+
+__always_inline static inode_value_t* inode_get(struct inode_key_t* inode) {
+  if (inode == NULL) {
+    return NULL;
+  }
+  return bpf_map_lookup_elem(&inode_map, inode);
+}
+
+__always_inline static long inode_remove(struct inode_key_t* inode) {
+  return bpf_map_delete_elem(&inode_map, inode);
+}
+
+typedef enum inode_monitored_t {
+  NOT_MONITORED = 0,
+  MONITORED,
+} inode_monitored_t;
+
+__always_inline static inode_monitored_t inode_is_monitored(const inode_value_t* inode) {
+  if (inode != NULL) {
+    return MONITORED;
+  }
+
+  return NOT_MONITORED;
+}
+
+__always_inline static void inode_copy_or_reset(inode_key_t* dst, const inode_key_t* src) {
+  if (dst == NULL) {
+    return;
+  }
+
+  if (src != NULL) {
+    dst->inode = src->inode;
+    dst->dev = src->dev;
+  } else {
+    dst->inode = 0;
+    dst->dev = 0;
+  }
+}

--- a/fact-ebpf/src/bpf/kdev.h
+++ b/fact-ebpf/src/bpf/kdev.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// clang-format off
+#include "vmlinux.h"
+
+#include <bpf/bpf_helpers.h>
+// clang-format on
+
+// Most of the code in this file is taken from:
+// https://github.com/torvalds/linux/blob/559e608c46553c107dbba19dae0854af7b219400/include/linux/kdev_t.h
+
+#define MINORBITS 20
+#define MINORMASK ((1U << MINORBITS) - 1)
+
+#define MAJOR(dev) ((unsigned int)((dev) >> MINORBITS))
+#define MINOR(dev) ((unsigned int)((dev) & MINORMASK))
+
+__always_inline static u32 new_encode_dev(dev_t dev) {
+  unsigned major = MAJOR(dev);
+  unsigned minor = MINOR(dev);
+  return (minor & 0xff) | (major << 8) | ((minor & ~0xff) << 12);
+}

--- a/fact-ebpf/src/bpf/maps.h
+++ b/fact-ebpf/src/bpf/maps.h
@@ -93,6 +93,13 @@ struct {
 } rb SEC(".maps");
 
 struct {
+  __uint(type, BPF_MAP_TYPE_HASH);
+  __type(key, inode_key_t);
+  __type(value, inode_value_t);
+  __uint(max_entries, 1024);
+} inode_map SEC(".maps");
+
+struct {
   __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
   __type(key, __u32);
   __type(value, struct metrics_t);

--- a/fact-ebpf/src/bpf/process.h
+++ b/fact-ebpf/src/bpf/process.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "file.h"
-#include "maps.h"
-#include "types.h"
-
 // clang-format off
 #include "vmlinux.h"
+
+#include "d_path.h"
+#include "maps.h"
+#include "types.h"
 
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>

--- a/fact-ebpf/src/bpf/types.h
+++ b/fact-ebpf/src/bpf/types.h
@@ -32,6 +32,13 @@ typedef struct process_t {
   char in_root_mount_ns;
 } process_t;
 
+typedef struct inode_key_t {
+  unsigned long long inode;
+  unsigned long long dev;
+} inode_key_t;
+
+typedef char inode_value_t;
+
 typedef enum file_activity_type_t {
   FILE_ACTIVITY_INIT = -1,
   FILE_ACTIVITY_OPEN = 0,
@@ -43,7 +50,7 @@ struct event_t {
   unsigned long timestamp;
   process_t process;
   char filename[PATH_MAX];
-  char host_file[PATH_MAX];
+  inode_key_t inode;
   file_activity_type_t type;
 };
 

--- a/fact/src/bpf/mod.rs
+++ b/fact/src/bpf/mod.rs
@@ -1,8 +1,8 @@
-use std::{io, path::PathBuf, sync::Arc};
+use std::{io, path::PathBuf};
 
 use anyhow::{bail, Context};
 use aya::{
-    maps::{Array, LpmTrie, MapData, PerCpuArray, RingBuf},
+    maps::{Array, HashMap, LpmTrie, MapData, PerCpuArray, RingBuf},
     programs::Lsm,
     Btf, Ebpf,
 };
@@ -11,13 +11,13 @@ use libc::c_char;
 use log::{debug, error, info};
 use tokio::{
     io::unix::AsyncFd,
-    sync::{broadcast, watch},
+    sync::{mpsc, watch},
     task::JoinHandle,
 };
 
 use crate::{event::Event, host_info, metrics::EventCounter};
 
-use fact_ebpf::{event_t, metrics_t, path_prefix_t, LPM_SIZE_MAX};
+use fact_ebpf::{event_t, inode_key_t, inode_value_t, metrics_t, path_prefix_t, LPM_SIZE_MAX};
 
 mod checks;
 
@@ -26,7 +26,7 @@ const RINGBUFFER_NAME: &str = "rb";
 pub struct Bpf {
     obj: Ebpf,
 
-    tx: broadcast::Sender<Arc<Event>>,
+    tx: mpsc::Sender<Event>,
 
     paths: Vec<path_prefix_t>,
     paths_config: watch::Receiver<Vec<PathBuf>>,
@@ -36,6 +36,7 @@ impl Bpf {
     pub fn new(
         paths_config: watch::Receiver<Vec<PathBuf>>,
         ringbuf_size: u32,
+        tx: mpsc::Sender<Event>,
     ) -> anyhow::Result<Self> {
         Bpf::bump_memlock_rlimit()?;
 
@@ -55,7 +56,6 @@ impl Bpf {
             .load(fact_ebpf::EBPF_OBJ)?;
 
         let paths = Vec::new();
-        let (tx, _) = broadcast::channel(100);
         let mut bpf = Bpf {
             obj,
             tx,
@@ -86,8 +86,13 @@ impl Bpf {
         Ok(())
     }
 
-    pub fn subscribe(&self) -> broadcast::Receiver<Arc<Event>> {
-        self.tx.subscribe()
+    pub fn take_inode_map(
+        &mut self,
+    ) -> anyhow::Result<HashMap<MapData, inode_key_t, inode_value_t>> {
+        let Some(inode_map) = self.obj.take_map("inode_map") else {
+            bail!("inode_map not found");
+        };
+        Ok(inode_map.try_into()?)
     }
 
     pub fn take_metrics(&mut self) -> anyhow::Result<PerCpuArray<MapData, metrics_t>> {
@@ -184,7 +189,7 @@ impl Bpf {
                         while let Some(event) = ringbuf.next() {
                             let event: &event_t = unsafe { &*(event.as_ptr() as *const _) };
                             let event = match Event::try_from(event) {
-                                Ok(event) => Arc::new(event),
+                                Ok(event) => event,
                                 Err(e) => {
                                     error!("Failed to parse event: '{e}'");
                                     debug!("Event: {event:?}");
@@ -194,7 +199,7 @@ impl Bpf {
                             };
 
                             event_counter.added();
-                            if self.tx.send(event).is_err() {
+                            if self.tx.send(event).await.is_err() {
                                 info!("No BPF consumers left, stopping...");
                                 break;
                             }
@@ -261,9 +266,9 @@ mod bpf_tests {
         config.set_paths(paths);
         let reloader = Reloader::from(config);
         executor.block_on(async {
-            let mut bpf = Bpf::new(reloader.paths(), reloader.config().ringbuf_size())
+            let (tx, mut rx) = mpsc::channel(100);
+            let mut bpf = Bpf::new(reloader.paths(), reloader.config().ringbuf_size(), tx)
                 .expect("Failed to load BPF code");
-            let mut rx = bpf.subscribe();
             let (run_tx, run_rx) = watch::channel(true);
             // Create a metrics exporter, but don't start it
             let exporter = Exporter::new(bpf.take_metrics().unwrap());
@@ -281,16 +286,16 @@ mod bpf_tests {
                 file_activity_type_t::FILE_ACTIVITY_CREATION,
                 host_info::get_hostname(),
                 file.path().to_path_buf(),
-                file.path().to_path_buf(),
+                PathBuf::new(), // host path is resolved by HostScanner
                 Process::current(),
             )
             .unwrap();
 
             println!("Expected: {expected:?}");
             let wait = timeout(Duration::from_secs(1), async move {
-                while let Ok(event) = rx.recv().await {
+                while let Some(event) = rx.recv().await {
                     println!("{event:?}");
-                    if *event == expected {
+                    if event == expected {
                         break;
                     }
                 }

--- a/fact/src/host_info.rs
+++ b/fact/src/host_info.rs
@@ -7,7 +7,7 @@ use std::{
     fs::{read_to_string, File},
     io::{BufRead, BufReader},
     mem,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::LazyLock,
 };
 
@@ -20,6 +20,25 @@ pub fn get_host_mount() -> &'static PathBuf {
     static HOST_MOUNT: LazyLock<PathBuf> =
         LazyLock::new(|| env::var("FACT_HOST_MOUNT").unwrap_or("/".into()).into());
     &HOST_MOUNT
+}
+
+pub fn prepend_host_mount(path: &Path) -> PathBuf {
+    let path = if path.has_root() {
+        path.strip_prefix(Path::new("/")).unwrap()
+    } else {
+        path
+    };
+    get_host_mount().join(path)
+}
+
+pub fn remove_host_mount(path: &Path) -> PathBuf {
+    let host_mount = get_host_mount();
+    if path.starts_with(host_mount) {
+        let path = path.strip_prefix(host_mount).unwrap();
+        Path::new("/").join(path)
+    } else {
+        path.to_path_buf()
+    }
 }
 
 fn get_clock(clockid: clockid_t) -> u64 {

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -1,0 +1,143 @@
+use std::{
+    cell::RefCell,
+    os::linux::fs::MetadataExt,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::Context;
+use aya::maps::MapData;
+use fact_ebpf::{inode_key_t, inode_value_t};
+use log::{debug, info, warn};
+use tokio::{
+    sync::{broadcast, mpsc, watch},
+    task::JoinHandle,
+};
+
+use crate::{bpf::Bpf, event::Event, host_info};
+
+pub struct HostScanner {
+    kernel_inode_map: RefCell<aya::maps::HashMap<MapData, inode_key_t, inode_value_t>>,
+    inode_map: RefCell<std::collections::HashMap<inode_key_t, PathBuf>>,
+
+    config: watch::Receiver<Vec<PathBuf>>,
+    running: watch::Receiver<bool>,
+
+    rx: mpsc::Receiver<Event>,
+    tx: broadcast::Sender<Arc<Event>>,
+}
+
+impl HostScanner {
+    pub fn new(
+        bpf: &mut Bpf,
+        rx: mpsc::Receiver<Event>,
+        config: watch::Receiver<Vec<PathBuf>>,
+        running: watch::Receiver<bool>,
+    ) -> anyhow::Result<Self> {
+        let kernel_inode_map = RefCell::new(bpf.take_inode_map()?);
+        let inode_map = RefCell::new(std::collections::HashMap::new());
+        let (tx, _) = broadcast::channel(100);
+
+        let host_scanner = HostScanner {
+            kernel_inode_map,
+            inode_map,
+            config,
+            running,
+            rx,
+            tx,
+        };
+
+        // Run an initial scan to fill in the inode map
+        host_scanner.scan()?;
+
+        Ok(host_scanner)
+    }
+
+    fn scan(&self) -> anyhow::Result<()> {
+        debug!("Host scan started");
+        for path in self.config.borrow().iter() {
+            let path = host_info::prepend_host_mount(path);
+            self.scan_inner(&path)?;
+        }
+        debug!("Host scan done");
+
+        Ok(())
+    }
+
+    fn scan_inner(&self, path: &Path) -> anyhow::Result<()> {
+        if path.is_dir() {
+            for entry in path.read_dir()?.flatten() {
+                let entry = entry.path();
+                self.scan_inner(&entry)
+                    .with_context(|| format!("Failed to scan {}", entry.display()))?;
+            }
+        } else if path.is_file() {
+            self.update_entry(path)
+                .with_context(|| format!("Failed to update entry for {}", path.display()))?;
+        }
+        Ok(())
+    }
+
+    fn update_entry(&self, path: &Path) -> anyhow::Result<()> {
+        if !path.exists() {
+            // If path does not exist, we don't have anything to update
+            return Ok(());
+        }
+
+        let metadata = path.metadata()?;
+        let inode = inode_key_t {
+            inode: metadata.st_ino(),
+            dev: metadata.st_dev(),
+        };
+
+        self.kernel_inode_map.borrow_mut().insert(inode, 0, 0)?;
+        let mut inode_map = self.inode_map.borrow_mut();
+        let entry = inode_map.entry(inode).or_default();
+        *entry = host_info::remove_host_mount(path);
+        Ok(())
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<Event>> {
+        self.tx.subscribe()
+    }
+
+    fn get_host_path(&self, inode: &inode_key_t) -> Option<PathBuf> {
+        // The path here needs to be cloned because we won't keep the
+        // inode_map borrow long enough.
+        self.inode_map.borrow().get(inode).cloned()
+    }
+
+    pub fn start(mut self) -> JoinHandle<anyhow::Result<()>> {
+        tokio::spawn(async move {
+            info!("Starting host scanner...");
+
+            loop {
+                tokio::select! {
+                    event = self.rx.recv() => {
+                        let Some(mut event) = event else {
+                            info!("No more events to process");
+                            break;
+                        };
+
+                        if let Some(host_path) = self.get_host_path(event.get_inode()) {
+                            event.set_host_path(host_path);
+                        }
+
+                        let event = Arc::new(event);
+                        if let Err(e) = self.tx.send(event) {
+                            warn!("Failed to send event: {e}");
+                        }
+                    },
+                    _ = self.running.changed() => {
+                        if !*self.running.borrow() {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            info!("Stopping host scanner");
+            Ok(())
+        })
+    }
+}

--- a/fact/src/lib.rs
+++ b/fact/src/lib.rs
@@ -3,11 +3,12 @@ use std::{borrow::BorrowMut, io::Write, str::FromStr};
 use anyhow::Context;
 use bpf::Bpf;
 use host_info::{get_distro, get_hostname, SystemInfo};
+use host_scanner::HostScanner;
 use log::{debug, info, warn, LevelFilter};
 use metrics::exporter::Exporter;
 use tokio::{
     signal::unix::{signal, SignalKind},
-    sync::watch,
+    sync::{mpsc, watch},
 };
 
 mod bpf;
@@ -15,6 +16,7 @@ pub mod config;
 mod endpoints;
 mod event;
 mod host_info;
+mod host_scanner;
 mod metrics;
 mod output;
 mod pre_flight;
@@ -76,16 +78,21 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
     let reloader = config::reloader::Reloader::from(config);
     let config_trigger = reloader.get_trigger();
 
-    let mut bpf = Bpf::new(reloader.paths(), reloader.config().ringbuf_size())?;
+    let (tx, rx) = mpsc::channel(100);
+
+    let mut bpf = Bpf::new(reloader.paths(), reloader.config().ringbuf_size(), tx)?;
     let exporter = Exporter::new(bpf.take_metrics()?);
 
+    let host_scanner = HostScanner::new(&mut bpf, rx, reloader.paths(), running.subscribe())?;
+
     output::start(
-        bpf.subscribe(),
+        host_scanner.subscribe(),
         running.subscribe(),
         exporter.metrics.output.clone(),
         reloader.grpc(),
         reloader.config().json(),
     )?;
+    let mut host_scanner_handle = host_scanner.start();
     endpoints::Server::new(exporter.clone(), reloader.endpoint(), running.subscribe()).start();
     let mut bpf_handle = bpf.start(running.subscribe(), exporter.metrics.bpf_worker.clone());
     reloader.start(running.subscribe());
@@ -103,6 +110,15 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
                         warn!("BPF worker errored out: {e:?}");
                     }
                     Err(e) => warn!("BPF task errored out: {e:?}"),
+                }
+                break;
+            }
+            res = host_scanner_handle.borrow_mut() => {
+                match res {
+                    Ok(res) => if let Err(e) = res {
+                        warn!("HostScanner worker errored out: {e:?}");
+                    }
+                    Err(e) => warn!("HostScanner task errored out: {e:?}"),
                 }
                 break;
             }

--- a/fact/src/output/mod.rs
+++ b/fact/src/output/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use tokio::sync::{broadcast, watch};
+use log::{info, warn};
+use tokio::sync::{broadcast, mpsc, watch};
 
 use crate::{config::GrpcConfig, event::Event, metrics::OutputMetrics};
 
@@ -12,14 +13,16 @@ mod stdout;
 /// Each task is responsible for managing its lifetime, handling
 /// incoming events and reloading configuration.
 pub fn start(
-    rx: broadcast::Receiver<Arc<Event>>,
-    running: watch::Receiver<bool>,
+    mut input: mpsc::Receiver<Event>,
+    mut running: watch::Receiver<bool>,
     metrics: OutputMetrics,
     config: watch::Receiver<GrpcConfig>,
     stdout_enabled: bool,
 ) -> anyhow::Result<()> {
+    let (tx, _) = broadcast::channel(100);
+
     let grpc_client = grpc::Client::new(
-        rx.resubscribe(),
+        tx.subscribe(),
         running.clone(),
         metrics.grpc.clone(),
         config.clone(),
@@ -28,8 +31,31 @@ pub fn start(
     // JSON client will only start if explicitly enabled or no other
     // output is active at startup
     if !grpc_client.is_enabled() || stdout_enabled {
-        stdout::Client::new(rx.resubscribe(), running.clone(), metrics.stdout.clone()).start();
+        stdout::Client::new(tx.subscribe(), running.clone(), metrics.stdout.clone()).start();
     }
+
+    tokio::spawn(async move {
+        info!("Starting output dispatcher");
+        loop {
+            tokio::select! {
+                event = input.recv() => {
+                    let Some(event) = event else {
+                        info!("No more messages to process");
+                        break;
+                    };
+                    if let Err(e) = tx.send(Arc::new(event)) {
+                        warn!("Failed to receive message: {e}");
+                    }
+                },
+                _ = running.changed() => {
+                    if !*running.borrow() {
+                        info!("Stopping output dispatcher");
+                        break;
+                    }
+                }
+            }
+        }
+    });
 
     grpc_client.start();
 

--- a/k8s/manifest.yml
+++ b/k8s/manifest.yml
@@ -26,6 +26,8 @@ spec:
         env:
         - name: FACT_LOGLEVEL
           value: 'debug'
+        - name: FACT_HOST_MOUNT
+          value: '/host'
         securityContext:
           capabilities:
             drop:
@@ -33,11 +35,11 @@ spec:
           privileged: true
           readOnlyRootFilesystem: true
         volumeMounts:
-        - mountPath: /sys
-          name: sys-ro
+        - mountPath: /host
+          name: root-ro
           readOnly: true
           mountPropagation: HostToContainer
       volumes:
       - hostPath:
-          path: /sys/
-        name: sys-ro
+          path: /
+        name: root-ro

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,20 @@ def monitored_dir():
 
 
 @pytest.fixture
+def test_file(monitored_dir):
+    """
+    Create a temporary file for tests
+
+    This file needs to exist when fact starts up for the inode tracking
+    algorithm to work.
+    """
+    fut = os.path.join(monitored_dir, 'test.txt')
+    with open(fut, 'w') as f:
+        f.write('test')
+    yield fut
+
+
+@pytest.fixture
 def ignored_dir():
     """
     Create a temporary directory for tests that will not be monitored
@@ -84,7 +98,7 @@ def dump_logs(container, file):
 def fact_config(request, monitored_dir, logs_dir):
     cwd = os.getcwd()
     config = {
-        'paths': [monitored_dir],
+        'paths': [monitored_dir, '/mounted', '/container-dir'],
         'grpc': {
             'url': 'http://127.0.0.1:9999',
         },
@@ -107,7 +121,36 @@ def fact_config(request, monitored_dir, logs_dir):
 
 
 @pytest.fixture
-def fact(request, docker_client, fact_config, server, logs_dir):
+def test_container(request, docker_client, monitored_dir, ignored_dir):
+    """
+    Run a container for triggering events in.
+    """
+    container = docker_client.containers.run(
+        'quay.io/fedora/fedora:43',
+        detach=True,
+        tty=True,
+        volumes={
+            ignored_dir: {
+                'bind': '/mounted',
+                'mode': 'z',
+            },
+            monitored_dir: {
+                'bind': '/unmonitored',
+                'mode': 'z',
+            }
+        },
+        name='fedora',
+    )
+    container.exec_run('mkdir /container-dir')
+
+    yield container
+
+    container.stop(timeout=1)
+    container.remove()
+
+
+@pytest.fixture
+def fact(request, docker_client, fact_config, server, logs_dir, test_file):
     """
     Run the fact docker container for integration tests.
     """
@@ -124,20 +167,8 @@ def fact(request, docker_client, fact_config, server, logs_dir):
         network_mode='host',
         privileged=True,
         volumes={
-            '/sys/kernel/security': {
-                'bind': '/host/sys/kernel/security',
-                'mode': 'ro',
-            },
-            '/etc': {
-                'bind': '/host/etc',
-                'mode': 'ro',
-            },
-            '/proc/sys/kernel': {
-                'bind': '/host/proc/sys/kernel',
-                'mode': 'ro',
-            },
-            '/usr/lib/os-release': {
-                'bind': '/host/usr/lib/os-release',
+            '/': {
+                'bind': '/host',
                 'mode': 'ro',
             },
             config_file: {

--- a/tests/test_config_hotreload.py
+++ b/tests/test_config_hotreload.py
@@ -93,12 +93,13 @@ def test_output_grpc_address_change(fact, fact_config, monitored_dir, server, al
     change.
     """
     # File Under Test
-    fut = os.path.join(monitored_dir, 'test.txt')
+    fut = os.path.join(monitored_dir, 'test2.txt')
     with open(fut, 'w') as f:
         f.write('This is a test')
 
-    process = Process()
-    e = Event(process=process, event_type=EventType.CREATION, file=fut)
+    process = Process.from_proc()
+    e = Event(process=process, event_type=EventType.CREATION,
+              file=fut, host_path='')
     print(f'Waiting for event: {e}')
 
     server.wait_events([e])
@@ -111,30 +112,32 @@ def test_output_grpc_address_change(fact, fact_config, monitored_dir, server, al
     with open(fut, 'w') as f:
         f.write('This is another test')
 
-    e = Event(process=process, event_type=EventType.OPEN, file=fut)
+    e = Event(process=process, event_type=EventType.OPEN,
+              file=fut, host_path='')
     print(f'Waiting for event on alternate server: {e}')
 
     alternate_server.wait_events([e])
 
 
 def test_paths(fact, fact_config, monitored_dir, ignored_dir, server):
-    p = Process()
+    p = Process.from_proc()
 
     # Ignored file, must not show up in the server
     ignored_file = os.path.join(ignored_dir, 'test.txt')
     with open(ignored_file, 'w') as f:
         f.write('This is to be ignored')
 
-    ignored_event = Event(
-        process=p, event_type=EventType.CREATION, file=ignored_file)
+    ignored_event = Event(process=p, event_type=EventType.CREATION,
+                          file=ignored_file, host_path='')
     print(f'Ignoring: {ignored_event}')
 
     # File Under Test
-    fut = os.path.join(monitored_dir, 'test.txt')
+    fut = os.path.join(monitored_dir, 'test2.txt')
     with open(fut, 'w') as f:
         f.write('This is a test')
 
-    e = Event(process=p, event_type=EventType.CREATION, file=fut)
+    e = Event(process=p, event_type=EventType.CREATION,
+              file=fut, host_path='')
     print(f'Waiting for event: {e}')
 
     server.wait_events([e], ignored=[ignored_event])
@@ -148,38 +151,40 @@ def test_paths(fact, fact_config, monitored_dir, ignored_dir, server):
     with open(ignored_file, 'w') as f:
         f.write('This is another test')
 
-    e = Event(
-        process=p, event_type=EventType.OPEN, file=ignored_file)
+    e = Event(process=p, event_type=EventType.OPEN,
+              file=ignored_file, host_path='')
     print(f'Waiting for event: {e}')
 
     # File Under Test
     with open(fut, 'w') as f:
         f.write('This is another ignored event')
 
-    ignored_event = Event(process=p, event_type=EventType.OPEN, file=fut)
+    ignored_event = Event(
+        process=p, event_type=EventType.OPEN, file=fut, host_path='')
     print(f'Ignoring: {ignored_event}')
 
     server.wait_events([e], ignored=[ignored_event])
 
 
 def test_paths_addition(fact, fact_config, monitored_dir, ignored_dir, server):
-    p = Process()
+    p = Process.from_proc()
 
     # Ignored file, must not show up in the server
     ignored_file = os.path.join(ignored_dir, 'test.txt')
     with open(ignored_file, 'w') as f:
         f.write('This is to be ignored')
 
-    ignored_event = Event(
-        process=p, event_type=EventType.CREATION, file=ignored_file)
+    ignored_event = Event(process=p, event_type=EventType.CREATION,
+                          file=ignored_file, host_path='')
     print(f'Ignoring: {ignored_event}')
 
     # File Under Test
-    fut = os.path.join(monitored_dir, 'test.txt')
+    fut = os.path.join(monitored_dir, 'test2.txt')
     with open(fut, 'w') as f:
         f.write('This is a test')
 
-    e = Event(process=p, event_type=EventType.CREATION, file=fut)
+    e = Event(process=p, event_type=EventType.CREATION,
+              file=fut, host_path='')
     print(f'Waiting for event: {e}')
 
     server.wait_events([e], ignored=[ignored_event])
@@ -196,8 +201,9 @@ def test_paths_addition(fact, fact_config, monitored_dir, ignored_dir, server):
         f.write('This is one final event')
 
     events = [
-        Event(process=p, event_type=EventType.OPEN, file=ignored_file),
-        Event(process=p, event_type=EventType.OPEN, file=fut)
+        Event(process=p, event_type=EventType.OPEN,
+              file=ignored_file, host_path=''),
+        Event(process=p, event_type=EventType.OPEN, file=fut, host_path='')
     ]
     print(f'Waiting for events: {events}')
 

--- a/tests/test_file_open.py
+++ b/tests/test_file_open.py
@@ -1,6 +1,8 @@
 import multiprocessing as mp
 import os
 
+import docker
+
 from event import Event, EventType, Process
 
 
@@ -15,11 +17,12 @@ def test_open(fact, monitored_dir, server):
         server: The server instance to communicate with.
     """
     # File Under Test
-    fut = os.path.join(monitored_dir, 'test.txt')
+    fut = os.path.join(monitored_dir, 'create.txt')
     with open(fut, 'w') as f:
         f.write('This is a test')
 
-    e = Event(process=Process(), event_type=EventType.CREATION, file=fut)
+    e = Event(process=Process.from_proc(), event_type=EventType.CREATION,
+              file=fut, host_path='')
     print(f'Waiting for event: {e}')
 
     server.wait_events([e])
@@ -36,21 +39,22 @@ def test_multiple(fact, monitored_dir, server):
         server: The server instance to communicate with.
     """
     events = []
-    process = Process()
+    process = Process.from_proc()
     # File Under Test
     for i in range(3):
         fut = os.path.join(monitored_dir, f'{i}.txt')
         with open(fut, 'w') as f:
             f.write('This is a test')
 
-        e = Event(process=process, event_type=EventType.CREATION, file=fut)
+        e = Event(process=process, event_type=EventType.CREATION,
+                  file=fut, host_path='')
         print(f'Waiting for event: {e}')
         events.append(e)
 
     server.wait_events(events)
 
 
-def test_multiple_access(fact, monitored_dir, server):
+def test_multiple_access(fact, test_file, server):
     """
     Tests multiple opening of a file and verifies that the
     corresponding events are captured by the server.
@@ -61,49 +65,46 @@ def test_multiple_access(fact, monitored_dir, server):
         server: The server instance to communicate with.
     """
     events = []
-    # File Under Test
-    fut = os.path.join(monitored_dir, 'test.txt')
-
     for i in range(3):
-        with open(fut, 'a+') as f:
+        with open(test_file, 'a+') as f:
             f.write('This is a test')
 
-        e = Event(process=Process(), file=fut,
-                  event_type=EventType.CREATION if i == 0 else EventType.OPEN)
+        e = Event(process=Process.from_proc(), file=test_file,
+                  host_path=test_file, event_type=EventType.OPEN)
         print(f'Waiting for event: {e}')
         events.append(e)
 
     server.wait_events(events)
 
 
-def test_ignored(fact, monitored_dir, ignored_dir, server):
+def test_ignored(fact, test_file, ignored_dir, server):
     """
     Tests that open events on ignored files are not captured by the
     server.
 
     Args:
         fact: Fixture for file activity (only required to be running).
-        monitored_dir: Temporary directory path for creating the test file.
+        test_file: Temporary file for testing.
         ignored_dir: Temporary directory path that is not monitored by fact.
         server: The server instance to communicate with.
     """
-    p = Process()
+    p = Process.from_proc()
 
     # Ignored file, must not show up in the server
     ignored_file = os.path.join(ignored_dir, 'test.txt')
     with open(ignored_file, 'w') as f:
         f.write('This is to be ignored')
 
-    ignored_event = Event(
-        process=p, event_type=EventType.CREATION, file=ignored_file)
+    ignored_event = Event(process=p, event_type=EventType.CREATION,
+                          file=ignored_file, host_path='')
     print(f'Ignoring: {ignored_event}')
 
     # File Under Test
-    fut = os.path.join(monitored_dir, 'test.txt')
-    with open(fut, 'w') as f:
+    with open(test_file, 'w') as f:
         f.write('This is a test')
 
-    e = Event(process=p, event_type=EventType.CREATION, file=fut)
+    e = Event(process=p, event_type=EventType.OPEN,
+              file=test_file, host_path=test_file)
     print(f'Waiting for event: {e}')
 
     server.wait_events([e], ignored=[ignored_event])
@@ -131,15 +132,17 @@ def test_external_process(fact, monitored_dir, server):
     """
 
     # File Under Test
-    fut = os.path.join(monitored_dir, 'test.txt')
+    fut = os.path.join(monitored_dir, 'test2.txt')
     stop_event = mp.Event()
     proc = mp.Process(target=do_test, args=(fut, stop_event))
     proc.start()
-    p = Process(proc.pid)
+    p = Process.from_proc(proc.pid)
 
-    creation = Event(process=p, event_type=EventType.CREATION, file=fut)
+    creation = Event(process=p, event_type=EventType.CREATION,
+                     file=fut, host_path='')
     print(f'Waiting for event: {creation}')
-    write_access = Event(process=p, event_type=EventType.OPEN, file=fut)
+    write_access = Event(
+        process=p, event_type=EventType.OPEN, file=fut, host_path='')
     print(f'Waiting for event: {write_access}')
 
     try:
@@ -147,3 +150,77 @@ def test_external_process(fact, monitored_dir, server):
     finally:
         stop_event.set()
         proc.join(1)
+
+
+def test_overlay(fact, test_container, server):
+    # File Under Test
+    fut = '/container-dir/test.txt'
+
+    # Create the exec and an equivalent event that it will trigger
+    test_container.exec_run(f'touch {fut}')
+    inspect = docker.APIClient().inspect_container(test_container.id)
+    upper_dir = inspect['GraphDriver']['Data']['UpperDir']
+
+    process = Process(pid=None,
+                      uid=0,
+                      gid=0,
+                      exe_path='/usr/bin/touch',
+                      args=f'touch {fut}',
+                      name='touch',
+                      container_id=test_container.id[:12],
+                      loginuid=pow(2, 32)-1)
+    events = [
+        Event(process=process, event_type=EventType.CREATION,
+              file=fut, host_path=''),
+        Event(process=process, event_type=EventType.OPEN,
+              file=fut, host_path='')
+    ]
+
+    for e in events:
+        print(f'Waiting for event: {e}')
+
+    server.wait_events(events)
+
+
+def test_mounted_dir(fact, test_container, ignored_dir, server):
+    # File Under Test
+    fut = '/mounted/test.txt'
+
+    # Create the exec and an equivalent event that it will trigger
+    test_container.exec_run(f'touch {fut}')
+
+    process = Process(pid=None,
+                      uid=0,
+                      gid=0,
+                      exe_path='/usr/bin/touch',
+                      args=f'touch {fut}',
+                      name='touch',
+                      container_id=test_container.id[:12],
+                      loginuid=pow(2, 32)-1)
+    event = Event(process=process, event_type=EventType.CREATION,
+                  file=fut, host_path='')
+    print(f'Waiting for event: {event}')
+
+    server.wait_events([event])
+
+
+def test_unmonitored_mounted_dir(fact, test_container, test_file, server):
+    # File Under Test
+    fut = '/unmonitored/test.txt'
+
+    # Create the exec and an equivalent event that it will trigger
+    test_container.exec_run(f'touch {fut}')
+
+    process = Process(pid=None,
+                      uid=0,
+                      gid=0,
+                      exe_path='/usr/bin/touch',
+                      args=f'touch {fut}',
+                      name='touch',
+                      container_id=test_container.id[:12],
+                      loginuid=pow(2, 32)-1)
+    event = Event(process=process, event_type=EventType.OPEN,
+                  file=fut, host_path=test_file)
+    print(f'Waiting for event: {event}')
+
+    server.wait_events([event])

--- a/tests/test_path_unlink.py
+++ b/tests/test_path_unlink.py
@@ -1,28 +1,27 @@
 import multiprocessing as mp
 import os
 
+import docker
+
 from event import Event, EventType, Process
 
 
-def test_remove(fact, monitored_dir, server):
+def test_remove(fact, test_file, server):
     """
     Tests the removal of a file and verifies the corresponding event is
     captured by the server.
 
     Args:
         fact: Fixture for file activity (only required to be running).
-        monitored_dir: Temporary directory path for monitoring the test file.
+        test_file: Temporary file for testing.
         server: The server instance to communicate with.
     """
-    fut = os.path.join(monitored_dir, 'test.txt')
-    with open(fut, 'w') as f:
-        f.write('This is a test')
-    os.remove(fut)
+    os.remove(test_file)
 
-    process = Process()
+    process = Process.from_proc()
     events = [
-        Event(process=process, event_type=EventType.CREATION, file=fut),
-        Event(process=process, event_type=EventType.UNLINK, file=fut),
+        Event(process=process, event_type=EventType.UNLINK,
+              file=test_file, host_path=test_file),
     ]
 
     server.wait_events(events)
@@ -39,7 +38,7 @@ def test_multiple(fact, monitored_dir, server):
         server: The server instance to communicate with.
     """
     events = []
-    process = Process()
+    process = Process.from_proc()
 
     # File Under Test
     for i in range(3):
@@ -49,14 +48,16 @@ def test_multiple(fact, monitored_dir, server):
         os.remove(fut)
 
         events.extend([
-            Event(process=process, event_type=EventType.CREATION, file=fut),
-            Event(process=process, event_type=EventType.UNLINK, file=fut),
+            Event(process=process, event_type=EventType.CREATION,
+                  file=fut, host_path=''),
+            Event(process=process, event_type=EventType.UNLINK,
+                  file=fut, host_path=''),
         ])
 
     server.wait_events(events)
 
 
-def test_ignored(fact, monitored_dir, ignored_dir, server):
+def test_ignored(fact, test_file, ignored_dir, server):
     """
     Tests that unlink events on ignored files are not captured by the
     server.
@@ -67,7 +68,7 @@ def test_ignored(fact, monitored_dir, ignored_dir, server):
         ignored_dir: Temporary directory path that is not monitored by fact.
         server: The server instance to communicate with.
     """
-    process = Process()
+    process = Process.from_proc()
 
     # Ignored file, must not show up in the server
     ignored_file = os.path.join(ignored_dir, 'test.txt')
@@ -75,17 +76,15 @@ def test_ignored(fact, monitored_dir, ignored_dir, server):
         f.write('This is to be ignored')
     os.remove(ignored_file)
 
-    ignored_event = Event(
-        process=process, event_type=EventType.UNLINK, file=ignored_file)
+    ignored_event = Event(process=process, event_type=EventType.UNLINK,
+                          file=ignored_file, host_path='')
     print(f'Ignoring: {ignored_event}')
 
     # File Under Test
-    fut = os.path.join(monitored_dir, 'test.txt')
-    with open(fut, 'w') as f:
-        f.write('This is a test')
-    os.remove(fut)
+    os.remove(test_file)
 
-    e = Event(process=process, event_type=EventType.UNLINK, file=fut)
+    e = Event(process=process, event_type=EventType.UNLINK,
+              file=test_file, host_path=test_file)
     print(f'Waiting for event: {e}')
 
     server.wait_events([e], ignored=[ignored_event])
@@ -111,13 +110,14 @@ def test_external_process(fact, monitored_dir, server):
         server: The server instance to communicate with.
     """
     # File Under Test
-    fut = os.path.join(monitored_dir, 'test.txt')
+    fut = os.path.join(monitored_dir, 'test2.txt')
     stop_event = mp.Event()
     proc = mp.Process(target=do_test, args=(fut, stop_event))
     proc.start()
-    process = Process(proc.pid)
+    process = Process.from_proc(proc.pid)
 
-    removal = Event(process=process, event_type=EventType.UNLINK, file=fut)
+    removal = Event(process=process, event_type=EventType.UNLINK,
+                    file=fut, host_path='')
     print(f'Waiting for event: {removal}')
 
     try:
@@ -125,3 +125,105 @@ def test_external_process(fact, monitored_dir, server):
     finally:
         stop_event.set()
         proc.join(1)
+
+
+def test_overlay(fact, test_container, server):
+    # File Under Test
+    fut = '/container-dir/test.txt'
+
+    # Create the exec and an equivalent event that it will trigger
+    test_container.exec_run(f'touch {fut}')
+    test_container.exec_run(f'rm {fut}')
+    inspect = docker.APIClient().inspect_container(test_container.id)
+    upper_dir = inspect['GraphDriver']['Data']['UpperDir']
+
+    loginuid = pow(2, 32)-1
+    touch = Process(pid=None,
+                    uid=0,
+                    gid=0,
+                    exe_path='/usr/bin/touch',
+                    args=f'touch {fut}',
+                    name='touch',
+                    container_id=test_container.id[:12],
+                    loginuid=loginuid)
+    rm = Process(pid=None,
+                 uid=0,
+                 gid=0,
+                 exe_path='/usr/bin/rm',
+                 args=f'rm {fut}',
+                 name='rm',
+                 container_id=test_container.id[:12],
+                 loginuid=loginuid)
+    events = [
+        Event(process=touch, event_type=EventType.CREATION,
+              file=fut, host_path=''),
+        Event(process=touch, event_type=EventType.OPEN,
+              file=fut, host_path=''),
+        Event(process=rm, event_type=EventType.UNLINK,
+              file=fut, host_path=''),
+    ]
+
+    for e in events:
+        print(f'Waiting for event: {e}')
+
+    server.wait_events(events)
+
+
+def test_mounted_dir(fact, test_container, ignored_dir, server):
+    # File Under Test
+    fut = '/mounted/test.txt'
+
+    # Create the exec and an equivalent event that it will trigger
+    test_container.exec_run(f'touch {fut}')
+    test_container.exec_run(f'rm {fut}')
+
+    loginuid = pow(2, 32)-1
+    touch = Process(pid=None,
+                    uid=0,
+                    gid=0,
+                    exe_path='/usr/bin/touch',
+                    args=f'touch {fut}',
+                    name='touch',
+                    container_id=test_container.id[:12],
+                    loginuid=loginuid)
+    rm = Process(pid=None,
+                 uid=0,
+                 gid=0,
+                 exe_path='/usr/bin/rm',
+                 args=f'rm {fut}',
+                 name='rm',
+                 container_id=test_container.id[:12],
+                 loginuid=loginuid)
+    events = [
+        Event(process=touch, event_type=EventType.CREATION, file=fut,
+              host_path=''),
+        Event(process=rm, event_type=EventType.UNLINK, file=fut,
+              host_path=''),
+    ]
+
+    for e in events:
+        print(f'Waiting for event: {e}')
+
+    server.wait_events(events)
+
+
+def test_unmonitored_mounted_dir(fact, test_container, test_file, server):
+    # File Under Test
+    fut = '/unmonitored/test.txt'
+
+    # Create the exec and an equivalent event that it will trigger
+    test_container.exec_run(f'rm {fut}')
+
+    process = Process(pid=None,
+                      uid=0,
+                      gid=0,
+                      exe_path='/usr/bin/rm',
+                      args=f'rm {fut}',
+                      name='rm',
+                      container_id=test_container.id[:12],
+                      loginuid=pow(2, 32)-1)
+    event = Event(process=process, event_type=EventType.UNLINK,
+                  file=fut, host_path=test_file)
+    print(f'Waiting for event: {event}')
+
+    server.wait_events([event])


### PR DESCRIPTION
## Description

This patch proposes a simple way of pipelining components. The pattern is to have each new component in the chain take the receiver end of the previous block as part of their builder, having the builder return a tuple with the object and the receiver end of this block, allowing that receiver to be passed to the next block.

In this new approach there are two special cases:
* The Bpf module starts the chain, so it does not take a receiver.
* The output module is the end of the chain, so it does not give a receiver back.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
