### PR TITLE
feat: improve handling of path buffers

### DIFF
--- a/fact-ebpf/src/bpf/bound_path.h
+++ b/fact-ebpf/src/bpf/bound_path.h
@@ -69,6 +69,7 @@ __always_inline static enum path_append_status_t path_append_dentry(struct bound
 
   path->len += len;
   path_write_char(path->path, path->len, '\0');
+  path->len++;
 
   return 0;
 }

--- a/fact-ebpf/src/bpf/d_path.h
+++ b/fact-ebpf/src/bpf/d_path.h
@@ -77,7 +77,7 @@ __always_inline static long __d_path(const struct path* path, char* buf, int buf
     dentry = parent;
   }
 
-  bpf_probe_read_str(buf, buflen, &helper->buf[offset]);
+  bpf_probe_read(buf, buflen - offset, &helper->buf[offset]);
   return buflen - offset;
 }
 

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -56,7 +56,7 @@ int BPF_PROG(trace_file_open, struct file* file) {
       break;
   }
 
-  submit_event(&m->file_open, event_type, path->path, &inode_key, true);
+  submit_event(&m->file_open, event_type, path, &inode_key, true);
 
   return 0;
 
@@ -116,7 +116,7 @@ int BPF_PROG(trace_path_unlink, struct path* dir, struct dentry* dentry) {
 
   submit_event(&m->path_unlink,
                FILE_ACTIVITY_UNLINK,
-               path->path,
+               path,
                &inode_key,
                path_unlink_supports_bpf_d_path);
   return 0;

--- a/fact-ebpf/src/bpf/process.h
+++ b/fact-ebpf/src/bpf/process.h
@@ -131,7 +131,7 @@ __always_inline static int64_t process_fill(process_t* p, bool use_bpf_d_path) {
     return -1;
   }
 
-  d_path(&task->mm->exe_file->f_path, p->exe_path, PATH_MAX, use_bpf_d_path);
+  p->exe_path_len = d_path(&task->mm->exe_file->f_path, p->exe_path, PATH_MAX, use_bpf_d_path);
 
   const char* cg = get_memory_cgroup(helper);
   if (cg != NULL) {

--- a/fact-ebpf/src/bpf/types.h
+++ b/fact-ebpf/src/bpf/types.h
@@ -22,6 +22,7 @@ typedef struct process_t {
   char args[4096];
   unsigned int args_len;
   char exe_path[PATH_MAX];
+  short unsigned int exe_path_len;
   char memory_cgroup[PATH_MAX];
   unsigned int uid;
   unsigned int gid;
@@ -53,6 +54,7 @@ struct event_t {
   unsigned long timestamp;
   process_t process;
   char filename[PATH_MAX];
+  short unsigned int filename_len;
   inode_key_t inode;
   file_activity_type_t type;
 };


### PR DESCRIPTION

## Description

Since paths can be in non UTF-8 formats, we should strive to use types that are able to handle this situation when possible. In the case of the exe_path and filename fields that come from the kernel, handling has been changed to treat them as binary blobs (same way the kernel d_path function does) and the length is now being sent to userspace.

With this change, userspace is able to reconstruct a path in a fully safe way from the path buffer, treating it as a slice and using the first len - 1 (exclude the null terminator) bytes. This way we are able to preserve the path all the way to the gRPC event, which requires UTF-8 compliant strings. In a future change we might want to change path handling in our protobuffs to use byte blobs instead, but this will probably also require an effort from front end to properly display the data.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
