### PR TITLE
feat: variable event length

### DIFF
--- a/fact-ebpf/src/bpf/events.h
+++ b/fact-ebpf/src/bpf/events.h
@@ -3,47 +3,83 @@
 // clang-format off
 #include "vmlinux.h"
 
-#include "inode.h"
 #include "maps.h"
 #include "process.h"
 #include "types.h"
+#include "raw_event.h"
 
 #include <bpf/bpf_helpers.h>
 // clang-format on
 
+/**
+ * Format and submit an event to the ringbuffer.
+ *
+ * This method is responsible for using the provided values from
+ * different BPF programs, serialize this data alongside the current
+ * process information in a binary format and submit it as an event to
+ * the ringbuffer.
+ *
+ * The high level format for an event can be described as follows:
+ * |--|--------|---------------------------|---------------------------|
+ * |  |        |                           |                          ^ event end
+ * |  |        |                           ^ begin file data
+ * |  |        ^ begin process data
+ * |  ^ timestamp
+ * ^ event type
+ *
+ * Event type: a 16 bit integer specifying the type of event this is.
+ * Timestamp: the amount of nano seconds since boot time.
+ * Process data: all the information collected from the current process.
+ *   For more information on this field see the documentation for
+ *   `process_fill`.
+ * File data: information collected about the file being acted upon.
+ *
+ * The file data field can be expanded as follows:
+ * |----|--------------|---|
+ * |    |              ^ Event specific data
+ * |    ^ file path
+ * ^ inode information
+ *
+ * Inode information: Encoded as the inode and device numbers. Used for
+ *   host path tracking.
+ * File path: The path to the file being acted upon, retrieved from
+ *   d_path.
+ */
 __always_inline static void submit_event(struct metrics_by_hook_t* m,
                                          file_activity_type_t event_type,
                                          struct bound_path_t* path,
                                          inode_key_t* inode,
                                          bool use_bpf_d_path) {
-  struct event_t* event = bpf_ringbuf_reserve(&rb, sizeof(struct event_t), 0);
-  if (event == NULL) {
-    m->ringbuffer_full++;
+  unsigned int zero = 0;
+  struct raw_event_t raw_event = {
+      .buf = bpf_map_lookup_elem(&heap_map, &zero),
+      .len = 0,
+  };
+  if (raw_event.buf == NULL) {
+    m->error++;
     return;
   }
 
-  event->type = event_type;
-  event->timestamp = bpf_ktime_get_boot_ns();
-  inode_copy_or_reset(&event->inode, inode);
-  bpf_probe_read(event->filename, path->len & (PATH_MAX - 1), path->path);
-  event->filename_len = path->len;
+  raw_event_copy_u16(&raw_event, event_type);
+  raw_event_copy_uint(&raw_event, bpf_ktime_get_boot_ns());
 
-  struct helper_t* helper = get_helper();
-  if (helper == NULL) {
-    goto error;
-  }
-
-  int64_t err = process_fill(&event->process, use_bpf_d_path);
+  int64_t err = process_fill(&raw_event, use_bpf_d_path);
   if (err) {
     bpf_printk("Failed to fill process information: %d", err);
     goto error;
   }
 
+  // File data
+  raw_event_copy_inode(&raw_event, inode);
+  raw_event_copy_bound_path(&raw_event, path);
+
+  if (bpf_ringbuf_output(&rb, raw_event.buf, raw_event.len, 0) != 0) {
+    m->ringbuffer_full++;
+    return;
+  }
   m->added++;
-  bpf_ringbuf_submit(event, 0);
   return;
 
 error:
   m->error++;
-  bpf_ringbuf_discard(event, 0);
 }

--- a/fact-ebpf/src/bpf/maps.h
+++ b/fact-ebpf/src/bpf/maps.h
@@ -7,6 +7,18 @@
 
 #include <bpf/bpf_helpers.h>
 
+#define MAX_EVENT_LEN ((1<< 15) - 1)
+/**
+ * Raw buffer to encode events into prior to submitting to the
+ * ringbuffer
+ */
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
+  __type(value, char[MAX_EVENT_LEN]);
+  __uint(max_entries, 1);
+} heap_map SEC(".maps");
+
 /**
  * Helper struct with buffers for various operations
  */

--- a/fact-ebpf/src/bpf/process.h
+++ b/fact-ebpf/src/bpf/process.h
@@ -6,6 +6,7 @@
 #include "d_path.h"
 #include "maps.h"
 #include "types.h"
+#include "raw_event.h"
 
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
@@ -77,23 +78,36 @@ __always_inline static const char* get_memory_cgroup(struct helper_t* helper) {
   return helper->buf;
 }
 
-__always_inline static void process_fill_lineage(process_t* p, struct helper_t* helper, bool use_bpf_d_path) {
+__always_inline static long process_fill_lineage(struct raw_event_t* event, struct helper_t* helper, bool use_bpf_d_path) {
   struct task_struct* task = (struct task_struct*)bpf_get_current_task_btf();
-  p->lineage_len = 0;
+  uint16_t lineage_len_pos = event->len;
+  event->len += 2;
 
-  for (int i = 0; i < LINEAGE_MAX; i++) {
+  uint16_t i = 0;
+  for (; i < LINEAGE_MAX; i++) {
     struct task_struct* parent = task->real_parent;
 
     if (task == parent || parent->pid == 0) {
-      return;
+      break;
     }
     task = parent;
 
-    p->lineage[i].uid = task->cred->uid.val;
-
-    d_path(&task->mm->exe_file->f_path, p->lineage[i].exe_path, PATH_MAX, use_bpf_d_path);
-    p->lineage_len++;
+    raw_event_copy_uint(event, task->cred->uid.val);
+    long err = raw_event_d_path(event, &task->mm->exe_file->f_path, use_bpf_d_path);
+    if (err != 0) {
+      bpf_printk("Failed to read lineage exe_path");
+      return err;
+    }
   }
+
+  // go back and set the amount of lineage processes in the buffer
+  uint16_t back = event->len;
+  event->len = lineage_len_pos;
+
+  raw_event_copy_uint(event, i);
+
+  event->len = back;
+  return 0;
 }
 
 __always_inline static unsigned long get_mount_ns() {
@@ -101,15 +115,35 @@ __always_inline static unsigned long get_mount_ns() {
   return task->nsproxy->mnt_ns->ns.inum;
 }
 
-__always_inline static int64_t process_fill(process_t* p, bool use_bpf_d_path) {
+/**
+ * Fill in the information about the current process to the event
+ * buffer.
+ *
+ * This method serializes all required process information for the event
+ * as a binary blob into the provided event buffer. The serialized data
+ * will look something like this:
+ * |--|--|--|--|-------|--------------|-------------|------------|-|----|---|
+ * |  |  |  |  |       |              |             |            | |    ^ grandparent lineage
+ * |  |  |  |  |       |              |             |            | ^ parent lineage
+ * |  |  |  |  |       |              |             |            ^ in_root_mount_ns
+ * |  |  |  |  |       |              |             ^ cgroup
+ * |  |  |  |  |       |              ^ executable path
+ * |  |  |  |  |       ^ arguments
+ * |  |  |  |  ^ comm
+ * |  |  |  ^ pid
+ * |  |  ^ loginuid
+ * |  ^ gid
+ * ^ uid
+ */
+__always_inline static int64_t process_fill(struct raw_event_t* event, bool use_bpf_d_path) {
   struct task_struct* task = (struct task_struct*)bpf_get_current_task_btf();
   uint32_t key = 0;
   uint64_t uid_gid = bpf_get_current_uid_gid();
-  p->uid = uid_gid & 0xFFFFFFFF;
-  p->gid = (uid_gid >> 32) & 0xFFFFFFFF;
-  p->login_uid = task->loginuid.val;
-  p->pid = (bpf_get_current_pid_tgid() >> 32) & 0xFFFFFFFF;
-  u_int64_t err = bpf_get_current_comm(p->comm, TASK_COMM_LEN);
+  raw_event_copy_u32(event, uid_gid & 0xFFFFFFFF);
+  raw_event_copy_u32(event, ((uid_gid >> 32) & 0xFFFFFFFF));
+  raw_event_copy_uint(event, task->loginuid.val);
+  raw_event_copy_u32(event, (bpf_get_current_pid_tgid() >> 32) & 0xFFFFFFFF);
+  uint64_t err = raw_event_copy_comm(event);
   if (err != 0) {
     bpf_printk("Failed to fill task comm");
     return err;
@@ -117,12 +151,17 @@ __always_inline static int64_t process_fill(process_t* p, bool use_bpf_d_path) {
 
   unsigned long arg_start = task->mm->arg_start;
   unsigned long arg_end = task->mm->arg_end;
-  p->args_len = (arg_end - arg_start) & 0xFFF;
-  p->args[4095] = '\0';  // Ensure string termination at end of buffer
-  err = bpf_probe_read_user(p->args, p->args_len, (const char*)arg_start);
-  if (err != 0) {
-    bpf_printk("Failed to fill task args");
-    return err;
+  uint16_t args_len = (arg_end - arg_start) & 0xFFF;
+  err = raw_event_copy_buffer(event, (const void*)arg_start, args_len);
+  if (err < 0) {
+    bpf_printk("Failed to read process args");
+    return -1;
+  }
+
+  err = raw_event_d_path(event, &task->mm->exe_file->f_path, use_bpf_d_path);
+  if (err < 0) {
+    bpf_printk("Failed to read exe_path");
+    return -1;
   }
 
   struct helper_t* helper = bpf_map_lookup_elem(&helper_map, &key);
@@ -131,16 +170,26 @@ __always_inline static int64_t process_fill(process_t* p, bool use_bpf_d_path) {
     return -1;
   }
 
-  p->exe_path_len = d_path(&task->mm->exe_file->f_path, p->exe_path, PATH_MAX, use_bpf_d_path);
-
   const char* cg = get_memory_cgroup(helper);
   if (cg != NULL) {
-    bpf_probe_read_str(p->memory_cgroup, PATH_MAX, cg);
+    // Reserve space for the cgroup length
+    event->len += 2;
+    uint16_t cg_len = (uint16_t)bpf_probe_read_str(&event->buf[event->len], PATH_MAX, cg);
+
+    // Move back and fix the length
+    event->len -= 2;
+    raw_event_copy_u16(event, cg_len - 1);
+
+    // Forward past the cgroup
+    event->len += ((cg_len - 1) & (PATH_MAX - 1));
   }
 
-  p->in_root_mount_ns = get_mount_ns() == host_mount_ns;
+  raw_event_copy_u8(event, get_mount_ns() == host_mount_ns);
 
-  process_fill_lineage(p, helper, use_bpf_d_path);
+  err = process_fill_lineage(event, helper, use_bpf_d_path);
+  if (err < 0) {
+    return -1;
+  }
 
   return 0;
 }

--- a/fact-ebpf/src/bpf/raw_event.h
+++ b/fact-ebpf/src/bpf/raw_event.h
@@ -1,0 +1,170 @@
+#pragma once
+
+// clang-format off
+#include "vmlinux.h"
+
+#include "d_path.h"
+#include "bound_path.h"
+#include "types.h"
+
+#include <bpf/bpf_helpers.h>
+// clang-format on
+
+struct raw_event_t {
+  char* buf;
+  unsigned short len;
+};
+
+/**
+ * Copy a single byte to the event buffer and increment its size.
+ */
+__always_inline static void raw_event_copy_u8(struct raw_event_t* event, uint8_t val) {
+  event->buf[event->len++] = val;
+}
+
+/**
+ * Copy an unsigned integer in big endian format to the event buffer
+ * and increase its size accordingly.
+ *
+ * Big endian is used in order to make parsing easier in user space by
+ * simply rotating a target integer and adding bytes to the end.
+ */
+__always_inline static void _raw_event_copy_uint(struct raw_event_t* event, uint64_t val, uint8_t size) {
+  for (int8_t i = size - 1; i >= 0; i--) {
+    uint64_t mask = 0xFFULL << (i * 8);
+    uint8_t v = (val & mask) >> (i * 8);
+    raw_event_copy_u8(event, v);
+  }
+}
+
+/**
+ * Type safe integer copying.
+ */
+#define raw_event_copy_uint(event, val) _Generic(val,             \
+    uint8_t: raw_event_copy_u8(event, val),                       \
+    uint16_t: _raw_event_copy_uint(event, val, sizeof(uint16_t)), \
+    uint32_t: _raw_event_copy_uint(event, val, sizeof(uint32_t)), \
+    uint64_t: _raw_event_copy_uint(event, val, sizeof(uint64_t)), \
+    unsigned long: _raw_event_copy_uint(event, val, sizeof(unsigned long)))
+
+/**
+ * Copy a 16 bit integer to the event buffer and increase its size.
+ */
+__always_inline static void raw_event_copy_u16(struct raw_event_t* event, uint16_t val) {
+  raw_event_copy_uint(event, val);
+}
+
+/**
+ * Copy a 32 bit integer to the event buffer and increase its size.
+ */
+__always_inline static void raw_event_copy_u32(struct raw_event_t* event, uint32_t val) {
+  raw_event_copy_uint(event, val);
+}
+
+/**
+ * Copy a 64 bit integer to the event buffer and increase its size.
+ */
+__always_inline static void raw_event_copy_u64(struct raw_event_t* event, uint64_t val) {
+  raw_event_copy_uint(event, val);
+}
+
+/**
+ * Copy the provided inode information to the event buffer.
+ *
+ * The serialized blob will be of 2 big endian 32 bits integers, with
+ * the inode number first and the device number second.
+ *
+ * If no inode information is provided, the same space is filled with
+ * zeroes for ease of parsing.
+ */
+__always_inline static void raw_event_copy_inode(struct raw_event_t* event, inode_key_t* val) {
+  if (val != NULL) {
+    raw_event_copy_uint(event, val->inode);
+    raw_event_copy_uint(event, val->dev);
+  } else {
+    raw_event_copy_u32(event, 0);
+    raw_event_copy_u32(event, 0);
+  }
+}
+
+/**
+ * Copy a buffer to the event.
+ *
+ * The format used for the serialized buffer is as follows:
+ * |--|------------|
+ * |  ^ begin data
+ * ^ data length
+ *
+ * Data length: 16 bit, big endian integer, number of data bytes held.
+ * Data: a blob of bytes with the required data.
+ */
+__always_inline static long raw_event_copy_buffer(struct raw_event_t* event, const void* buf, uint16_t len) {
+  raw_event_copy_uint(event, len);
+  long res = bpf_probe_read(&event->buf[event->len], len, buf);
+  if (res < 0) {
+    return res;
+  }
+  event->len += len;
+  return 0;
+}
+
+/**
+ * Helper function for encoding a bound_path_t as a buffer in the event.
+ *
+ * The resulting buffer that is serialized will not be null terminated.
+ */
+__always_inline static long raw_event_copy_bound_path(struct raw_event_t* event, struct bound_path_t* path) {
+  // The & (PATH_MAX - 1) is there to convince the verifier we are at
+  // most copying 4KB, otherwise it will assume we can add UINT16_MAX
+  // bytes and immediately fail, as the event buffer is smaller than
+  // that.
+  return raw_event_copy_buffer(event, path->path, (path->len - 1) & (PATH_MAX - 1));
+}
+
+/**
+ * Serialize the comm value for the current task in the event buffer.
+ *
+ * For simplicity, the comm value is directly copied into the buffer by
+ * using the bpf_get_current_comm helper with a fix length of 16.
+ *
+ * bpf_get_current_comm ensures the copied data is null terminated and
+ * padded with zeroes if the comm is smaller than 16 bytes.
+ */
+__always_inline static long raw_event_copy_comm(struct raw_event_t* event) {
+  long res = bpf_get_current_comm((char*)&event->buf[event->len], TASK_COMM_LEN);
+  if (res != 0) {
+    return res;
+  }
+  event->len += TASK_COMM_LEN;
+  return 0;
+}
+
+/**
+ * Serialize the result of calling d_path onto the event buffer.
+ *
+ * The resulting path is encoded as described in raw_event_copy_buffer
+ * and is not null terminated.
+ */
+__always_inline static long raw_event_d_path(struct raw_event_t* event, struct path* path, bool use_bpf_d_path) {
+  // Reserve room for the path length
+  event->len += 2;
+  long res = d_path(path, &event->buf[event->len], PATH_MAX, use_bpf_d_path);
+  if (res < 0) {
+    return res;
+  }
+
+  // Go back and add the length of the path
+  uint16_t len = (uint16_t)res;
+  event->len -= 2;
+  raw_event_copy_u16(event, len - 1);
+
+  // Move the buffer past the path
+  //
+  // The & (PATH_MAX - 1) is there to convince the verifier we are at
+  // most copying 4KB, otherwise it will assume we can add UINT16_MAX
+  // bytes and immediately fail, as the event buffer is smaller than
+  // that.
+  event->len += ((len - 1) & (PATH_MAX - 1));
+
+  return 0;
+}

--- a/fact-ebpf/src/bpf/types.h
+++ b/fact-ebpf/src/bpf/types.h
@@ -12,30 +12,9 @@
 
 #define LPM_SIZE_MAX 256
 
-typedef struct lineage_t {
-  unsigned int uid;
-  char exe_path[PATH_MAX];
-} lineage_t;
-
-typedef struct process_t {
-  char comm[TASK_COMM_LEN];
-  char args[4096];
-  unsigned int args_len;
-  char exe_path[PATH_MAX];
-  short unsigned int exe_path_len;
-  char memory_cgroup[PATH_MAX];
-  unsigned int uid;
-  unsigned int gid;
-  unsigned int login_uid;
-  unsigned int pid;
-  lineage_t lineage[LINEAGE_MAX];
-  unsigned int lineage_len;
-  char in_root_mount_ns;
-} process_t;
-
 typedef struct inode_key_t {
-  unsigned long inode;
-  unsigned long dev;
+  unsigned int inode;
+  unsigned int dev;
 } inode_key_t;
 
 // We can't use bool here because it is not a standard C type, we would
@@ -49,15 +28,6 @@ typedef enum file_activity_type_t {
   FILE_ACTIVITY_CREATION,
   FILE_ACTIVITY_UNLINK,
 } file_activity_type_t;
-
-struct event_t {
-  unsigned long timestamp;
-  process_t process;
-  char filename[PATH_MAX];
-  short unsigned int filename_len;
-  inode_key_t inode;
-  file_activity_type_t type;
-};
 
 /**
  * Used as the key for the path_prefix map.

--- a/fact-ebpf/src/lib.rs
+++ b/fact-ebpf/src/lib.rs
@@ -92,6 +92,17 @@ impl Serialize for inode_key_t {
 
 unsafe impl Pod for inode_key_t {}
 
+impl From<u16> for file_activity_type_t {
+    fn from(value: u16) -> Self {
+        match value {
+            0 => file_activity_type_t::FILE_ACTIVITY_OPEN,
+            1 => file_activity_type_t::FILE_ACTIVITY_CREATION,
+            2 => file_activity_type_t::FILE_ACTIVITY_UNLINK,
+            invalid => unreachable!("Invalid file activity type: {invalid}"),
+        }
+    }
+}
+
 impl metrics_by_hook_t {
     fn accumulate(&self, other: &metrics_by_hook_t) -> metrics_by_hook_t {
         let mut m = metrics_by_hook_t { ..*self };

--- a/fact/src/bpf/mod.rs
+++ b/fact/src/bpf/mod.rs
@@ -8,7 +8,7 @@ use aya::{
 };
 use checks::Checks;
 use libc::c_char;
-use log::{debug, error, info};
+use log::{error, info};
 use tokio::{
     io::unix::AsyncFd,
     sync::{mpsc, watch},
@@ -17,7 +17,7 @@ use tokio::{
 
 use crate::{event::Event, host_info, metrics::EventCounter};
 
-use fact_ebpf::{event_t, inode_key_t, inode_value_t, metrics_t, path_prefix_t, LPM_SIZE_MAX};
+use fact_ebpf::{inode_key_t, inode_value_t, metrics_t, path_prefix_t, LPM_SIZE_MAX};
 
 mod checks;
 
@@ -187,12 +187,10 @@ impl Bpf {
                             .context("ringbuffer guard held while runtime is stopping")?;
                         let ringbuf = guard.get_inner_mut();
                         while let Some(event) = ringbuf.next() {
-                            let event: &event_t = unsafe { &*(event.as_ptr() as *const _) };
                             let event = match Event::try_from(event) {
                                 Ok(event) => event,
                                 Err(e) => {
-                                    error!("Failed to parse event: '{e}'");
-                                    debug!("Event: {event:?}");
+                                    error!("Failed to parse event: '{e:?}'");
                                     event_counter.dropped();
                                     continue;
                                 }

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -1,31 +1,32 @@
+//! Event handling module
+//!
+//! This module provides Rust types that make it easier and safer to
+//! interact with the information received from the BPF programs.
+//!
+//! The main interest is the `Event` type, which can be parsed from an
+//! element received from the ringbuffer and passed around to other
+//! components.
+
 #[cfg(test)]
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
-    ffi::{CStr, OsString},
-    os::{raw::c_char, unix::ffi::OsStringExt},
+    ffi::OsStr,
+    ops::{BitOrAssign, ShlAssign},
+    os::unix::ffi::OsStrExt,
     path::PathBuf,
 };
 
+use anyhow::bail;
+use aya::maps::ring_buf::RingBufItem;
+use log::warn;
 use serde::Serialize;
 
-use fact_ebpf::{event_t, file_activity_type_t, inode_key_t};
+use fact_ebpf::{file_activity_type_t, inode_key_t};
 
 use crate::host_info;
 use process::Process;
 
 pub(crate) mod process;
-
-fn slice_to_pathbuf(s: &[c_char]) -> PathBuf {
-    #[cfg(target_arch = "x86_64")]
-    let v = s.iter().map(|c| *c as u8).collect::<Vec<u8>>();
-    #[cfg(not(target_arch = "x86_64"))]
-    let v = s.to_vec();
-    OsString::from_vec(v).into()
-}
-
-fn slice_to_string(s: &[c_char]) -> anyhow::Result<String> {
-    Ok(unsafe { CStr::from_ptr(s.as_ptr()) }.to_str()?.to_owned())
-}
 
 fn timestamp_to_proto(ts: u64) -> prost_types::Timestamp {
     let seconds = (ts / 1_000_000_000) as i64;
@@ -89,17 +90,99 @@ impl Event {
             FileData::Unlink(data) => data.host_file = host_path,
         }
     }
+
+    /// Parse an integer value from the supplied slice.
+    ///
+    /// This method parses integers as they are added to the ringbuffer
+    /// by the kernel side BPF programs. For simplicity, integers are
+    /// always loaded in Big Endian format regardless of the
+    /// architecture the program runs on.
+    fn parse_int<T>(s: &[u8]) -> Option<(T, &[u8])>
+    where
+        T: From<u8> + BitOrAssign<T> + ShlAssign<i32>,
+    {
+        let len = size_of::<T>();
+        let (val, s) = s.split_at_checked(len)?;
+        let mut res = T::from(0);
+        for byte in val {
+            // Types with size of 1 byte cannot be shifted since they
+            // would overflow, so we only shift bigger types.
+            if len > 1 {
+                res <<= 8;
+            }
+            res |= (*byte).into();
+        }
+        Some((res, s))
+    }
+
+    /// Parse a buffer from the supplied slice.
+    ///
+    /// This method parses buffers as they are added to the ringbuffer
+    /// by the kernel side BPF programs. The format these programs use
+    /// is relatively straightforward, they use 2 bytes in Big Endian
+    /// format to encode the length of the buffer in bytes, then put
+    /// the buffer right after, looking something like this:
+    ///
+    /// |--|--------------|-------
+    /// |  |              | ^ rest of the event
+    /// |  |              ^ buffer end
+    /// |  ^ buffer start
+    /// ^ length of the buffer
+    ///
+    /// This allows parsing fairly easy in userspace, we can simply
+    /// parse a u16 for the size of the buffer, then take as many bytes
+    /// as that value indicates.
+    ///
+    /// This representation also works for both strings and binary
+    /// blobs, so it allows for quite good flexibility, leaving the
+    /// specialization of the type to the caller.
+    fn parse_buffer(s: &[u8]) -> Option<(&[u8], &[u8])> {
+        let (len, s) = Event::parse_int::<u16>(s)?;
+        s.split_at_checked(len as usize)
+    }
 }
 
-impl TryFrom<&event_t> for Event {
+impl TryFrom<RingBufItem<'_>> for Event {
     type Error = anyhow::Error;
 
-    fn try_from(value: &event_t) -> Result<Self, Self::Error> {
-        let process = Process::try_from(value.process)?;
-        let timestamp = host_info::get_boot_time() + value.timestamp;
-        let filename_len = value.filename_len as usize;
-        let (filename, _) = value.filename.as_slice().split_at(filename_len - 1);
-        let file = FileData::new(value.type_, filename, value.inode)?;
+    fn try_from(value: RingBufItem) -> Result<Self, Self::Error> {
+        let Some((event_type, value)) = Event::parse_int::<u16>(&value) else {
+            bail!("Failed to read event type");
+        };
+        let event_type = event_type.into();
+
+        let Some((timestamp, value)) = Event::parse_int::<u64>(value) else {
+            bail!("Failed to parse timestamp");
+        };
+        let timestamp = timestamp + host_info::get_boot_time();
+
+        let (process, value) = Process::parse(value)?;
+
+        let Some((inode, value)) = Event::parse_int::<u32>(value) else {
+            bail!("Failed to parse inode");
+        };
+        let Some((dev, value)) = Event::parse_int::<u32>(value) else {
+            bail!("Failed to parse device number");
+        };
+        let inode = inode_key_t { inode, dev };
+        let Some((filename, value)) = Event::parse_buffer(value) else {
+            bail!("Failed to parse filename");
+        };
+        let filename = OsStr::from_bytes(filename).into();
+        let file = FileData::new(event_type, filename, inode)?;
+
+        // Handling of special fields.
+        // TODO: Currently implemented events have no special fields.
+        match event_type {
+            file_activity_type_t::FILE_ACTIVITY_CREATION
+            | file_activity_type_t::FILE_ACTIVITY_OPEN
+            | file_activity_type_t::FILE_ACTIVITY_UNLINK => {}
+            invalid => unreachable!("missing special field treatment for event type {invalid:?}"),
+        }
+
+        if !value.is_empty() {
+            warn!("Event has remaining data");
+        }
 
         Ok(Event {
             timestamp,
@@ -142,7 +225,7 @@ pub enum FileData {
 impl FileData {
     pub fn new(
         event_type: file_activity_type_t,
-        filename: &[c_char],
+        filename: PathBuf,
         inode: inode_key_t,
     ) -> anyhow::Result<Self> {
         let inner = BaseFileData::new(filename, inode)?;
@@ -199,9 +282,7 @@ pub struct BaseFileData {
 }
 
 impl BaseFileData {
-    pub fn new(filename: &[c_char], inode: inode_key_t) -> anyhow::Result<Self> {
-        let filename = slice_to_pathbuf(filename);
-
+    pub fn new(filename: PathBuf, inode: inode_key_t) -> anyhow::Result<Self> {
         Ok(BaseFileData {
             filename,
             host_file: PathBuf::new(), // this field is set by HostScanner
@@ -222,6 +303,149 @@ impl From<BaseFileData> for fact_api::FileActivityBase {
         fact_api::FileActivityBase {
             path: value.filename.to_string_lossy().to_string(),
             host_path: value.host_file.to_string_lossy().to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    use super::*;
+
+    struct ParseIntTestCase<'a, T> {
+        input: &'a [u8],
+        expected: Option<(T, &'a [u8])>,
+    }
+
+    impl<'a, T> ParseIntTestCase<'a, T> {
+        fn new(input: &'a [u8], expected: Option<(T, &'a [u8])>) -> Self {
+            ParseIntTestCase { input, expected }
+        }
+    }
+
+    fn test_parse_int<T>(ParseIntTestCase { input, expected }: &ParseIntTestCase<T>)
+    where
+        T: From<u8> + BitOrAssign<T> + ShlAssign<i32> + Debug + PartialEq,
+    {
+        let res = Event::parse_int::<T>(input);
+        assert_eq!(
+            res, *expected,
+            "\ninput: {input:#x?}\nexpected: {expected:#x?}\nres: {res:#x?}"
+        )
+    }
+
+    #[test]
+    fn test_parse_u8() {
+        let tests = &[
+            ParseIntTestCase::new(&[0xef], Some((0xef, &[]))),
+            ParseIntTestCase::new(&[0xef, 0x00], Some((0xef, &[0x00]))),
+            ParseIntTestCase::new(&[0xbe, 0xef, 0x00], Some((0xbe, &[0xef, 0x00]))),
+            ParseIntTestCase::new(&[], None),
+        ];
+
+        for test in tests {
+            test_parse_int::<u8>(test);
+        }
+    }
+
+    #[test]
+    fn test_parse_u16() {
+        let tests = &[
+            ParseIntTestCase::new(&[0xbe, 0xef], Some((0xbeef, &[]))),
+            ParseIntTestCase::new(&[0xbe, 0xef, 0x00], Some((0xbeef, &[0x00]))),
+            ParseIntTestCase::new(
+                &[0xbe, 0xef, 0xbe, 0xef, 0x00],
+                Some((0xbeef, &[0xbe, 0xef, 0x00])),
+            ),
+            ParseIntTestCase::new(&[0xef], None),
+            ParseIntTestCase::new(&[], None),
+        ];
+
+        for test in tests {
+            test_parse_int::<u16>(test);
+        }
+    }
+
+    #[test]
+    fn test_parse_u32() {
+        let tests = &[
+            ParseIntTestCase::new(&[0xde, 0xad, 0xbe, 0xef], Some((0xdeadbeef, &[]))),
+            ParseIntTestCase::new(&[0xde, 0xad, 0xbe, 0xef, 0x00], Some((0xdeadbeef, &[0x00]))),
+            ParseIntTestCase::new(
+                &[0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0x00],
+                Some((0xdeadbeef, &[0xde, 0xad, 0xbe, 0xef, 0x00])),
+            ),
+            ParseIntTestCase::new(&[0xad, 0xbe, 0xef], None),
+            ParseIntTestCase::new(&[], None),
+        ];
+
+        for test in tests {
+            test_parse_int::<u32>(test);
+        }
+    }
+
+    #[test]
+    fn test_parse_u64() {
+        let tests = &[
+            ParseIntTestCase::new(
+                &[0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef],
+                Some((0xdeadbeefdeadbeef, &[])),
+            ),
+            ParseIntTestCase::new(
+                &[0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0x00],
+                Some((0xdeadbeefdeadbeef, &[0x00])),
+            ),
+            ParseIntTestCase::new(
+                &[
+                    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde,
+                    0xad, 0xbe, 0xef, 0x00,
+                ],
+                Some((
+                    0xdeadbeefdeadbeef,
+                    &[0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0x00],
+                )),
+            ),
+            ParseIntTestCase::new(&[0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef], None),
+            ParseIntTestCase::new(&[], None),
+        ];
+
+        for test in tests {
+            test_parse_int::<u64>(test);
+        }
+    }
+
+    #[test]
+    fn test_parse_buffer() {
+        struct TestCase<'a> {
+            input: &'a [u8],
+            expected: Option<(&'a [u8], &'a [u8])>,
+        }
+        let tests = &[
+            TestCase {
+                input: b"\x00\x0B/usr/bin/rm",
+                expected: Some((b"/usr/bin/rm", &[])),
+            },
+            TestCase {
+                input: b"\x00\x0B/usr/bin/",
+                expected: None,
+            },
+            TestCase {
+                input: b"\x00\x0E/usr/bin/touch ignored",
+                expected: Some((b"/usr/bin/touch", b" ignored")),
+            },
+            TestCase {
+                input: b"\x00\x00\x00\x0E/usr/bin/touch ignored",
+                expected: Some((b"", b"\x00\x0E/usr/bin/touch ignored")),
+            },
+            TestCase {
+                input: b"",
+                expected: None,
+            },
+        ];
+        for TestCase { input, expected } in tests {
+            let res = Event::parse_buffer(input);
+            assert_eq!(res, *expected, "input: {}", String::from_utf8_lossy(input));
         }
     }
 }

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -106,8 +106,8 @@ impl HostScanner {
 
         let metadata = path.metadata()?;
         let inode = inode_key_t {
-            inode: metadata.st_ino(),
-            dev: metadata.st_dev(),
+            inode: metadata.st_ino() as u32,
+            dev: metadata.st_dev() as u32,
         };
 
         self.kernel_inode_map


### PR DESCRIPTION
## Description

Change from a fixed type for events from BPF to a variable length one. This is done by using a helper map in which we can write all the information for a given event, then submit it to the ringbuffer with the bpf_ringbuf_output helper.

On the userspace, we get a RingBufItem which can be treated as a slice of bytes we can split to retrieve fields one by one.

This change needs to be properly tested for performance, we should use a lot less space for each event in the ringbuffer but serializing and deserializing each event might require more CPU.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.