### PR TITLE
ROX-33217: Instrument inode tracking on directory being created path mkdir

### DIFF
--- a/fact-ebpf/src/bpf/events.h
+++ b/fact-ebpf/src/bpf/events.h
@@ -129,3 +129,17 @@ __always_inline static void submit_rename_event(struct metrics_by_hook_t* m,
 
   __submit_event(event, m, FILE_ACTIVITY_RENAME, new_filename, new_inode, new_parent_inode, path_hooks_support_bpf_d_path);
 }
+
+__always_inline static void submit_mkdir_event(struct metrics_by_hook_t* m,
+                                               const char filename[PATH_MAX],
+                                               inode_key_t* inode,
+                                               inode_key_t* parent_inode) {
+  struct event_t* event = bpf_ringbuf_reserve(&rb, sizeof(struct event_t), 0);
+  if (event == NULL) {
+    m->ringbuffer_full++;
+    return;
+  }
+
+  // d_instantiate doesn't support bpf_d_path, so we use false and rely on the stashed path from path_mkdir
+  __submit_event(event, m, FILE_ACTIVITY_CREATION, filename, inode, parent_inode, false);
+}

--- a/fact-ebpf/src/bpf/events.h
+++ b/fact-ebpf/src/bpf/events.h
@@ -141,5 +141,5 @@ __always_inline static void submit_mkdir_event(struct metrics_by_hook_t* m,
   }
 
   // d_instantiate doesn't support bpf_d_path, so we use false and rely on the stashed path from path_mkdir
-  __submit_event(event, m, FILE_ACTIVITY_CREATION, filename, inode, parent_inode, false);
+  __submit_event(event, m, DIR_ACTIVITY_CREATION, filename, inode, parent_inode, false);
 }

--- a/fact-ebpf/src/bpf/file.h
+++ b/fact-ebpf/src/bpf/file.h
@@ -43,3 +43,19 @@ __always_inline static inode_monitored_t is_monitored(inode_key_t inode, struct 
 
   return NOT_MONITORED;
 }
+
+// Check if a new directory should be tracked based on its parent and path.
+// This is used during mkdir operations where the child inode doesn't exist yet.
+__always_inline static inode_monitored_t should_track_mkdir(inode_key_t parent_inode, struct bound_path_t* child_path) {
+  const inode_value_t* volatile parent_value = inode_get(&parent_inode);
+
+  if (parent_value != NULL) {
+    return PARENT_MONITORED;
+  }
+
+  if (path_is_monitored(child_path)) {
+    return MONITORED;
+  }
+
+  return NOT_MONITORED;
+}

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -20,6 +20,7 @@ char _license[] SEC("license") = "Dual MIT/GPL";
 #define FMODE_CREATED ((fmode_t)(1 << 20))
 
 // File type constants from linux/stat.h
+// https://github.com/torvalds/linux/blob/5619b098e2fbf3a23bf13d91897056a1fe238c6d/include/uapi/linux/stat.h
 #define S_IFMT 00170000
 #define S_IFDIR 0040000
 #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -264,18 +264,20 @@ int BPF_PROG(trace_path_mkdir, struct path* dir, struct dentry* dentry, umode_t 
 
   // Stash mkdir context for security_d_instantiate
   __u64 pid_tgid = bpf_get_current_pid_tgid();
-
-  if (bpf_map_update_elem(&mkdir_context, &pid_tgid, NULL, BPF_ANY) != 0) {
-    bpf_printk("Failed to create mkdir context entry");
-    m->path_mkdir.error++;
-    return 0;
-  }
-
   struct mkdir_context_t* mkdir_ctx = bpf_map_lookup_elem(&mkdir_context, &pid_tgid);
   if (mkdir_ctx == NULL) {
-    bpf_printk("Failed to lookup mkdir context after creation");
-    m->path_mkdir.error++;
-    return 0;
+    static const struct mkdir_context_t empty_ctx = {0};
+    if (bpf_map_update_elem(&mkdir_context, &pid_tgid, &empty_ctx, BPF_NOEXIST) != 0) {
+      bpf_printk("Failed to create mkdir context entry");
+      m->path_mkdir.error++;
+      return 0;
+    }
+    mkdir_ctx = bpf_map_lookup_elem(&mkdir_context, &pid_tgid);
+    if (mkdir_ctx == NULL) {
+      bpf_printk("Failed to lookup mkdir context after creation");
+      m->path_mkdir.error++;
+      return 0;
+    }
   }
 
   long path_copy_len = bpf_probe_read_str(mkdir_ctx->path, PATH_MAX, path->path);

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -296,16 +296,17 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
   m->d_instantiate.total++;
 
   __u64 pid_tgid = bpf_get_current_pid_tgid();
+
+  if (inode == NULL) {
+    m->d_instantiate.ignored++;
+    goto cleanup;
+  }
+
   struct mkdir_context_t* mkdir_ctx = bpf_map_lookup_elem(&mkdir_context, &pid_tgid);
 
   if (mkdir_ctx == NULL) {
     m->d_instantiate.ignored++;
     return 0;
-  }
-
-  if (inode == NULL) {
-    m->d_instantiate.ignored++;
-    goto cleanup;
   }
 
   inode_key_t inode_key = inode_to_key(inode);

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -309,11 +309,11 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
     return 0;
   }
 
+  // From this point on, we must clean up mkdir_context before returning
   umode_t mode = BPF_CORE_READ(inode, i_mode);
   if (!S_ISDIR(mode)) {
-    bpf_map_delete_elem(&mkdir_context, &pid_tgid);
     m->d_instantiate.ignored++;
-    return 0;
+    goto cleanup;
   }
 
   inode_key_t inode_key = inode_to_key(inode);
@@ -329,7 +329,7 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
                      &inode_key,
                      &mkdir_ctx->parent_inode);
 
+cleanup:
   bpf_map_delete_elem(&mkdir_context, &pid_tgid);
-
   return 0;
 }

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -309,7 +309,6 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
     return 0;
   }
 
-  // Check if this is a directory
   umode_t mode = BPF_CORE_READ(inode, i_mode);
   if (!S_ISDIR(mode)) {
     bpf_map_delete_elem(&mkdir_context, &pid_tgid);
@@ -317,23 +316,19 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
     return 0;
   }
 
-  // Get the inode key for the new directory
   inode_key_t inode_key = inode_to_key(inode);
 
-  // Add the new directory inode to tracking
   if (inode_add(&inode_key) == 0) {
     m->d_instantiate.added++;
   } else {
     m->d_instantiate.error++;
   }
 
-  // Submit creation event using the stashed path
   submit_mkdir_event(&m->d_instantiate,
                      mkdir_ctx->path,
                      &inode_key,
                      &mkdir_ctx->parent_inode);
 
-  // Clean up context
   bpf_map_delete_elem(&mkdir_context, &pid_tgid);
 
   return 0;

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -264,9 +264,16 @@ int BPF_PROG(trace_path_mkdir, struct path* dir, struct dentry* dentry, umode_t 
 
   // Stash mkdir context for security_d_instantiate
   __u64 pid_tgid = bpf_get_current_pid_tgid();
-  struct mkdir_context_t* mkdir_ctx = get_mkdir_context();
+
+  if (bpf_map_update_elem(&mkdir_context, &pid_tgid, NULL, BPF_ANY) != 0) {
+    bpf_printk("Failed to create mkdir context entry");
+    m->path_mkdir.error++;
+    return 0;
+  }
+
+  struct mkdir_context_t* mkdir_ctx = bpf_map_lookup_elem(&mkdir_context, &pid_tgid);
   if (mkdir_ctx == NULL) {
-    bpf_printk("Failed to get mkdir context buffer");
+    bpf_printk("Failed to lookup mkdir context after creation");
     m->path_mkdir.error++;
     return 0;
   }
@@ -275,15 +282,10 @@ int BPF_PROG(trace_path_mkdir, struct path* dir, struct dentry* dentry, umode_t 
   if (path_copy_len < 0) {
     bpf_printk("Failed to copy path string");
     m->path_mkdir.error++;
+    bpf_map_delete_elem(&mkdir_context, &pid_tgid);
     return 0;
   }
   mkdir_ctx->parent_inode = parent_inode;
-
-  if (bpf_map_update_elem(&mkdir_context, &pid_tgid, mkdir_ctx, BPF_ANY) != 0) {
-    bpf_printk("Failed to stash mkdir context");
-    m->path_mkdir.error++;
-    return 0;
-  }
 
   return 0;
 }

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -19,6 +19,11 @@ char _license[] SEC("license") = "Dual MIT/GPL";
 #define FMODE_PWRITE ((fmode_t)(1 << 4))
 #define FMODE_CREATED ((fmode_t)(1 << 20))
 
+// File type constants from linux/stat.h
+#define S_IFMT 00170000
+#define S_IFDIR 0040000
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+
 SEC("lsm/file_open")
 int BPF_PROG(trace_file_open, struct file* file) {
   struct metrics_t* m = get_metrics();
@@ -229,5 +234,107 @@ int BPF_PROG(trace_path_rename, struct path* old_dir,
 
 error:
   m->path_rename.error++;
+  return 0;
+}
+
+SEC("lsm/path_mkdir")
+int BPF_PROG(trace_path_mkdir, struct path* dir, struct dentry* dentry, umode_t mode) {
+  struct metrics_t* m = get_metrics();
+  if (m == NULL) {
+    return 0;
+  }
+
+  m->path_mkdir.total++;
+
+  struct bound_path_t* path = path_read_append_d_entry(dir, dentry);
+  if (path == NULL) {
+    bpf_printk("Failed to read path");
+    m->path_mkdir.error++;
+    return 0;
+  }
+
+  struct dentry* parent_dentry = BPF_CORE_READ(dir, dentry);
+  struct inode* parent_inode_ptr = BPF_CORE_READ(parent_dentry, d_inode);
+  inode_key_t parent_inode = inode_to_key(parent_inode_ptr);
+
+  if (should_track_mkdir(parent_inode, path) == NOT_MONITORED) {
+    m->path_mkdir.ignored++;
+    return 0;
+  }
+
+  // Stash mkdir context for security_d_instantiate
+  __u64 pid_tgid = bpf_get_current_pid_tgid();
+  struct mkdir_context_t* mkdir_ctx = get_mkdir_context();
+  if (mkdir_ctx == NULL) {
+    bpf_printk("Failed to get mkdir context buffer");
+    m->path_mkdir.error++;
+    return 0;
+  }
+
+  long path_copy_len = bpf_probe_read_str(mkdir_ctx->path, PATH_MAX, path->path);
+  if (path_copy_len < 0) {
+    bpf_printk("Failed to copy path string");
+    m->path_mkdir.error++;
+    return 0;
+  }
+  mkdir_ctx->parent_inode = parent_inode;
+
+  if (bpf_map_update_elem(&mkdir_context, &pid_tgid, mkdir_ctx, BPF_ANY) != 0) {
+    bpf_printk("Failed to stash mkdir context");
+    m->path_mkdir.error++;
+    return 0;
+  }
+
+  return 0;
+}
+
+SEC("lsm/d_instantiate")
+int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
+  struct metrics_t* m = get_metrics();
+  if (m == NULL) {
+    return 0;
+  }
+
+  m->d_instantiate.total++;
+
+  if (inode == NULL) {
+    m->d_instantiate.ignored++;
+    return 0;
+  }
+
+  __u64 pid_tgid = bpf_get_current_pid_tgid();
+  struct mkdir_context_t* mkdir_ctx = bpf_map_lookup_elem(&mkdir_context, &pid_tgid);
+  if (mkdir_ctx == NULL) {
+    m->d_instantiate.ignored++;
+    return 0;
+  }
+
+  // Check if this is a directory
+  umode_t mode = BPF_CORE_READ(inode, i_mode);
+  if (!S_ISDIR(mode)) {
+    bpf_map_delete_elem(&mkdir_context, &pid_tgid);
+    m->d_instantiate.ignored++;
+    return 0;
+  }
+
+  // Get the inode key for the new directory
+  inode_key_t inode_key = inode_to_key(inode);
+
+  // Add the new directory inode to tracking
+  if (inode_add(&inode_key) == 0) {
+    m->d_instantiate.added++;
+  } else {
+    m->d_instantiate.error++;
+  }
+
+  // Submit creation event using the stashed path
+  submit_mkdir_event(&m->d_instantiate,
+                     mkdir_ctx->path,
+                     &inode_key,
+                     &mkdir_ctx->parent_inode);
+
+  // Clean up context
+  bpf_map_delete_elem(&mkdir_context, &pid_tgid);
+
   return 0;
 }

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -19,12 +19,6 @@ char _license[] SEC("license") = "Dual MIT/GPL";
 #define FMODE_PWRITE ((fmode_t)(1 << 4))
 #define FMODE_CREATED ((fmode_t)(1 << 20))
 
-// File type constants from linux/stat.h
-// https://github.com/torvalds/linux/blob/5619b098e2fbf3a23bf13d91897056a1fe238c6d/include/uapi/linux/stat.h
-#define S_IFMT 00170000
-#define S_IFDIR 0040000
-#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
-
 SEC("lsm/file_open")
 int BPF_PROG(trace_file_open, struct file* file) {
   struct metrics_t* m = get_metrics();
@@ -310,12 +304,6 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
   }
 
   if (inode == NULL) {
-    m->d_instantiate.ignored++;
-    goto cleanup;
-  }
-
-  umode_t mode = BPF_CORE_READ(inode, i_mode);
-  if (!S_ISDIR(mode)) {
     m->d_instantiate.ignored++;
     goto cleanup;
   }

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -257,7 +257,7 @@ int BPF_PROG(trace_path_mkdir, struct path* dir, struct dentry* dentry, umode_t 
   struct inode* parent_inode_ptr = BPF_CORE_READ(parent_dentry, d_inode);
   inode_key_t parent_inode = inode_to_key(parent_inode_ptr);
 
-  if (should_track_mkdir(parent_inode, path) == NOT_MONITORED) {
+  if (should_track_mkdir(parent_inode, path) != PARENT_MONITORED) {
     m->path_mkdir.ignored++;
     return 0;
   }

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -253,8 +253,7 @@ int BPF_PROG(trace_path_mkdir, struct path* dir, struct dentry* dentry, umode_t 
     return 0;
   }
 
-  struct dentry* parent_dentry = BPF_CORE_READ(dir, dentry);
-  struct inode* parent_inode_ptr = BPF_CORE_READ(parent_dentry, d_inode);
+  struct inode* parent_inode_ptr = BPF_CORE_READ(dir, dentry, d_inode);
   inode_key_t parent_inode = inode_to_key(parent_inode_ptr);
 
   if (should_track_mkdir(parent_inode, path) != PARENT_MONITORED) {

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -297,19 +297,19 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
 
   m->d_instantiate.total++;
 
-  if (inode == NULL) {
-    m->d_instantiate.ignored++;
-    return 0;
-  }
-
   __u64 pid_tgid = bpf_get_current_pid_tgid();
   struct mkdir_context_t* mkdir_ctx = bpf_map_lookup_elem(&mkdir_context, &pid_tgid);
+
   if (mkdir_ctx == NULL) {
     m->d_instantiate.ignored++;
     return 0;
   }
 
-  // From this point on, we must clean up mkdir_context before returning
+  if (inode == NULL) {
+    m->d_instantiate.ignored++;
+    goto cleanup;
+  }
+
   umode_t mode = BPF_CORE_READ(inode, i_mode);
   if (!S_ISDIR(mode)) {
     m->d_instantiate.ignored++;

--- a/fact-ebpf/src/bpf/maps.h
+++ b/fact-ebpf/src/bpf/maps.h
@@ -86,6 +86,26 @@ struct {
 struct {
   __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
   __type(key, __u32);
+  __type(value, struct mkdir_context_t);
+  __uint(max_entries, 1);
+} mkdir_context_heap SEC(".maps");
+
+__always_inline static struct mkdir_context_t* get_mkdir_context() {
+  unsigned int zero = 0;
+  return bpf_map_lookup_elem(&mkdir_context_heap, &zero);
+}
+
+struct {
+  __uint(type, BPF_MAP_TYPE_HASH);
+  __type(key, __u64);
+  __type(value, struct mkdir_context_t);
+  __uint(max_entries, 16384);
+  __uint(map_flags, BPF_F_NO_PREALLOC);
+} mkdir_context SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
   __type(value, struct metrics_t);
   __uint(max_entries, 1);
 } metrics SEC(".maps");

--- a/fact-ebpf/src/bpf/maps.h
+++ b/fact-ebpf/src/bpf/maps.h
@@ -84,7 +84,7 @@ struct {
 } inode_map SEC(".maps");
 
 struct {
-  __uint(type, BPF_MAP_TYPE_HASH);
+  __uint(type, BPF_MAP_TYPE_LRU_HASH);
   __type(key, __u64);
   __type(value, struct mkdir_context_t);
   __uint(max_entries, 16384);

--- a/fact-ebpf/src/bpf/maps.h
+++ b/fact-ebpf/src/bpf/maps.h
@@ -84,23 +84,10 @@ struct {
 } inode_map SEC(".maps");
 
 struct {
-  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-  __type(key, __u32);
-  __type(value, struct mkdir_context_t);
-  __uint(max_entries, 1);
-} mkdir_context_heap SEC(".maps");
-
-__always_inline static struct mkdir_context_t* get_mkdir_context() {
-  unsigned int zero = 0;
-  return bpf_map_lookup_elem(&mkdir_context_heap, &zero);
-}
-
-struct {
   __uint(type, BPF_MAP_TYPE_HASH);
   __type(key, __u64);
   __type(value, struct mkdir_context_t);
   __uint(max_entries, 16384);
-  __uint(map_flags, BPF_F_NO_PREALLOC);
 } mkdir_context SEC(".maps");
 
 struct {

--- a/fact-ebpf/src/bpf/types.h
+++ b/fact-ebpf/src/bpf/types.h
@@ -55,6 +55,7 @@ typedef enum file_activity_type_t {
   FILE_ACTIVITY_CHMOD,
   FILE_ACTIVITY_CHOWN,
   FILE_ACTIVITY_RENAME,
+  DIR_ACTIVITY_CREATION,
 } file_activity_type_t;
 
 struct event_t {

--- a/fact-ebpf/src/bpf/types.h
+++ b/fact-ebpf/src/bpf/types.h
@@ -96,6 +96,12 @@ struct path_prefix_t {
   const char path[LPM_SIZE_MAX];
 };
 
+// Context for correlating mkdir operations
+struct mkdir_context_t {
+  char path[PATH_MAX];
+  inode_key_t parent_inode;
+};
+
 // Metrics types
 struct metrics_by_hook_t {
   unsigned long long total;
@@ -111,4 +117,6 @@ struct metrics_t {
   struct metrics_by_hook_t path_chmod;
   struct metrics_by_hook_t path_chown;
   struct metrics_by_hook_t path_rename;
+  struct metrics_by_hook_t path_mkdir;
+  struct metrics_by_hook_t d_instantiate;
 };

--- a/fact-ebpf/src/lib.rs
+++ b/fact-ebpf/src/lib.rs
@@ -125,6 +125,8 @@ impl metrics_t {
         m.path_chmod = m.path_chmod.accumulate(&other.path_chmod);
         m.path_chown = m.path_chown.accumulate(&other.path_chown);
         m.path_rename = m.path_rename.accumulate(&other.path_rename);
+        m.path_mkdir = m.path_mkdir.accumulate(&other.path_mkdir);
+        m.d_instantiate = m.d_instantiate.accumulate(&other.d_instantiate);
         m
     }
 }

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -310,7 +310,7 @@ impl FileData {
         let inner = BaseFileData::new(filename, inode, parent_inode)?;
         let file = match event_type {
             file_activity_type_t::FILE_ACTIVITY_OPEN => FileData::Open(inner),
-            file_activity_type_t::FILE_ACTIVITY_CREATION => FileData::Creation(inner),
+            file_activity_type_t::FILE_ACTIVITY_CREATION |
             file_activity_type_t::DIR_ACTIVITY_CREATION => FileData::Creation(inner),
             file_activity_type_t::FILE_ACTIVITY_UNLINK => FileData::Unlink(inner),
             file_activity_type_t::FILE_ACTIVITY_CHMOD => {

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -311,6 +311,7 @@ impl FileData {
         let file = match event_type {
             file_activity_type_t::FILE_ACTIVITY_OPEN => FileData::Open(inner),
             file_activity_type_t::FILE_ACTIVITY_CREATION => FileData::Creation(inner),
+            file_activity_type_t::DIR_ACTIVITY_CREATION => FileData::Creation(inner),
             file_activity_type_t::FILE_ACTIVITY_UNLINK => FileData::Unlink(inner),
             file_activity_type_t::FILE_ACTIVITY_CHMOD => {
                 let data = ChmodFileData {

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -98,15 +98,24 @@ impl Event {
             parent_inode: Default::default(),
         };
         let (file, event_type) = match data {
-            EventTestData::Creation => (FileData::Creation(inner), file_activity_type_t::FILE_ACTIVITY_CREATION),
-            EventTestData::Unlink => (FileData::Unlink(inner), file_activity_type_t::FILE_ACTIVITY_UNLINK),
+            EventTestData::Creation => (
+                FileData::Creation(inner),
+                file_activity_type_t::FILE_ACTIVITY_CREATION,
+            ),
+            EventTestData::Unlink => (
+                FileData::Unlink(inner),
+                file_activity_type_t::FILE_ACTIVITY_UNLINK,
+            ),
             EventTestData::Chmod(new_mode, old_mode) => {
                 let data = ChmodFileData {
                     inner,
                     new_mode,
                     old_mode,
                 };
-                (FileData::Chmod(data), file_activity_type_t::FILE_ACTIVITY_CHMOD)
+                (
+                    FileData::Chmod(data),
+                    file_activity_type_t::FILE_ACTIVITY_CHMOD,
+                )
             }
             EventTestData::Rename(old_path) => {
                 let data = RenameFileData {
@@ -116,7 +125,10 @@ impl Event {
                         ..Default::default()
                     },
                 };
-                (FileData::Rename(data), file_activity_type_t::FILE_ACTIVITY_RENAME)
+                (
+                    FileData::Rename(data),
+                    file_activity_type_t::FILE_ACTIVITY_RENAME,
+                )
             }
         };
 

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -131,9 +131,6 @@ impl Event {
         matches!(self.file, FileData::Creation(_) | FileData::MkDir(_))
     }
 
-    pub fn is_file_creation(&self) -> bool {
-        matches!(self.file, FileData::Creation(_))
-    }
 
     pub fn is_mkdir(&self) -> bool {
         matches!(self.file, FileData::MkDir(_))
@@ -376,12 +373,7 @@ impl From<FileData> for fact_api::file_activity::File {
                 fact_api::file_activity::File::Creation(f_act)
             }
             FileData::MkDir(event) => {
-                warn!(
-                    "MkDir event reached protobuf conversion - converting to Creation (filtering may have failed)"
-                );
-                let activity = Some(fact_api::FileActivityBase::from(event));
-                let f_act = fact_api::FileCreation { activity };
-                fact_api::file_activity::File::Creation(f_act)
+                unreachable!("MkDir event reached protobuf conversion");
             }
             FileData::Unlink(event) => {
                 let activity = Some(fact_api::FileActivityBase::from(event));

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -131,7 +131,6 @@ impl Event {
         matches!(self.file, FileData::Creation(_) | FileData::MkDir(_))
     }
 
-
     pub fn is_mkdir(&self) -> bool {
         matches!(self.file, FileData::MkDir(_))
     }

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -145,6 +145,10 @@ impl Event {
         matches!(self.file, FileData::Creation(_))
     }
 
+    pub(crate) fn event_type(&self) -> file_activity_type_t {
+        self.event_type
+    }
+
     pub fn is_unlink(&self) -> bool {
         matches!(self.file, FileData::Unlink(_))
     }

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -376,7 +376,9 @@ impl From<FileData> for fact_api::file_activity::File {
                 fact_api::file_activity::File::Creation(f_act)
             }
             FileData::MkDir(event) => {
-                warn!("MkDir event reached protobuf conversion - converting to Creation (filtering may have failed)");
+                warn!(
+                    "MkDir event reached protobuf conversion - converting to Creation (filtering may have failed)"
+                );
                 let activity = Some(fact_api::FileActivityBase::from(event));
                 let f_act = fact_api::FileCreation { activity };
                 fact_api::file_activity::File::Creation(f_act)

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use globset::GlobSet;
-use log::warn;
 use serde::Serialize;
 
 use fact_ebpf::{PATH_MAX, event_t, file_activity_type_t, inode_key_t};
@@ -371,7 +370,7 @@ impl From<FileData> for fact_api::file_activity::File {
                 let f_act = fact_api::FileCreation { activity };
                 fact_api::file_activity::File::Creation(f_act)
             }
-            FileData::MkDir(event) => {
+            FileData::MkDir(_) => {
                 unreachable!("MkDir event reached protobuf conversion");
             }
             FileData::Unlink(event) => {

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -97,16 +97,16 @@ impl Event {
             inode: Default::default(),
             parent_inode: Default::default(),
         };
-        let file = match data {
-            EventTestData::Creation => FileData::Creation(inner),
-            EventTestData::Unlink => FileData::Unlink(inner),
+        let (file, event_type) = match data {
+            EventTestData::Creation => (FileData::Creation(inner), file_activity_type_t::FILE_ACTIVITY_CREATION),
+            EventTestData::Unlink => (FileData::Unlink(inner), file_activity_type_t::FILE_ACTIVITY_UNLINK),
             EventTestData::Chmod(new_mode, old_mode) => {
                 let data = ChmodFileData {
                     inner,
                     new_mode,
                     old_mode,
                 };
-                FileData::Chmod(data)
+                (FileData::Chmod(data), file_activity_type_t::FILE_ACTIVITY_CHMOD)
             }
             EventTestData::Rename(old_path) => {
                 let data = RenameFileData {
@@ -116,7 +116,7 @@ impl Event {
                         ..Default::default()
                     },
                 };
-                FileData::Rename(data)
+                (FileData::Rename(data), file_activity_type_t::FILE_ACTIVITY_RENAME)
             }
         };
 
@@ -125,7 +125,7 @@ impl Event {
             hostname,
             process,
             file,
-            event_type: file_activity_type_t::FILE_ACTIVITY_CREATION,
+            event_type,
         })
     }
 

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use globset::GlobSet;
+use log::warn;
 use serde::Serialize;
 
 use fact_ebpf::{PATH_MAX, event_t, file_activity_type_t, inode_key_t};
@@ -74,8 +75,6 @@ pub struct Event {
     hostname: &'static str,
     process: Process,
     file: FileData,
-    #[serde(skip)]
-    event_type: file_activity_type_t,
 }
 
 impl Event {
@@ -97,25 +96,16 @@ impl Event {
             inode: Default::default(),
             parent_inode: Default::default(),
         };
-        let (file, event_type) = match data {
-            EventTestData::Creation => (
-                FileData::Creation(inner),
-                file_activity_type_t::FILE_ACTIVITY_CREATION,
-            ),
-            EventTestData::Unlink => (
-                FileData::Unlink(inner),
-                file_activity_type_t::FILE_ACTIVITY_UNLINK,
-            ),
+        let file = match data {
+            EventTestData::Creation => FileData::Creation(inner),
+            EventTestData::Unlink => FileData::Unlink(inner),
             EventTestData::Chmod(new_mode, old_mode) => {
                 let data = ChmodFileData {
                     inner,
                     new_mode,
                     old_mode,
                 };
-                (
-                    FileData::Chmod(data),
-                    file_activity_type_t::FILE_ACTIVITY_CHMOD,
-                )
+                FileData::Chmod(data)
             }
             EventTestData::Rename(old_path) => {
                 let data = RenameFileData {
@@ -125,10 +115,7 @@ impl Event {
                         ..Default::default()
                     },
                 };
-                (
-                    FileData::Rename(data),
-                    file_activity_type_t::FILE_ACTIVITY_RENAME,
-                )
+                FileData::Rename(data)
             }
         };
 
@@ -137,24 +124,23 @@ impl Event {
             hostname,
             process,
             file,
-            event_type,
         })
     }
 
     pub fn is_creation(&self) -> bool {
+        matches!(self.file, FileData::Creation(_) | FileData::MkDir(_))
+    }
+
+    pub fn is_file_creation(&self) -> bool {
         matches!(self.file, FileData::Creation(_))
     }
 
-    pub(crate) fn event_type(&self) -> file_activity_type_t {
-        self.event_type
+    pub fn is_mkdir(&self) -> bool {
+        matches!(self.file, FileData::MkDir(_))
     }
 
     pub fn is_unlink(&self) -> bool {
         matches!(self.file, FileData::Unlink(_))
-    }
-        
-    pub fn is_dir_creation(&self) -> bool {
-        self.event_type == file_activity_type_t::DIR_ACTIVITY_CREATION
     }
 
     /// Unwrap the inner FileData and return the inode that triggered
@@ -166,6 +152,7 @@ impl Event {
         match &self.file {
             FileData::Open(data) => &data.inode,
             FileData::Creation(data) => &data.inode,
+            FileData::MkDir(data) => &data.inode,
             FileData::Unlink(data) => &data.inode,
             FileData::Chmod(data) => &data.inner.inode,
             FileData::Chown(data) => &data.inner.inode,
@@ -178,6 +165,7 @@ impl Event {
         match &self.file {
             FileData::Open(data) => &data.parent_inode,
             FileData::Creation(data) => &data.parent_inode,
+            FileData::MkDir(data) => &data.parent_inode,
             FileData::Unlink(data) => &data.parent_inode,
             FileData::Chmod(data) => &data.inner.parent_inode,
             FileData::Chown(data) => &data.inner.parent_inode,
@@ -199,6 +187,7 @@ impl Event {
         match &self.file {
             FileData::Open(data) => &data.filename,
             FileData::Creation(data) => &data.filename,
+            FileData::MkDir(data) => &data.filename,
             FileData::Unlink(data) => &data.filename,
             FileData::Chmod(data) => &data.inner.filename,
             FileData::Chown(data) => &data.inner.filename,
@@ -217,6 +206,7 @@ impl Event {
         match &self.file {
             FileData::Open(data) => &data.host_file,
             FileData::Creation(data) => &data.host_file,
+            FileData::MkDir(data) => &data.host_file,
             FileData::Unlink(data) => &data.host_file,
             FileData::Chmod(data) => &data.inner.host_file,
             FileData::Chown(data) => &data.inner.host_file,
@@ -232,6 +222,7 @@ impl Event {
         match &mut self.file {
             FileData::Open(data) => data.host_file = host_path,
             FileData::Creation(data) => data.host_file = host_path,
+            FileData::MkDir(data) => data.host_file = host_path,
             FileData::Unlink(data) => data.host_file = host_path,
             FileData::Chmod(data) => data.inner.host_file = host_path,
             FileData::Chown(data) => data.inner.host_file = host_path,
@@ -286,7 +277,6 @@ impl TryFrom<&event_t> for Event {
             hostname: host_info::get_hostname(),
             process,
             file,
-            event_type: value.type_,
         })
     }
 }
@@ -317,6 +307,7 @@ impl PartialEq for Event {
 pub enum FileData {
     Open(BaseFileData),
     Creation(BaseFileData),
+    MkDir(BaseFileData),
     Unlink(BaseFileData),
     Chmod(ChmodFileData),
     Chown(ChownFileData),
@@ -334,8 +325,8 @@ impl FileData {
         let inner = BaseFileData::new(filename, inode, parent_inode)?;
         let file = match event_type {
             file_activity_type_t::FILE_ACTIVITY_OPEN => FileData::Open(inner),
-            file_activity_type_t::FILE_ACTIVITY_CREATION
-            | file_activity_type_t::DIR_ACTIVITY_CREATION => FileData::Creation(inner),
+            file_activity_type_t::FILE_ACTIVITY_CREATION => FileData::Creation(inner),
+            file_activity_type_t::DIR_ACTIVITY_CREATION => FileData::MkDir(inner),
             file_activity_type_t::FILE_ACTIVITY_UNLINK => FileData::Unlink(inner),
             file_activity_type_t::FILE_ACTIVITY_CHMOD => {
                 let data = ChmodFileData {
@@ -384,6 +375,12 @@ impl From<FileData> for fact_api::file_activity::File {
                 let f_act = fact_api::FileCreation { activity };
                 fact_api::file_activity::File::Creation(f_act)
             }
+            FileData::MkDir(event) => {
+                warn!("MkDir event reached protobuf conversion - converting to Creation (filtering may have failed)");
+                let activity = Some(fact_api::FileActivityBase::from(event));
+                let f_act = fact_api::FileCreation { activity };
+                fact_api::file_activity::File::Creation(f_act)
+            }
             FileData::Unlink(event) => {
                 let activity = Some(fact_api::FileActivityBase::from(event));
                 let f_act = fact_api::FileUnlink { activity };
@@ -411,6 +408,7 @@ impl PartialEq for FileData {
         match (self, other) {
             (FileData::Open(this), FileData::Open(other)) => this == other,
             (FileData::Creation(this), FileData::Creation(other)) => this == other,
+            (FileData::MkDir(this), FileData::MkDir(other)) => this == other,
             (FileData::Unlink(this), FileData::Unlink(other)) => this == other,
             (FileData::Chmod(this), FileData::Chmod(other)) => this == other,
             (FileData::Rename(this), FileData::Rename(other)) => this == other,

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -318,8 +318,8 @@ impl FileData {
         let inner = BaseFileData::new(filename, inode, parent_inode)?;
         let file = match event_type {
             file_activity_type_t::FILE_ACTIVITY_OPEN => FileData::Open(inner),
-            file_activity_type_t::FILE_ACTIVITY_CREATION |
-            file_activity_type_t::DIR_ACTIVITY_CREATION => FileData::Creation(inner),
+            file_activity_type_t::FILE_ACTIVITY_CREATION
+            | file_activity_type_t::DIR_ACTIVITY_CREATION => FileData::Creation(inner),
             file_activity_type_t::FILE_ACTIVITY_UNLINK => FileData::Unlink(inner),
             file_activity_type_t::FILE_ACTIVITY_CHMOD => {
                 let data = ChmodFileData {

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -74,6 +74,8 @@ pub struct Event {
     hostname: &'static str,
     process: Process,
     file: FileData,
+    #[serde(skip)]
+    event_type: file_activity_type_t,
 }
 
 impl Event {
@@ -123,6 +125,7 @@ impl Event {
             hostname,
             process,
             file,
+            event_type: file_activity_type_t::FILE_ACTIVITY_CREATION,
         })
     }
 
@@ -132,6 +135,10 @@ impl Event {
 
     pub fn is_unlink(&self) -> bool {
         matches!(self.file, FileData::Unlink(_))
+    }
+        
+    pub fn is_dir_creation(&self) -> bool {
+        self.event_type == file_activity_type_t::DIR_ACTIVITY_CREATION
     }
 
     /// Unwrap the inner FileData and return the inode that triggered
@@ -263,6 +270,7 @@ impl TryFrom<&event_t> for Event {
             hostname: host_info::get_hostname(),
             process,
             file,
+            event_type: value.type_,
         })
     }
 }

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -308,7 +308,7 @@ impl HostScanner {
                         }
 
                         // Skip directory creation events - we track them internally but don't send to sensor
-                        if !event.is_dir_creation() {
+                        if event.event_type() != fact_ebpf::file_activity_type_t::DIR_ACTIVITY_CREATION {
                             let event = Arc::new(event);
                             if let Err(e) = self.tx.send(event) {
                                 self.metrics.events.dropped();

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -311,7 +311,6 @@ impl HostScanner {
                             self.metrics.events.dropped();
                             warn!("Failed to send event: {e}");
                         }
-                        }
                     },
                     _ = scan_trigger.notified() => self.scan()?,
                     _ = self.paths.changed() => self.scan()?,

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -306,6 +306,15 @@ impl HostScanner {
                             self.metrics.events.dropped();
                             warn!("Failed to send event: {e}");
                         }
+
+                        // Skip directory creation events - we track them internally but don't send to sensor
+                        if !event.is_dir_creation() {
+                            let event = Arc::new(event);
+                            if let Err(e) = self.tx.send(event) {
+                                self.metrics.events.dropped();
+                                warn!("Failed to send event: {e}");
+                            }
+                        }
                     },
                     _ = scan_trigger.notified() => self.scan()?,
                     _ = self.paths.changed() => self.scan()?,

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -302,12 +302,15 @@ impl HostScanner {
                         }
 
                         // Skip directory creation events - we track them internally but don't send to sensor
-                        if !event.is_mkdir() {
-                            let event = Arc::new(event);
-                            if let Err(e) = self.tx.send(event) {
-                                self.metrics.events.dropped();
-                                warn!("Failed to send event: {e}");
-                            }
+                        if event.is_mkdir() {
+                            continue;
+                        }
+
+                        let event = Arc::new(event);
+                        if let Err(e) = self.tx.send(event) {
+                            self.metrics.events.dropped();
+                            warn!("Failed to send event: {e}");
+                        }
                         }
                     },
                     _ = scan_trigger.notified() => self.scan()?,

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -301,12 +301,6 @@ impl HostScanner {
                             self.handle_unlink_event(&event);
                         }
 
-                        let event = Arc::new(event);
-                        if let Err(e) = self.tx.send(event) {
-                            self.metrics.events.dropped();
-                            warn!("Failed to send event: {e}");
-                        }
-
                         // Skip directory creation events - we track them internally but don't send to sensor
                         if event.event_type() != fact_ebpf::file_activity_type_t::DIR_ACTIVITY_CREATION {
                             let event = Arc::new(event);

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -280,7 +280,7 @@ impl HostScanner {
                         };
                         self.metrics.events.added();
 
-                        // Handle file creation events by adding new inodes to the map
+                        // Handle file and directory creation events by adding new inodes to the map
                         if event.is_creation() &&
                             let Err(e) = self.handle_creation_event(&event) {
                                 warn!("Failed to handle creation event: {e}");
@@ -302,7 +302,7 @@ impl HostScanner {
                         }
 
                         // Skip directory creation events - we track them internally but don't send to sensor
-                        if event.event_type() != fact_ebpf::file_activity_type_t::DIR_ACTIVITY_CREATION {
+                        if !event.is_mkdir() {
                             let event = Arc::new(event);
                             if let Err(e) = self.tx.send(event) {
                                 self.metrics.events.dropped();

--- a/fact/src/metrics/kernel_metrics.rs
+++ b/fact/src/metrics/kernel_metrics.rs
@@ -13,6 +13,8 @@ pub struct KernelMetrics {
     path_chmod: EventCounter,
     path_chown: EventCounter,
     path_rename: EventCounter,
+    path_mkdir: EventCounter,
+    d_instantiate: EventCounter,
     map: PerCpuArray<MapData, metrics_t>,
 }
 
@@ -43,12 +45,24 @@ impl KernelMetrics {
             "Events processed by the path_rename LSM hook",
             &[], // Labels are not needed since `collect` will add them all
         );
+        let path_mkdir = EventCounter::new(
+            "kernel_path_mkdir_events",
+            "Events processed by the path_mkdir LSM hook",
+            &[], // Labels are not needed since `collect` will add them all
+        );
+        let d_instantiate = EventCounter::new(
+            "kernel_d_instantiate_events",
+            "Events processed by the d_instantiate LSM hook",
+            &[], // Labels are not needed since `collect` will add them all
+        );
 
         file_open.register(reg);
         path_unlink.register(reg);
         path_chmod.register(reg);
         path_chown.register(reg);
         path_rename.register(reg);
+        path_mkdir.register(reg);
+        d_instantiate.register(reg);
 
         KernelMetrics {
             file_open,
@@ -56,6 +70,8 @@ impl KernelMetrics {
             path_chmod,
             path_chown,
             path_rename,
+            path_mkdir,
+            d_instantiate,
             map: kernel_metrics,
         }
     }
@@ -105,6 +121,8 @@ impl KernelMetrics {
         KernelMetrics::refresh_labels(&self.path_chmod, &metrics.path_chmod);
         KernelMetrics::refresh_labels(&self.path_chown, &metrics.path_chown);
         KernelMetrics::refresh_labels(&self.path_rename, &metrics.path_rename);
+        KernelMetrics::refresh_labels(&self.path_mkdir, &metrics.path_mkdir);
+        KernelMetrics::refresh_labels(&self.d_instantiate, &metrics.d_instantiate);
 
         Ok(())
     }

--- a/tests/test_path_mkdir.py
+++ b/tests/test_path_mkdir.py
@@ -34,13 +34,9 @@ def test_mkdir_nested(monitored_dir, server, dirname):
     with open(test_file, 'w') as f:
         f.write('nested content')
 
+    # Directory creation events are tracked internally but not sent to sensor
+    # Only the file creation event should be sent
     events = [
-        Event(process=process, event_type=EventType.CREATION,
-              file=level1, host_path=level1),
-        Event(process=process, event_type=EventType.CREATION,
-              file=level2, host_path=level2),
-        Event(process=process, event_type=EventType.CREATION,
-              file=level3, host_path=level3),
         Event(process=process, event_type=EventType.CREATION,
               file=test_file, host_path=test_file),
     ]
@@ -62,13 +58,19 @@ def test_mkdir_ignored(monitored_dir, ignored_dir, server):
     # Create directory in ignored path - should not be tracked
     ignored_subdir = os.path.join(ignored_dir, 'ignored_subdir')
     os.mkdir(ignored_subdir)
+    ignored_file = os.path.join(ignored_subdir, 'ignored.txt')
+    with open(ignored_file, 'w') as f:
+        f.write('ignored')
 
     # Create directory in monitored path - should be tracked
     monitored_subdir = os.path.join(monitored_dir, 'monitored_subdir')
     os.mkdir(monitored_subdir)
+    monitored_file = os.path.join(monitored_subdir, 'monitored.txt')
+    with open(monitored_file, 'w') as f:
+        f.write('monitored')
 
-    # Only the monitored directory should generate an event
+    # Only the monitored file should generate an event (directories are tracked internally)
     e = Event(process=process, event_type=EventType.CREATION,
-              file=monitored_subdir, host_path=monitored_subdir)
+              file=monitored_file, host_path=monitored_file)
 
     server.wait_events([e])

--- a/tests/test_path_mkdir.py
+++ b/tests/test_path_mkdir.py
@@ -1,0 +1,69 @@
+import os
+
+import pytest
+
+from event import Event, EventType, Process
+
+
+def test_mkdir_nested(monitored_dir, server):
+    """
+    Tests that creating nested directories tracks all inodes correctly.
+
+    Args:
+        monitored_dir: Temporary directory path for creating the test directory.
+        server: The server instance to communicate with.
+    """
+    process = Process.from_proc()
+
+    # Create nested directories
+    level1 = os.path.join(monitored_dir, 'level1')
+    level2 = os.path.join(level1, 'level2')
+    level3 = os.path.join(level2, 'level3')
+
+    os.mkdir(level1)
+    os.mkdir(level2)
+    os.mkdir(level3)
+
+    # Create a file in the deepest directory
+    test_file = os.path.join(level3, 'deep_file.txt')
+    with open(test_file, 'w') as f:
+        f.write('nested content')
+
+    events = [
+        Event(process=process, event_type=EventType.CREATION,
+              file=level1, host_path=level1),
+        Event(process=process, event_type=EventType.CREATION,
+              file=level2, host_path=level2),
+        Event(process=process, event_type=EventType.CREATION,
+              file=level3, host_path=level3),
+        Event(process=process, event_type=EventType.CREATION,
+              file=test_file, host_path=test_file),
+    ]
+
+    server.wait_events(events)
+
+
+def test_mkdir_ignored(monitored_dir, ignored_dir, server):
+    """
+    Tests that directories created outside monitored paths are ignored.
+
+    Args:
+        monitored_dir: Temporary directory path that is monitored.
+        ignored_dir: Temporary directory path that is not monitored.
+        server: The server instance to communicate with.
+    """
+    process = Process.from_proc()
+
+    # Create directory in ignored path - should not be tracked
+    ignored_subdir = os.path.join(ignored_dir, 'ignored_subdir')
+    os.mkdir(ignored_subdir)
+
+    # Create directory in monitored path - should be tracked
+    monitored_subdir = os.path.join(monitored_dir, 'monitored_subdir')
+    os.mkdir(monitored_subdir)
+
+    # Only the monitored directory should generate an event
+    e = Event(process=process, event_type=EventType.CREATION,
+              file=monitored_subdir, host_path=monitored_subdir)
+
+    server.wait_events([e])

--- a/tests/test_path_mkdir.py
+++ b/tests/test_path_mkdir.py
@@ -5,20 +5,27 @@ import pytest
 from event import Event, EventType, Process
 
 
-def test_mkdir_nested(monitored_dir, server):
+@pytest.mark.parametrize("dirname", [
+    pytest.param('level3', id='ASCII'),
+    pytest.param('café', id='French'),
+    pytest.param('файл', id='Cyrillic'),
+    pytest.param('日本語', id='Japanese'),
+])
+def test_mkdir_nested(monitored_dir, server, dirname):
     """
     Tests that creating nested directories tracks all inodes correctly.
 
     Args:
         monitored_dir: Temporary directory path for creating the test directory.
         server: The server instance to communicate with.
+        dirname: Final directory name to test (including UTF-8 variants).
     """
     process = Process.from_proc()
 
     # Create nested directories
     level1 = os.path.join(monitored_dir, 'level1')
     level2 = os.path.join(level1, 'level2')
-    level3 = os.path.join(level2, 'level3')
+    level3 = os.path.join(level2, dirname)
 
     os.makedirs(level3, exist_ok=True)
 

--- a/tests/test_path_mkdir.py
+++ b/tests/test_path_mkdir.py
@@ -23,14 +23,11 @@ def test_mkdir_nested(monitored_dir, server, dirname):
     process = Process.from_proc()
 
     # Create nested directories
-    level1 = os.path.join(monitored_dir, 'level1')
-    level2 = os.path.join(level1, 'level2')
-    level3 = os.path.join(level2, dirname)
-
-    os.makedirs(level3, exist_ok=True)
+    test_dir = os.path.join(monitored_dir, 'level1', 'level2', dirname)
+    os.makedirs(test_dir, exist_ok=True)
 
     # Create a file in the deepest directory
-    test_file = os.path.join(level3, 'deep_file.txt')
+    test_file = os.path.join(test_dir, 'deep_file.txt')
     with open(test_file, 'w') as f:
         f.write('nested content')
 

--- a/tests/test_path_mkdir.py
+++ b/tests/test_path_mkdir.py
@@ -20,9 +20,7 @@ def test_mkdir_nested(monitored_dir, server):
     level2 = os.path.join(level1, 'level2')
     level3 = os.path.join(level2, 'level3')
 
-    os.mkdir(level1)
-    os.mkdir(level2)
-    os.mkdir(level3)
+    os.makedirs(level3, exist_ok=True)
 
     # Create a file in the deepest directory
     test_file = os.path.join(level3, 'deep_file.txt')


### PR DESCRIPTION
## Description

Directory creation events need to be handled correctly. When a directory is created in a tracked directory its inode should be added to a hash set in kernel space. In user space an entry needs to be added into a map with the inode as the key and file path as the value.

An alternative approach can be found at https://github.com/stackrox/fact/pull/449 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [x] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Checked metrics

```
$ grep path_mkdir */metrics 
test_mkdir_ignored/metrics:# HELP stackrox_fact_kernel_path_mkdir_events Events processed by the path_mkdir LSM hook.
test_mkdir_ignored/metrics:# TYPE stackrox_fact_kernel_path_mkdir_events counter
test_mkdir_ignored/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="RingbufferFull"} 0
test_mkdir_ignored/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="Added"} 0
test_mkdir_ignored/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="Error"} 0
test_mkdir_ignored/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="Ignored"} 2
test_mkdir_ignored/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="Total"} 3
test_mkdir_nested/metrics:# HELP stackrox_fact_kernel_path_mkdir_events Events processed by the path_mkdir LSM hook.
test_mkdir_nested/metrics:# TYPE stackrox_fact_kernel_path_mkdir_events counter
test_mkdir_nested/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="RingbufferFull"} 0
test_mkdir_nested/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="Added"} 0
test_mkdir_nested/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="Total"} 3
test_mkdir_nested/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="Ignored"} 0
test_mkdir_nested/metrics:stackrox_fact_kernel_path_mkdir_events_total{label="Error"} 0
```

```
$ grep d_instantiate */metrics 
test_mkdir_ignored/metrics:# HELP stackrox_fact_kernel_d_instantiate_events Events processed by the d_instantiate LSM hook.
test_mkdir_ignored/metrics:# TYPE stackrox_fact_kernel_d_instantiate_events counter
test_mkdir_ignored/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="Error"} 0
test_mkdir_ignored/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="Added"} 2
test_mkdir_ignored/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="Ignored"} 36
test_mkdir_ignored/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="RingbufferFull"} 0
test_mkdir_ignored/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="Total"} 37
test_mkdir_nested/metrics:# HELP stackrox_fact_kernel_d_instantiate_events Events processed by the d_instantiate LSM hook.
test_mkdir_nested/metrics:# TYPE stackrox_fact_kernel_d_instantiate_events counter
test_mkdir_nested/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="RingbufferFull"} 0
test_mkdir_nested/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="Added"} 6
test_mkdir_nested/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="Error"} 0
test_mkdir_nested/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="Total"} 115
test_mkdir_nested/metrics:stackrox_fact_kernel_d_instantiate_events_total{label="Ignored"} 112
```