### PR TITLE
fix: mitigate flaky tests on path reloading

### DIFF
--- a/tests/test_config_hotreload.py
+++ b/tests/test_config_hotreload.py
@@ -164,7 +164,7 @@ def test_no_paths_then_add(fact, fact_config, monitored_dir, server):
     # Remove all paths
     config, config_file = fact_config
     config['paths'] = []
-    reload_config(fact, config, config_file)
+    reload_config(fact, config, config_file, 1)
 
     # Write to a file — should NOT produce events
     fut = os.path.join(monitored_dir, 'test2.txt')
@@ -180,7 +180,7 @@ def test_no_paths_then_add(fact, fact_config, monitored_dir, server):
 
     # Add paths back
     config['paths'] = [f'{monitored_dir}/**/*']
-    reload_config(fact, config, config_file)
+    reload_config(fact, config, config_file, 1)
 
     # Write to a file — should produce events
     with open(fut, 'w') as f:
@@ -209,7 +209,7 @@ def test_paths_then_remove(fact, fact_config, monitored_dir, server):
     # Remove all paths
     config, config_file = fact_config
     config['paths'] = []
-    reload_config(fact, config, config_file)
+    reload_config(fact, config, config_file, 1)
 
     # Write to a file — should NOT produce events
     with open(fut, 'w') as f:


### PR DESCRIPTION

## Description

Reloading the paths now triggers a scan of the filesystem, which can take slightly longer than what it used to take when the scan wasn't done. In order to mitigate this, we bump the amount of time the tests wait before attempting to trigger events after reloading configuration with monitored paths being changed.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
