### PR TITLE
Fix nightly lint error

### DIFF
--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -124,23 +124,19 @@ impl HostScanner {
         };
 
         for entry in glob::glob(glob_str)? {
-            match entry {
-                Ok(path) => {
-                    if path.is_file() {
-                        self.metrics.scan_inc(ScanLabels::FileScanned);
-                        self.update_entry(path.as_path()).with_context(|| {
-                            format!("Failed to update entry for {}", path.display())
-                        })?;
-                    } else if path.is_dir() {
-                        self.metrics.scan_inc(ScanLabels::DirectoryScanned);
-                        self.update_entry(path.as_path()).with_context(|| {
-                            format!("Failed to update entry for {}", path.display())
-                        })?;
-                    } else {
-                        self.metrics.scan_inc(ScanLabels::FsItemIgnored);
-                    }
-                }
-                Err(e) => return Err(e.into()),
+            let path = entry?;
+            if path.is_file() {
+                self.metrics.scan_inc(ScanLabels::FileScanned);
+                self.update_entry(path.as_path()).with_context(|| {
+                    format!("Failed to update entry for {}", path.display())
+                })?;
+            } else if path.is_dir() {
+                self.metrics.scan_inc(ScanLabels::DirectoryScanned);
+                self.update_entry(path.as_path()).with_context(|| {
+                    format!("Failed to update entry for {}", path.display())
+                })?;
+            } else {
+                self.metrics.scan_inc(ScanLabels::FsItemIgnored);
             }
         }
         Ok(())

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -127,14 +127,12 @@ impl HostScanner {
             let path = entry?;
             if path.is_file() {
                 self.metrics.scan_inc(ScanLabels::FileScanned);
-                self.update_entry(path.as_path()).with_context(|| {
-                    format!("Failed to update entry for {}", path.display())
-                })?;
+                self.update_entry(path.as_path())
+                    .with_context(|| format!("Failed to update entry for {}", path.display()))?;
             } else if path.is_dir() {
                 self.metrics.scan_inc(ScanLabels::DirectoryScanned);
-                self.update_entry(path.as_path()).with_context(|| {
-                    format!("Failed to update entry for {}", path.display())
-                })?;
+                self.update_entry(path.as_path())
+                    .with_context(|| format!("Failed to update entry for {}", path.display()))?;
             } else {
                 self.metrics.scan_inc(ScanLabels::FsItemIgnored);
             }


### PR DESCRIPTION
## Description

Currently the following error is occurring in the `basic (arm64, nightly)` CI job. E.g https://github.com/stackrox/fact/actions/runs/24660694211/job/72105605981?pr=531

This PR fixes this error.

```
error: this `match` expression can be replaced with `?`
   --> fact/src/host_scanner.rs:127:13
    |
127 | /             match entry {
128 | |                 Ok(path) => {
129 | |                     if path.is_file() {
130 | |                         self.metrics.scan_inc(ScanLabels::FileScanned);
...   |
143 | |                 Err(e) => return Err(e.into()),
144 | |             }
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
    = note: `-D clippy::question-mark` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::question_mark)]`
help: try instead
    |
127 ~             {
128 +                 let path = entry?;
129 +                 if path.is_file() {
130 +                     self.metrics.scan_inc(ScanLabels::FileScanned);
131 +                     self.update_entry(path.as_path()).with_context(|| {
132 +                         format!("Failed to update entry for {}", path.display())
133 +                     })?;
134 +                 } else if path.is_dir() {
135 +                     self.metrics.scan_inc(ScanLabels::DirectoryScanned);
136 +                     self.update_entry(path.as_path()).with_context(|| {
137 +                         format!("Failed to update entry for {}", path.display())
138 +                     })?;
139 +                 } else {
140 +                     self.metrics.scan_inc(ScanLabels::FsItemIgnored);
141 +                 }
142 +             }
    |

error: could not compile `fact` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `fact` (lib test) due to 1 previous error
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

This just fixes a linting error.

## Testing Performed

CI is sufficient.
