### PR TITLE
cleanup(bpf): reduce preemption fragility in overlayfs dedup

### DIFF
--- a/fact-ebpf/src/bpf/maps.h
+++ b/fact-ebpf/src/bpf/maps.h
@@ -100,7 +100,7 @@ struct {
 // Track pid_tgid of overlayfs file_open events so we can skip the
 // duplicate underlying filesystem event that follows immediately.
 struct {
-  __uint(type, BPF_MAP_TYPE_LRU_PERCPU_HASH);
+  __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
   __type(key, __u64);
   __type(value, char);
   __uint(max_entries, 1);

--- a/fact-ebpf/src/bpf/maps.h
+++ b/fact-ebpf/src/bpf/maps.h
@@ -100,10 +100,10 @@ struct {
 // Track pid_tgid of overlayfs file_open events so we can skip the
 // duplicate underlying filesystem event that follows immediately.
 struct {
-  __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+  __uint(type, BPF_MAP_TYPE_LRU_HASH);
   __type(key, __u64);
   __type(value, char);
-  __uint(max_entries, 1);
+  __uint(max_entries, 256);
 } overlayfs_dedup SEC(".maps");
 
 __always_inline static struct metrics_t* get_metrics() {


### PR DESCRIPTION
## Description

The whole chain is in a single syscall context:
overlayfs -> open (first call to lsm hook) -> underlying fs -> open (second call to lsm hook.)

But the kernel thread might be preempted between the two lsm calls, resulting in scheduling on a different CPU and causing a cache miss when deduplicating overlayfs events.

To reduce this risk, this PR changes the dedup map to a global (not PERCPU) LRU map with 256 entries.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
