### PR TITLE
fix: don't fail integration test jobs on artifact upload errors

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -117,6 +117,10 @@ jobs:
 
     - name: Store artifacts
       if: always()
+      # Don't fail the job on upload errors (e.g. ECONNRESET) —
+      # these are debug logs, not consumed by downstream jobs.
+      # Test failures still fail the job via the Run Tests step.
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.vm }}-test-logs


### PR DESCRIPTION
## Description

The Store artifacts step uploads debug logs for human inspection but is not consumed by any downstream job. Network errors (ECONNRESET) during upload were causing passing test runs to be marked as failed.

Test failures still fail the job.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Trivial CI fix.