### PR TITLE
Refactor rmdir hook

### DIFF
--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -409,12 +409,10 @@ int BPF_PROG(trace_path_rmdir, struct path* dir, struct dentry* dentry) {
 
   args.inode = inode_to_key(dentry->d_inode);
 
-  if (is_monitored(&args.inode, path, NULL) == NOT_MONITORED) {
+  if (inode_remove(&args.inode) < 0) {
     m->path_rmdir.ignored++;
     return 0;
   }
-
-  inode_remove(&args.inode);
 
   submit_rmdir_event(&args);
   return 0;


### PR DESCRIPTION
## Description

Calling `is_monitored` when removing a directory from inode tracking is not needed since the inode will be in the map if it is monitored and not in the map if it is not monitored. A similar refactor does not work for unlinking files since the output of `is_monitored` is used to set `args.monitored` in that case and we need to know how it is monitored rather than if it is monitored or not in that case.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly (No documentation change is needed).

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient.
