### PR TITLE
fix: use shutil.rmtree instead of `rm -rf`

### DIFF
--- a/tests/test_path_rmdir.py
+++ b/tests/test_path_rmdir.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import subprocess
 
 import pytest
 
@@ -116,7 +115,7 @@ def test_rmdir_empty(monitored_dir, server, fact_config, dirname):
         f"Expected exactly 1 kernel rmdir event processed, got {kernel_delta}"
 
 
-def test_rmdir_recursive_with_rm(monitored_dir, server, fact_config):
+def test_rmdir_recursive(monitored_dir, server, fact_config):
     """
     Tests that removing a directory tree recursively cleans up all inode tracking.
 
@@ -169,27 +168,19 @@ def test_rmdir_recursive_with_rm(monitored_dir, server, fact_config):
 
     server.wait_events(creation_events)
 
-    # Remove the entire tree recursively using subprocess (like running rm -rf)
+    # Remove the entire tree recursively (like running rm -rf)
     # This will generate events for all files and directories
     # Order: deepest files/dirs first, then work up to the root
-    proc = subprocess.Popen(["rm", "-rf", level1])
-
-    # Capture process info while subprocess is running
-    rm_process = Process.from_proc(proc.pid)
-
-    # Wait for completion
-    proc.wait()
-    if proc.returncode != 0:
-        raise RuntimeError(f"rm command failed with exit code {proc.returncode}")
+    shutil.rmtree(level1)
 
     # Wait for file deletion events (rm -rf deletes depth-first)
     unlink_events = [
-        Event(process=rm_process, event_type=EventType.UNLINK,
-              file=file3, host_path=file3),
-        Event(process=rm_process, event_type=EventType.UNLINK,
-              file=file2, host_path=file2),
-        Event(process=rm_process, event_type=EventType.UNLINK,
+        Event(process=process, event_type=EventType.UNLINK,
               file=file1, host_path=file1),
+        Event(process=process, event_type=EventType.UNLINK,
+              file=file2, host_path=file2),
+        Event(process=process, event_type=EventType.UNLINK,
+              file=file3, host_path=file3),
     ]
 
     server.wait_events(unlink_events)


### PR DESCRIPTION
## Description

The original implementation for the test was flaky, sometimes failing due to the arguments being read from `/proc` being empty. After looking into the kernel code, particularly at [this function](https://elixir.bootlin.com/linux/v7.0.1/source/fs/proc/base.c#L291), it seems the only condition for this type of error is that the process that the cmdline is being read from has not had time to populate its arguments yet, (there are some other conditions, but most seem for errors that we should not be hitting). We could try to fix this with a small delay between creating the process and reading `/proc`, but because the original test used `rm` directly the process may very well exit during the small delay, still causing the test to be buggy.

Instead, we change the test to use shutil.rmtree, which is Python's builtin way to run `rm -rf`. With this approach we don't need an external process at all, making the test a bit more stable.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run the new implementation of the test in a loop on my machine and it didn't fail.
