### PR TITLE
cleanup: fix some compilation warnings on test target

### DIFF
--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "bpf-test"))]
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     ffi::{CStr, OsStr},
@@ -59,7 +59,7 @@ fn timestamp_to_proto(ts: u64) -> prost_types::Timestamp {
     prost_types::Timestamp { seconds, nanos }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "bpf-test"))]
 #[derive(Debug)]
 pub(crate) enum EventTestData {
     Creation,
@@ -77,7 +77,7 @@ pub struct Event {
 }
 
 impl Event {
-    #[cfg(test)]
+    #[cfg(all(test, feature = "bpf-test"))]
     pub(crate) fn new(
         data: EventTestData,
         hostname: &'static str,


### PR DESCRIPTION

## Description

Some code was marked to be use on the test target when it should've been marked to be used with the `bpf-test` feature. This patch fixes this situation.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
