### PR TITLE
fix: use values_mut instead of iter_mut

### DIFF
--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -315,7 +315,7 @@ impl HostScanner {
                 if self.paths_globset.is_match(&new_host_path) {
                     // New path needs to be tracked.
                     // Move all entries for the old host path to the new one
-                    for (_, path) in inode_map.iter_mut() {
+                    for path in inode_map.values_mut() {
                         if let Ok(suffix) = path.strip_prefix(old_host_path) {
                             if suffix == Path::new("") {
                                 *path = new_host_path.clone();


### PR DESCRIPTION

## Description

Nightly clippy is flagging this error in our codebase. For more information see:
https://rust-lang.github.io/rust-clippy/master/index.html#for_kv_map

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
