### PR TITLE
feat(ci): validate checklist is updated

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   validate-checklist:
     runs-on: ubuntu-24.04
-    #if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     steps:
       - name: Verify PR Checklist is Complete
         if: github.actor != 'red-hat-konflux[bot]'

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,34 @@
+name: "Enforce PR Checklist"
+
+on:
+  pull_request:
+   types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  validate-checklist:
+    runs-on: ubuntu-24.04
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Verify PR Checklist is Complete
+        if: github.actor != 'red-hat-konflux[bot]'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if ! (echo "$PR_BODY" | grep  "\- \[x\] Patch has a change log entry \*\*OR\*\* does not need one"); then
+            echo "Missing change log check"
+            exit 1
+          fi
+
+          if ! (echo "$PR_BODY" | grep  "\- \[x\] Investigated and inspected CI test results"); then
+            echo "Missing CI test check"
+            exit 1
+          fi
+
+      - name: Skip check for MintMaker
+        if: github.actor == 'red-hat-konflux[bot]'
+        run: |
+          echo "MintMaker PRs are exempted from this check"

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -7,6 +7,7 @@ on:
       - edited
       - synchronize
       - reopened
+      - ready_for_review
 
 jobs:
   validate-checklist:

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -18,12 +18,12 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if ! (echo "$PR_BODY" | grep  "\- \[x\] Patch has a change log entry \*\*OR\*\* does not need one"); then
+          if ! (echo "$PR_BODY" | grep -q "\- \[x\] Patch has a change log entry \*\*OR\*\* does not need one"); then
             echo "Missing change log check"
             exit 1
           fi
 
-          if ! (echo "$PR_BODY" | grep  "\- \[x\] Investigated and inspected CI test results"); then
+          if ! (echo "$PR_BODY" | grep -q "\- \[x\] Investigated and inspected CI test results"); then
             echo "Missing CI test check"
             exit 1
           fi

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   validate-checklist:
     runs-on: ubuntu-24.04
-    if: github.event.pull_request.draft == false
+    #if: github.event.pull_request.draft == false
     steps:
       - name: Verify PR Checklist is Complete
         if: github.actor != 'red-hat-konflux[bot]'


### PR DESCRIPTION
## Description

This is a small CI check that verifies a few fields in the checklist section of the PR description is updated. If this is not too disruptive, we can probably make the check required in the near future.

## Checklist
- [x] Patch has a change log entry **OR** does not need one
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- Check is skipped for draft PRs: [CI run](https://github.com/stackrox/fact/actions/runs/25549334462/job/74993124502).
- Change log check fails when not set: [CI run](https://github.com/stackrox/fact/actions/runs/25549461007/job/74993554280?pr=636).
- CI check fails when not set: [CI run](https://github.com/stackrox/fact/actions/runs/25549471051/job/74993589335?pr=636)
- Job passes when both entries are set: [CI run](https://github.com/stackrox/fact/actions/runs/25549583113/job/74993978496?pr=636)
- Marking the PR as ready for review triggers the check: [CI run](https://github.com/stackrox/fact/actions/runs/25662860352/job/75327704193?pr=636)
