### PR TITLE
ROX-34663: Migrate from ubi-minimal to ubi-micro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ possible include a PR number for easier tracking.
 
 ## Next
 
+* ROX-34663: Migrate from ubi-minimal to ubi-micro (#653)
 * ROX-30256: track files and directories being renamed (#308)
 * ROX-33198: Instrument inode tracking on file open lsm hook (#391)
 * ROX-33217: Instrument inode tracking on directory being created path mkdir (#465)

--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,23 @@
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest AS ubi-micro-base
+
+FROM registry.access.redhat.com/ubi9/ubi:latest AS package_installer
+
+COPY --from=ubi-micro-base / /out/
+
+RUN dnf install -y \
+    --installroot=/out/ \
+    --releasever=9 \
+    --setopt=install_weak_deps=False \
+    --nodocs \
+    ca-certificates \
+    crypto-policies-scripts \
+    gzip \
+    less \
+    openssl-libs \
+    tar && \
+    dnf clean all --installroot=/out/ && \
+    rm -rf /out/var/cache/dnf /out/var/cache/yum
+
 FROM quay.io/centos/centos:stream9 AS builder
 
 ARG RUST_VERSION=stable
@@ -25,7 +45,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     cargo build --release && \
     cp target/release/fact fact
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM ubi-micro-base
 
 ARG FACT_VERSION
 LABEL name="fact" \
@@ -35,17 +55,12 @@ LABEL name="fact" \
       description="This image supports file activity data collection in the StackRox Kubernetes Security Platform." \
       io.stackrox.fact.version="${FACT_VERSION}"
 
-RUN microdnf install -y openssl-libs crypto-policies-scripts && \
-    # Enable post-quantum cryptography key exchange for TLS.
-    update-crypto-policies --set DEFAULT:PQ && \
-    microdnf clean all && \
-    rpm --verbose -e --nodeps $( \
-        rpm -qa 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' 'libyaml*' 'libarchive*' \
-    ) && \
-    rm -rf /var/cache/yum
+COPY --from=package_installer /out/ /
 
 COPY --from=build /app/fact /usr/local/bin
 
 COPY LICENSE-APACHE LICENSE-MIT LICENSE-GPL2 /licenses/
+
+RUN update-crypto-policies --set DEFAULT:PQ
 
 ENTRYPOINT ["fact"]

--- a/konflux.Containerfile
+++ b/konflux.Containerfile
@@ -1,6 +1,6 @@
-FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:fe9e574f04371b333ed4e21d30d984f6b7fcd1046e579f5ddab4816c0c8e231d AS ubi-micro-base
+FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:093a704be0eaef9bb52d9bc0219c67ee9db13c2e797da400ddb5d5ae6849fa10 AS ubi-micro-base
 
-FROM registry.access.redhat.com/ubi9/ubi@sha256:8ca59004c1c505bdabadd5202bd3363986f5bf873fcfb36f60561d7362fe52a7 AS package_installer
+FROM registry.access.redhat.com/ubi9/ubi@sha256:6ed9f6f637fe731d93ec60c065dbced79273f1e0b5f512951f2c0b0baedb16ad AS package_installer
 
 COPY --from=ubi-micro-base / /out/
 

--- a/konflux.Containerfile
+++ b/konflux.Containerfile
@@ -1,3 +1,24 @@
+FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:fe9e574f04371b333ed4e21d30d984f6b7fcd1046e579f5ddab4816c0c8e231d AS ubi-micro-base
+
+FROM registry.access.redhat.com/ubi9/ubi@sha256:8ca59004c1c505bdabadd5202bd3363986f5bf873fcfb36f60561d7362fe52a7 AS package_installer
+
+COPY --from=ubi-micro-base / /out/
+
+RUN dnf install -y \
+    --installroot=/out/ \
+    --releasever=9 \
+    --setopt=install_weak_deps=False \
+    --setopt=reposdir=/etc/yum.repos.d \
+    --nodocs \
+    ca-certificates \
+    crypto-policies-scripts \
+    gzip \
+    less \
+    openssl-libs \
+    tar && \
+    dnf clean all --installroot=/out/ && \
+    rm -rf /out/var/cache/dnf /out/var/cache/yum
+
 FROM registry.access.redhat.com/ubi9/ubi@sha256:8ca59004c1c505bdabadd5202bd3363986f5bf873fcfb36f60561d7362fe52a7 AS builder
 
 ARG FACT_TAG
@@ -18,7 +39,7 @@ COPY . .
 
 RUN cargo build --release
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:12db9874bd753eb98b1ab3d840e75de5d6842ac0604fbd68c012adefe97140be
+FROM ubi-micro-base
 
 ARG FACT_TAG
 
@@ -43,19 +64,12 @@ LABEL \
     # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
     release="1"
 
-RUN microdnf install -y \
-        crypto-policies-scripts \
-        openssl-libs && \
-    # Enable post-quantum cryptography key exchange for TLS.
-    update-crypto-policies --set DEFAULT:PQ && \
-    microdnf clean all && \
-    rpm --verbose -e --nodeps $( \
-        rpm -qa 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' 'libyaml*' 'libarchive*' \
-    ) && \
-    rm -rf /var/cache/yum
+COPY --from=package_installer /out/ /
 
 COPY --from=builder /app/target/release/fact /usr/local/bin
 
 COPY LICENSE-APACHE LICENSE-MIT LICENSE-GPL2 /licenses/
+
+RUN update-crypto-policies --set DEFAULT:PQ
 
 ENTRYPOINT ["fact"]

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -2,15 +2,19 @@
 # See our docs here: https://spaces.redhat.com/display/StackRox/How+to+prefetch+RPMs+for+ACS+Konflux+builds
 
 packages:
+- ca-certificates
 - cargo
 - clang
 - crypto-policies-scripts
+- gzip
+- less
 - libbpf-devel
 - openssl-libs
 - openssl-devel
 - protobuf-compiler
 - protobuf-devel
 - rust
+- tar
 contentOrigin:
   repofiles: ["rpms.rhel.repo"]
 context:

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -123,13 +123,13 @@ arches:
     name: glibc-devel
     evr: 2.34-231.el9_7.10
     sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-611.54.1.el9_7.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-611.55.1.el9_7.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 2991249
-    checksum: sha256:1ce921e3e289e6459751b3e74006b3d47732abdc0f1f59536f02f05d81e119ab
+    size: 2991565
+    checksum: sha256:ae3257c03d08536eeeb0b00fe49e6c929a357202f543ab70343a2bcf16689a21
     name: kernel-headers
-    evr: 5.14.0-611.54.1.el9_7
-    sourcerpm: kernel-5.14.0-611.54.1.el9_7.src.rpm
+    evr: 5.14.0-611.55.1.el9_7
+    sourcerpm: kernel-5.14.0-611.55.1.el9_7.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/l/libasan-11.5.0-11.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 408716
@@ -1243,6 +1243,13 @@ arches:
     name: systemd-rpm-macros
     evr: 252-55.el9_7.9
     sourcerpm: systemd-252-55.el9_7.9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/t/tar-1.34-9.el9_7.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 898317
+    checksum: sha256:2d0bd44116c3f5c229d25fdc6458f6ce24a7ad4fdb463767eea48dcab78c5062
+    name: tar
+    evr: 2:1.34-9.el9_7
+    sourcerpm: tar-1.34-9.el9_7.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/t/tcl-8.6.10-7.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 1137015
@@ -1443,13 +1450,13 @@ arches:
     name: glibc-headers
     evr: 2.34-231.el9_7.10
     sourcerpm: glibc-2.34-231.el9_7.10.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-611.54.1.el9_7.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-611.55.1.el9_7.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3030285
-    checksum: sha256:0b0cac1f70c953850798b2430e8918e231d93e58d5ed03c6d92cb0b45a33915f
+    size: 3030561
+    checksum: sha256:5791683d2358facf7330677530af09cd0b310c71ed92b151b30a9c11eeafab2a
     name: kernel-headers
-    evr: 5.14.0-611.54.1.el9_7
-    sourcerpm: kernel-5.14.0-611.54.1.el9_7.src.rpm
+    evr: 5.14.0-611.55.1.el9_7
+    sourcerpm: kernel-5.14.0-611.55.1.el9_7.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 66075
@@ -2556,6 +2563,13 @@ arches:
     name: systemd-rpm-macros
     evr: 252-55.el9_7.9
     sourcerpm: systemd-252-55.el9_7.9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tar-1.34-9.el9_7.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 906521
+    checksum: sha256:4c0beb933074a5254c297e8968b3f41ec5a02b23056997ddcf526fe7e6166482
+    name: tar
+    evr: 2:1.34-9.el9_7
+    sourcerpm: tar-1.34-9.el9_7.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tcl-8.6.10-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1152092


### PR DESCRIPTION
## Description

Reduce container image size and attack surface by migrating to ubi-micro base images following the pattern established in collector and stackrox repositories.

Refs:
- https://github.com/stackrox/collector/pull/3021
- https://github.com/stackrox/collector/pull/3220

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI