### PR TITLE
feat: dynamic length event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +442,7 @@ version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "aya",
+ "byteorder",
  "clap",
  "env_logger",
  "fact-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 aya = { version = "0.13.1", default-features = false }
 
 anyhow = { version = "1", default-features = false, features = ["std", "backtrace"] }
+byteorder = "1.5.0"
 clap = { version = "4.5.41", features = ["derive", "env"] }
 env_logger = { version = "0.11.5", default-features = false, features = ["humantime"] }
 glob = "0.3.3"

--- a/fact-ebpf/src/bpf/bound_path.h
+++ b/fact-ebpf/src/bpf/bound_path.h
@@ -72,6 +72,7 @@ __always_inline static enum path_append_status_t path_append_dentry(struct bound
 
   path->len += len;
   path_write_char(path->path, path->len, '\0');
+  path->len++;
 
   return 0;
 }

--- a/fact-ebpf/src/bpf/events.h
+++ b/fact-ebpf/src/bpf/events.h
@@ -8,88 +8,104 @@
 #include "maps.h"
 #include "process.h"
 #include "types.h"
+#include "raw_event.h"
 
 #include <bpf/bpf_helpers.h>
 // clang-format on
 
 struct submit_event_args_t {
-  struct event_t* event;
   struct metrics_by_hook_t* metrics;
-  const char* filename;
+  struct bound_path_t* filename;
   inode_key_t inode;
   inode_key_t parent_inode;
   monitored_t monitored;
 };
 
-__always_inline static bool reserve_event(struct submit_event_args_t* args) {
-  args->event = bpf_ringbuf_reserve(&rb, sizeof(struct event_t), 0);
-  if (args->event == NULL) {
-    args->metrics->ringbuffer_full++;
-    return false;
-  }
-  return true;
-}
+__always_inline static long fill_base_event(struct submit_event_args_t* args,
+                                            struct raw_event_t* event,
+                                            file_activity_type_t type,
+                                            bool use_bpf_d_path) {
+  raw_event_copy_u16(event, type);
+  raw_event_copy_u64(event, bpf_ktime_get_boot_ns());
 
-__always_inline static void __submit_event(struct submit_event_args_t* args,
-                                           bool use_bpf_d_path) {
-  struct event_t* event = args->event;
-  event->timestamp = bpf_ktime_get_boot_ns();
-  event->monitored = args->monitored;
-  inode_copy(&event->inode, &args->inode);
-  inode_copy(&event->parent_inode, &args->parent_inode);
-  bpf_probe_read_str(event->filename, PATH_MAX, args->filename);
-
-  struct helper_t* helper = get_helper();
-  if (helper == NULL) {
-    goto error;
-  }
-
-  int64_t err = process_fill(&event->process, use_bpf_d_path);
+  int64_t err = process_fill(event, use_bpf_d_path);
   if (err) {
     bpf_printk("Failed to fill process information: %d", err);
+    return -1;
+  }
+
+  // File data
+  raw_event_copy_u8(event, args->monitored);
+  raw_event_copy_inode(event, &args->inode);
+  raw_event_copy_inode(event, &args->parent_inode);
+  raw_event_copy_bound_path(event, args->filename);
+
+  return 0;
+}
+
+__always_inline static void __submit_event(struct submit_event_args_t* args, struct raw_event_t* event) {
+  if (bpf_ringbuf_output(&rb, event->buf, event->len, 0) != 0) {
+    args->metrics->ringbuffer_full++;
+    return;
+  }
+  args->metrics->added++;
+}
+
+__always_inline static void submit_open_event(struct submit_event_args_t* args,
+                                              file_activity_type_t type) {
+  struct raw_event_t event = INIT_RAW_EVENT();
+  if (event.buf == NULL) {
     goto error;
   }
 
-  args->metrics->added++;
-  bpf_ringbuf_submit(event, 0);
+  if (fill_base_event(args, &event, type, true) != 0) {
+    goto error;
+  }
+
+  __submit_event(args, &event);
   return;
 
 error:
   args->metrics->error++;
-  bpf_ringbuf_discard(event, 0);
-}
-
-__always_inline static void submit_open_event(struct submit_event_args_t* args,
-                                              file_activity_type_t event_type) {
-  if (!reserve_event(args)) {
-    return;
-  }
-  args->event->type = event_type;
-
-  __submit_event(args, true);
 }
 
 __always_inline static void submit_unlink_event(struct submit_event_args_t* args) {
-  if (!reserve_event(args)) {
-    return;
+  struct raw_event_t event = INIT_RAW_EVENT();
+  if (event.buf == NULL) {
+    goto error;
   }
-  args->event->type = FILE_ACTIVITY_UNLINK;
 
-  __submit_event(args, path_hooks_support_bpf_d_path);
+  if (fill_base_event(args, &event, FILE_ACTIVITY_UNLINK, path_hooks_support_bpf_d_path) != 0) {
+    goto error;
+  }
+
+  __submit_event(args, &event);
+  return;
+
+error:
+  args->metrics->error++;
 }
 
 __always_inline static void submit_mode_event(struct submit_event_args_t* args,
                                               umode_t mode,
                                               umode_t old_mode) {
-  if (!reserve_event(args)) {
-    return;
+  struct raw_event_t event = INIT_RAW_EVENT();
+  if (event.buf == NULL) {
+    goto error;
   }
 
-  args->event->type = FILE_ACTIVITY_CHMOD;
-  args->event->chmod.new = mode;
-  args->event->chmod.old = old_mode;
+  if (fill_base_event(args, &event, FILE_ACTIVITY_CHMOD, path_hooks_support_bpf_d_path) != 0) {
+    goto error;
+  }
 
-  __submit_event(args, path_hooks_support_bpf_d_path);
+  raw_event_copy_u16(&event, mode);
+  raw_event_copy_u16(&event, old_mode);
+
+  __submit_event(args, &event);
+  return;
+
+error:
+  args->metrics->error++;
 }
 
 __always_inline static void submit_ownership_event(struct submit_event_args_t* args,
@@ -97,50 +113,81 @@ __always_inline static void submit_ownership_event(struct submit_event_args_t* a
                                                    unsigned long long gid,
                                                    unsigned long long old_uid,
                                                    unsigned long long old_gid) {
-  if (!reserve_event(args)) {
-    return;
+  struct raw_event_t event = INIT_RAW_EVENT();
+  if (event.buf == NULL) {
+    goto error;
   }
 
-  args->event->type = FILE_ACTIVITY_CHOWN;
-  args->event->chown.new.uid = uid;
-  args->event->chown.new.gid = gid;
-  args->event->chown.old.uid = old_uid;
-  args->event->chown.old.gid = old_gid;
+  if (fill_base_event(args, &event, FILE_ACTIVITY_CHOWN, path_hooks_support_bpf_d_path) != 0) {
+    goto error;
+  }
 
-  __submit_event(args, path_hooks_support_bpf_d_path);
+  raw_event_copy_u32(&event, uid);
+  raw_event_copy_u32(&event, gid);
+  raw_event_copy_u32(&event, old_uid);
+  raw_event_copy_u32(&event, old_gid);
+
+  __submit_event(args, &event);
+  return;
+
+error:
+  args->metrics->error++;
 }
 
 __always_inline static void submit_rename_event(struct submit_event_args_t* args,
-                                                const char old_filename[PATH_MAX],
+                                                const struct bound_path_t* const filename,
                                                 inode_key_t* old_inode,
                                                 monitored_t old_monitored) {
-  if (!reserve_event(args)) {
-    return;
+  struct raw_event_t event = INIT_RAW_EVENT();
+  if (event.buf == NULL) {
+    goto error;
   }
 
-  args->event->type = FILE_ACTIVITY_RENAME;
-  bpf_probe_read_str(args->event->rename.filename, PATH_MAX, old_filename);
-  inode_copy(&args->event->rename.inode, old_inode);
-  args->event->rename.monitored = old_monitored;
+  if (fill_base_event(args, &event, FILE_ACTIVITY_RENAME, path_hooks_support_bpf_d_path) != 0) {
+    goto error;
+  }
 
-  __submit_event(args, path_hooks_support_bpf_d_path);
+  raw_event_copy_u8(&event, old_monitored);
+  raw_event_copy_inode(&event, old_inode);
+  raw_event_copy_bound_path(&event, filename);
+
+  __submit_event(args, &event);
+  return;
+
+error:
+  args->metrics->error++;
 }
 
 __always_inline static void submit_mkdir_event(struct submit_event_args_t* args) {
-  if (!reserve_event(args)) {
-    return;
+  struct raw_event_t event = INIT_RAW_EVENT();
+  if (event.buf == NULL) {
+    goto error;
   }
-  args->event->type = DIR_ACTIVITY_CREATION;
 
-  // d_instantiate doesn't support bpf_d_path, so we use false and rely on the stashed path from path_mkdir
-  __submit_event(args, false);
+  if (fill_base_event(args, &event, DIR_ACTIVITY_CREATION, false) != 0) {
+    goto error;
+  }
+
+  __submit_event(args, &event);
+  return;
+
+error:
+  args->metrics->error++;
 }
 
 __always_inline static void submit_rmdir_event(struct submit_event_args_t* args) {
-  if (!reserve_event(args)) {
-    return;
+  struct raw_event_t event = INIT_RAW_EVENT();
+  if (event.buf == NULL) {
+    goto error;
   }
-  args->event->type = DIR_ACTIVITY_UNLINK;
 
-  __submit_event(args, path_hooks_support_bpf_d_path);
+  if (fill_base_event(args, &event, DIR_ACTIVITY_UNLINK, path_hooks_support_bpf_d_path) != 0) {
+    goto error;
+  }
+
+  __submit_event(args, &event);
+  return;
+
+error:
+  args->metrics->error++;
 }

--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -54,13 +54,12 @@ int BPF_PROG(trace_file_open, struct file* file) {
     }
   }
 
-  struct bound_path_t* path = path_read_unchecked(&file->f_path);
-  if (path == NULL) {
+  args.filename = path_read_unchecked(&file->f_path);
+  if (args.filename == NULL) {
     bpf_printk("Failed to read path");
     m->file_open.error++;
     return 0;
   }
-  args.filename = path->path;
 
   args.inode = inode_to_key(file->f_inode);
 
@@ -68,7 +67,7 @@ int BPF_PROG(trace_file_open, struct file* file) {
   struct inode* parent_inode_ptr = parent_dentry ? BPF_CORE_READ(parent_dentry, d_inode) : NULL;
   args.parent_inode = inode_to_key(parent_inode_ptr);
 
-  args.monitored = is_monitored(&args.inode, path, &args.parent_inode);
+  args.monitored = is_monitored(&args.inode, args.filename, &args.parent_inode);
   if (args.monitored == NOT_MONITORED) {
     goto ignored;
   }
@@ -96,16 +95,15 @@ int BPF_PROG(trace_path_unlink, struct path* dir, struct dentry* dentry) {
 
   args.metrics->total++;
 
-  struct bound_path_t* path = path_read_append_d_entry(dir, dentry);
-  if (path == NULL) {
+  args.filename = path_read_append_d_entry(dir, dentry);
+  if (args.filename == NULL) {
     bpf_printk("Failed to read path");
     m->path_unlink.error++;
     return 0;
   }
-  args.filename = path->path;
 
   args.inode = inode_to_key(dentry->d_inode);
-  args.monitored = is_monitored(&args.inode, path, NULL);
+  args.monitored = is_monitored(&args.inode, args.filename, NULL);
 
   if (args.monitored == NOT_MONITORED) {
     m->path_unlink.ignored++;
@@ -129,16 +127,15 @@ int BPF_PROG(trace_path_chmod, struct path* path, umode_t mode) {
 
   args.metrics->total++;
 
-  struct bound_path_t* bound_path = path_read(path);
-  if (bound_path == NULL) {
+  args.filename = path_read(path);
+  if (args.filename == NULL) {
     bpf_printk("Failed to read path");
     args.metrics->error++;
     return 0;
   }
-  args.filename = bound_path->path;
 
   args.inode = inode_to_key(path->dentry->d_inode);
-  args.monitored = is_monitored(&args.inode, bound_path, NULL);
+  args.monitored = is_monitored(&args.inode, args.filename, NULL);
 
   if (args.monitored == NOT_MONITORED) {
     args.metrics->ignored++;
@@ -164,16 +161,15 @@ int BPF_PROG(trace_path_chown, struct path* path, unsigned long long uid, unsign
 
   args.metrics->total++;
 
-  struct bound_path_t* bound_path = path_read(path);
-  if (bound_path == NULL) {
+  args.filename = path_read(path);
+  if (args.filename == NULL) {
     bpf_printk("Failed to read path");
     args.metrics->error++;
     return 0;
   }
-  args.filename = bound_path->path;
 
   args.inode = inode_to_key(path->dentry->d_inode);
-  args.monitored = is_monitored(&args.inode, bound_path, NULL);
+  args.monitored = is_monitored(&args.inode, args.filename, NULL);
 
   if (args.monitored == NOT_MONITORED) {
     args.metrics->ignored++;
@@ -201,12 +197,11 @@ int BPF_PROG(trace_path_rename, struct path* old_dir,
 
   args.metrics->total++;
 
-  struct bound_path_t* new_path = path_read_append_d_entry(new_dir, new_dentry);
-  if (new_path == NULL) {
+  args.filename = path_read_append_d_entry(new_dir, new_dentry);
+  if (args.filename == NULL) {
     bpf_printk("Failed to read path");
     goto error;
   }
-  args.filename = new_path->path;
 
   struct bound_path_t* old_path = path_read_alt_append_d_entry(old_dir, old_dentry);
   if (old_path == NULL) {
@@ -216,7 +211,7 @@ int BPF_PROG(trace_path_rename, struct path* old_dir,
 
   args.inode = inode_to_key(new_dentry->d_inode);
   args.parent_inode = inode_to_key(new_dir->dentry->d_inode);
-  args.monitored = is_monitored(&args.inode, new_path, &args.parent_inode);
+  args.monitored = is_monitored(&args.inode, args.filename, &args.parent_inode);
 
   inode_key_t old_inode = inode_to_key(old_dentry->d_inode);
   monitored_t old_monitored = is_monitored(&old_inode, old_path, NULL);
@@ -283,7 +278,7 @@ int BPF_PROG(trace_path_rename, struct path* old_dir,
       break;
   }
 
-  submit_rename_event(&args, old_path->path, &old_inode, old_monitored);
+  submit_rename_event(&args, old_path, &old_inode, old_monitored);
   return 0;
 
 error:
@@ -334,13 +329,14 @@ int BPF_PROG(trace_path_mkdir, struct path* dir, struct dentry* dentry, umode_t 
     }
   }
 
-  long path_copy_len = bpf_probe_read_str(mkdir_ctx->path, PATH_MAX, path->path);
-  if (path_copy_len < 0) {
+  long res = bpf_probe_read(mkdir_ctx->path.path, PATH_LEN_CLAMP(path->len), path->path);
+  if (res < 0) {
     bpf_printk("Failed to copy path string");
     m->path_mkdir.error++;
     bpf_map_delete_elem(&mkdir_context, &pid_tgid);
     return 0;
   }
+  mkdir_ctx->path.len = path->len;
   mkdir_ctx->parent_inode = parent_inode;
   mkdir_ctx->monitored = monitored;
 
@@ -370,7 +366,7 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
     args.metrics->ignored++;
     return 0;
   }
-  args.filename = mkdir_ctx->path;
+  args.filename = &mkdir_ctx->path;
   args.parent_inode = mkdir_ctx->parent_inode;
   args.monitored = mkdir_ctx->monitored;
 
@@ -399,13 +395,12 @@ int BPF_PROG(trace_path_rmdir, struct path* dir, struct dentry* dentry) {
 
   args.metrics->total++;
 
-  struct bound_path_t* path = path_read_append_d_entry(dir, dentry);
-  if (path == NULL) {
+  args.filename = path_read_append_d_entry(dir, dentry);
+  if (args.filename == NULL) {
     bpf_printk("Failed to read directory path");
     m->path_rmdir.error++;
     return 0;
   }
-  args.filename = path->path;
 
   args.inode = inode_to_key(dentry->d_inode);
 

--- a/fact-ebpf/src/bpf/maps.h
+++ b/fact-ebpf/src/bpf/maps.h
@@ -7,6 +7,18 @@
 
 #include <bpf/bpf_helpers.h>
 
+#define MAX_EVENT_LEN ((1<< 15) - 1)
+/**
+ * Raw buffer to encode events into prior to submitting to the
+ * ringbuffer
+ */
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __type(key, __u32);
+  __type(value, char[MAX_EVENT_LEN]);
+  __uint(max_entries, 1);
+} heap_map SEC(".maps");
+
 /**
  * Helper struct with buffers for various operations
  */
@@ -82,6 +94,13 @@ struct {
   __uint(max_entries, 65536);
   __uint(map_flags, BPF_F_NO_PREALLOC);
 } inode_map SEC(".maps");
+
+// Context for correlating mkdir operations
+struct mkdir_context_t {
+  struct bound_path_t path;
+  inode_key_t parent_inode;
+  monitored_t monitored;
+};
 
 struct {
   __uint(type, BPF_MAP_TYPE_LRU_HASH);

--- a/fact-ebpf/src/bpf/process.h
+++ b/fact-ebpf/src/bpf/process.h
@@ -6,6 +6,7 @@
 #include "d_path.h"
 #include "maps.h"
 #include "types.h"
+#include "raw_event.h"
 
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
@@ -77,23 +78,38 @@ __always_inline static const char* get_memory_cgroup(struct helper_t* helper) {
   return helper->buf;
 }
 
-__always_inline static void process_fill_lineage(process_t* p, struct helper_t* helper, bool use_bpf_d_path) {
-  struct task_struct* task = (struct task_struct*)bpf_get_current_task_btf();
-  p->lineage_len = 0;
+__always_inline static long process_fill_lineage(struct raw_event_t* event,
+                                                 const struct task_struct* task,
+                                                 struct helper_t* helper,
+                                                 bool use_bpf_d_path) {
+  uint16_t lineage_len_pos = event->len;
+  event->len += 2;
 
-  for (int i = 0; i < LINEAGE_MAX; i++) {
+  uint16_t i = 0;
+  for (; i < LINEAGE_MAX; i++) {
     struct task_struct* parent = task->real_parent;
 
     if (task == parent || parent->pid == 0) {
-      return;
+      break;
     }
     task = parent;
 
-    p->lineage[i].uid = task->cred->uid.val;
-
-    d_path(&task->mm->exe_file->f_path, p->lineage[i].exe_path, PATH_MAX, use_bpf_d_path);
-    p->lineage_len++;
+    raw_event_copy_u32(event, task->cred->uid.val);
+    long err = raw_event_d_path(event, &task->mm->exe_file->f_path, use_bpf_d_path);
+    if (err != 0) {
+      bpf_printk("Failed to read lineage exe_path");
+      return err;
+    }
   }
+
+  // go back and set the amount of lineage processes in the buffer
+  uint16_t back = event->len;
+  event->len = lineage_len_pos;
+
+  raw_event_copy_u16(event, i);
+
+  event->len = back;
+  return 0;
 }
 
 __always_inline static unsigned long get_mount_ns() {
@@ -101,28 +117,50 @@ __always_inline static unsigned long get_mount_ns() {
   return task->nsproxy->mnt_ns->ns.inum;
 }
 
-__always_inline static int64_t process_fill(process_t* p, bool use_bpf_d_path) {
+/**
+ * Fill in the information about the current process to the event
+ * buffer.
+ *
+ * This method serializes all required process information for the event
+ * as a binary blob into the provided event buffer. The serialized data
+ * will look something like this:
+ * |--|--|--|--|-------|--------------|-------------|------------|-|----|---|
+ * |  |  |  |  |       |              |             |            | |    ^ grandparent lineage
+ * |  |  |  |  |       |              |             |            | ^ parent lineage
+ * |  |  |  |  |       |              |             |            ^ in_root_mount_ns
+ * |  |  |  |  |       |              |             ^ cgroup
+ * |  |  |  |  |       |              ^ executable path
+ * |  |  |  |  |       ^ arguments
+ * |  |  |  |  ^ comm
+ * |  |  |  ^ pid
+ * |  |  ^ loginuid
+ * |  ^ gid
+ * ^ uid
+ */
+__always_inline static int64_t process_fill(struct raw_event_t* event, bool use_bpf_d_path) {
   struct task_struct* task = (struct task_struct*)bpf_get_current_task_btf();
   uint32_t key = 0;
   uint64_t uid_gid = bpf_get_current_uid_gid();
-  p->uid = uid_gid & 0xFFFFFFFF;
-  p->gid = (uid_gid >> 32) & 0xFFFFFFFF;
-  p->login_uid = task->loginuid.val;
-  p->pid = (bpf_get_current_pid_tgid() >> 32) & 0xFFFFFFFF;
-  u_int64_t err = bpf_get_current_comm(p->comm, TASK_COMM_LEN);
+  raw_event_copy_u32(event, uid_gid & 0xFFFFFFFF);
+  raw_event_copy_u32(event, (uid_gid >> 32) & 0xFFFFFFFF);
+  raw_event_copy_u32(event, task->loginuid.val);
+  raw_event_copy_u32(event, (bpf_get_current_pid_tgid() >> 32) & 0xFFFFFFFF);
+  uint64_t err = raw_event_copy_comm(event);
   if (err != 0) {
     bpf_printk("Failed to fill task comm");
     return err;
   }
 
-  unsigned long arg_start = task->mm->arg_start;
-  unsigned long arg_end = task->mm->arg_end;
-  p->args_len = (arg_end - arg_start) & 0xFFF;
-  p->args[4095] = '\0';  // Ensure string termination at end of buffer
-  err = bpf_probe_read_user(p->args, p->args_len, (const char*)arg_start);
+  err = raw_event_copy_args(event, task);
   if (err != 0) {
     bpf_printk("Failed to fill task args");
-    return err;
+    return -1;
+  }
+
+  err = raw_event_d_path(event, &task->mm->exe_file->f_path, use_bpf_d_path);
+  if (err != 0) {
+    bpf_printk("Failed to read exe_path");
+    return -1;
   }
 
   struct helper_t* helper = bpf_map_lookup_elem(&helper_map, &key);
@@ -131,16 +169,18 @@ __always_inline static int64_t process_fill(process_t* p, bool use_bpf_d_path) {
     return -1;
   }
 
-  d_path(&task->mm->exe_file->f_path, p->exe_path, PATH_MAX, use_bpf_d_path);
-
   const char* cg = get_memory_cgroup(helper);
-  if (cg != NULL) {
-    bpf_probe_read_str(p->memory_cgroup, PATH_MAX, cg);
+  if (cg == NULL || raw_event_copy_str(event, cg) < 0) {
+    bpf_printk("Failed to read cgroup");
+    return -1;
   }
 
-  p->in_root_mount_ns = get_mount_ns() == host_mount_ns;
+  raw_event_copy_u8(event, get_mount_ns() == host_mount_ns);
 
-  process_fill_lineage(p, helper, use_bpf_d_path);
+  err = process_fill_lineage(event, task, helper, use_bpf_d_path);
+  if (err < 0) {
+    return -1;
+  }
 
   return 0;
 }

--- a/fact-ebpf/src/bpf/raw_event.h
+++ b/fact-ebpf/src/bpf/raw_event.h
@@ -1,0 +1,187 @@
+#pragma once
+
+// clang-format off
+#include "vmlinux.h"
+
+#include "d_path.h"
+#include "bound_path.h"
+#include "types.h"
+
+#include <bpf/bpf_helpers.h>
+// clang-format on
+
+struct raw_event_t {
+  char* buf;
+  unsigned short len;
+};
+
+#define INIT_RAW_EVENT()                              \
+  ({                                                  \
+    unsigned int zero = 0;                            \
+    struct raw_event_t event = {                      \
+        .buf = bpf_map_lookup_elem(&heap_map, &zero), \
+        .len = 0,                                     \
+    };                                                \
+    event;                                            \
+  })
+
+#define DECLARE_COPY_UINT(name, decltype)                                                      \
+  __always_inline static void raw_event_copy_##name(struct raw_event_t* event, decltype val) { \
+    *((decltype*)&event->buf[event->len]) = val;                                               \
+    event->len += sizeof(decltype);                                                            \
+  }
+
+DECLARE_COPY_UINT(u8, uint8_t);
+DECLARE_COPY_UINT(u16, uint16_t);
+DECLARE_COPY_UINT(u32, uint32_t);
+DECLARE_COPY_UINT(u64, uint64_t);
+
+/**
+ * Copy the provided inode information to the event buffer.
+ *
+ * The serialized blob will be of 2 big endian 32 bits integers, with
+ * the inode number first and the device number second.
+ *
+ * If no inode information is provided, the same space is filled with
+ * zeroes for ease of parsing.
+ */
+__always_inline static void raw_event_copy_inode(struct raw_event_t* event, inode_key_t* val) {
+  if (val != NULL) {
+    raw_event_copy_u32(event, val->inode);
+    raw_event_copy_u32(event, val->dev);
+  } else {
+    raw_event_copy_u32(event, 0);
+    raw_event_copy_u32(event, 0);
+  }
+}
+
+/**
+ * Copy a buffer to the event.
+ *
+ * The format used for the serialized buffer is as follows:
+ * |--|------------|
+ * |  ^ begin data
+ * ^ data length
+ *
+ * Data length: 16 bit, big endian integer, number of data bytes held.
+ * Data: a blob of bytes with the required data.
+ */
+__always_inline static long raw_event_copy_buffer(struct raw_event_t* event, const void* buf, uint16_t len) {
+  raw_event_copy_u16(event, len);
+  long res = bpf_probe_read(&event->buf[event->len], len, buf);
+  if (res < 0) {
+    return res;
+  }
+  event->len += len;
+  return 0;
+}
+
+/**
+ * Helper function for encoding a bound_path_t as a buffer in the event.
+ *
+ * The resulting buffer that is serialized will not be null terminated.
+ */
+__always_inline static long raw_event_copy_bound_path(struct raw_event_t* event, const struct bound_path_t* const path) {
+  // The PATH_LEN_CLAMP is there to convince the verifier we are at
+  // most copying 4KB, otherwise it will assume we can add UINT16_MAX
+  // bytes and immediately fail, as the event buffer is smaller than
+  // that.
+  return raw_event_copy_buffer(event, path->path, PATH_LEN_CLAMP(path->len - 1));
+}
+
+/**
+ * Serialize the comm value for the current task in the event buffer.
+ *
+ * For simplicity, the comm value is directly copied into the buffer by
+ * using the bpf_get_current_comm helper with a fix length of 16.
+ *
+ * bpf_get_current_comm ensures the copied data is null terminated and
+ * padded with zeroes if the comm is smaller than 16 bytes.
+ */
+__always_inline static long raw_event_copy_comm(struct raw_event_t* event) {
+  long res = bpf_get_current_comm((char*)&event->buf[event->len], TASK_COMM_LEN);
+  if (res != 0) {
+    return res;
+  }
+  event->len += TASK_COMM_LEN;
+  return 0;
+}
+
+/**
+ * Serialize the result of calling d_path onto the event buffer.
+ *
+ * The resulting path is encoded as described in raw_event_copy_buffer
+ * and is not null terminated.
+ */
+__always_inline static long raw_event_d_path(struct raw_event_t* event, struct path* path, bool use_bpf_d_path) {
+  // Reserve room for the path length
+  event->len += 2;
+  long res = d_path(path, &event->buf[event->len], PATH_MAX, use_bpf_d_path);
+  if (res < 0) {
+    return res;
+  }
+
+  // Go back and add the length of the path
+  uint16_t len = (uint16_t)PATH_LEN_CLAMP(res - 1);
+  event->len -= 2;
+  raw_event_copy_u16(event, len);
+
+  // Move the buffer past the path
+  event->len += len;
+
+  return 0;
+}
+
+/**
+ * Serialize a null terminated string onto the event buffer.
+ *
+ * The resulting blob is encoded as described in raw_event_copy_buffer
+ * and is not null terminated.
+ */
+__always_inline static long raw_event_copy_str(struct raw_event_t* event, const char* const str) {
+  event->len += 2;
+  long len = bpf_probe_read_str(&event->buf[event->len], PATH_MAX, str);
+  if (len < 0) {
+    return len;
+  }
+
+  // Go back and add the length of the path
+  event->len -= 2;
+  len = PATH_LEN_CLAMP(len - 1);
+  raw_event_copy_u16(event, len);
+
+  event->len += len;
+  return 0;
+}
+
+/**
+ * Serialize process arguments onto the event buffer.
+ *
+ * The kernel stores the process arguments as an array of strings, in
+ * case this ends up being larger than our maximum allowed length, we
+ * ensure NULL termination to make it easier for userspace to parse.
+ */
+__always_inline static long raw_event_copy_args(struct raw_event_t* event, const struct task_struct* task) {
+  static const uint16_t ARGS_LENGTH_MAX = 0xFFF;
+  unsigned long arg_start = task->mm->arg_start;
+  unsigned long arg_end = task->mm->arg_end;
+  uint16_t arg_len = arg_end - arg_start;
+  if (arg_len > ARGS_LENGTH_MAX) {
+    arg_len = ARGS_LENGTH_MAX;
+  }
+
+  // The final mask on arg_len is simply there to keep the verifier
+  // happy.
+  long err = raw_event_copy_buffer(event, (const void*)arg_start, (arg_len & ARGS_LENGTH_MAX));
+  if (err != 0) {
+    bpf_printk("Failed to fill task args");
+    return err;
+  }
+
+  // Ensure NULL termination of process arguments
+  if (arg_len == ARGS_LENGTH_MAX) {
+    event->buf[event->len - 1] = 0;
+  }
+
+  return 0;
+}

--- a/fact-ebpf/src/bpf/types.h
+++ b/fact-ebpf/src/bpf/types.h
@@ -17,29 +17,9 @@
 
 #define LPM_SIZE_MAX 256
 
-typedef struct lineage_t {
-  unsigned int uid;
-  char exe_path[PATH_MAX];
-} lineage_t;
-
-typedef struct process_t {
-  char comm[TASK_COMM_LEN];
-  char args[4096];
-  unsigned int args_len;
-  char exe_path[PATH_MAX];
-  char memory_cgroup[PATH_MAX];
-  unsigned int uid;
-  unsigned int gid;
-  unsigned int login_uid;
-  unsigned int pid;
-  lineage_t lineage[LINEAGE_MAX];
-  unsigned int lineage_len;
-  char in_root_mount_ns;
-} process_t;
-
 typedef struct inode_key_t {
-  unsigned long inode;
-  unsigned long dev;
+  unsigned int inode;
+  unsigned int dev;
 } inode_key_t;
 
 typedef enum monitored_t {
@@ -66,33 +46,6 @@ typedef enum file_activity_type_t {
   DIR_ACTIVITY_UNLINK,
 } file_activity_type_t;
 
-struct event_t {
-  unsigned long timestamp;
-  process_t process;
-  char filename[PATH_MAX];
-  inode_key_t inode;
-  inode_key_t parent_inode;
-  monitored_t monitored;
-  file_activity_type_t type;
-  union {
-    struct {
-      short unsigned int new;
-      short unsigned int old;
-    } chmod;
-    struct {
-      struct {
-        unsigned int uid;
-        unsigned int gid;
-      } old, new;
-    } chown;
-    struct {
-      char filename[PATH_MAX];
-      inode_key_t inode;
-      monitored_t monitored;
-    } rename;
-  };
-};
-
 /**
  * Used as the key for the path_prefix map.
  *
@@ -105,13 +58,6 @@ struct event_t {
 struct path_prefix_t {
   unsigned int bit_len;
   const char path[LPM_SIZE_MAX];
-};
-
-// Context for correlating mkdir operations
-struct mkdir_context_t {
-  char path[PATH_MAX];
-  inode_key_t parent_inode;
-  monitored_t monitored;
 };
 
 // Metrics types

--- a/fact/Cargo.toml
+++ b/fact/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 aya = { workspace = true }
+byteorder = { workspace = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
 glob = { workspace = true }

--- a/fact/src/bpf/mod.rs
+++ b/fact/src/bpf/mod.rs
@@ -16,9 +16,14 @@ use tokio::{
     task::JoinHandle,
 };
 
-use crate::{config::BpfConfig, event::Event, host_info, metrics::EventCounter};
+use crate::{
+    config::BpfConfig,
+    event::{Event, parser::Parser},
+    host_info,
+    metrics::EventCounter,
+};
 
-use fact_ebpf::{LPM_SIZE_MAX, event_t, inode_key_t, inode_value_t, metrics_t, path_prefix_t};
+use fact_ebpf::{LPM_SIZE_MAX, inode_key_t, inode_value_t, metrics_t, path_prefix_t};
 
 mod checks;
 
@@ -227,8 +232,7 @@ impl Bpf {
                             .context("ringbuffer guard held while runtime is stopping")?;
                         let ringbuf = guard.get_inner_mut();
                         while let Some(event) = ringbuf.next() {
-                            let event: &event_t = unsafe { &*(event.as_ptr() as *const _) };
-                            let event = match Event::try_from(event) {
+                            let event = match Parser::from(&event).parse() {
                                 Ok(event) => {
                                     // If the event is monitored by parent, we need to check
                                     // its host path, but we don't have that context here,

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -1,24 +1,20 @@
 #[cfg(all(test, feature = "bpf-test"))]
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
-    ffi::{CStr, OsStr},
-    os::{raw::c_char, unix::ffi::OsStrExt},
+    ffi::OsStr,
+    os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
 };
 
 use globset::GlobSet;
 use serde::Serialize;
 
-use fact_ebpf::{PATH_MAX, event_t, file_activity_type_t, inode_key_t, monitored_t};
+use fact_ebpf::{inode_key_t, monitored_t};
 
-use crate::host_info;
 use process::Process;
 
+pub(crate) mod parser;
 pub(crate) mod process;
-
-fn slice_to_string(s: &[c_char]) -> anyhow::Result<String> {
-    Ok(unsafe { CStr::from_ptr(s.as_ptr()) }.to_str()?.to_owned())
-}
 
 /// Sanitize a buffer obtained from calling d_path kernel side.
 ///
@@ -37,9 +33,8 @@ fn slice_to_string(s: &[c_char]) -> anyhow::Result<String> {
 /// However, we believe this would be a _very_ special case with a low
 /// chance that we will stumble upon it, so we purposely decide to
 /// ignore it.
-fn sanitize_d_path(s: &[c_char]) -> PathBuf {
-    let s = unsafe { CStr::from_ptr(s.as_ptr()) };
-    let p = Path::new(OsStr::from_bytes(s.to_bytes()));
+fn sanitize_d_path(s: &[u8]) -> PathBuf {
+    let p = Path::new(OsStr::from_bytes(s));
 
     // Take the file name of the path and remove the " (deleted)" suffix
     // if present.
@@ -300,30 +295,6 @@ impl Event {
     }
 }
 
-impl TryFrom<&event_t> for Event {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &event_t) -> Result<Self, Self::Error> {
-        let process = Process::try_from(value.process)?;
-        let timestamp = host_info::get_boot_time() + value.timestamp;
-        let file = FileData::new(
-            value.type_,
-            value.filename,
-            value.inode,
-            value.parent_inode,
-            value.monitored,
-            value.__bindgen_anon_1,
-        )?;
-
-        Ok(Event {
-            timestamp,
-            hostname: host_info::get_hostname(),
-            process,
-            file,
-        })
-    }
-}
-
 impl From<Event> for fact_api::FileActivity {
     fn from(value: Event) -> Self {
         let file = fact_api::file_activity::File::from(value.file);
@@ -356,62 +327,6 @@ pub enum FileData {
     Chmod(ChmodFileData),
     Chown(ChownFileData),
     Rename(RenameFileData),
-}
-
-impl FileData {
-    pub fn new(
-        event_type: file_activity_type_t,
-        filename: [c_char; PATH_MAX as usize],
-        inode: inode_key_t,
-        parent_inode: inode_key_t,
-        monitored: monitored_t,
-        extra_data: fact_ebpf::event_t__bindgen_ty_1,
-    ) -> anyhow::Result<Self> {
-        let inner = BaseFileData::new(filename, inode, parent_inode, monitored)?;
-        let file = match event_type {
-            file_activity_type_t::FILE_ACTIVITY_OPEN => FileData::Open(inner),
-            file_activity_type_t::FILE_ACTIVITY_CREATION => FileData::Creation(inner),
-            file_activity_type_t::DIR_ACTIVITY_CREATION => FileData::MkDir(inner),
-            file_activity_type_t::DIR_ACTIVITY_UNLINK => FileData::RmDir(inner),
-            file_activity_type_t::FILE_ACTIVITY_UNLINK => FileData::Unlink(inner),
-            file_activity_type_t::FILE_ACTIVITY_CHMOD => {
-                let data = ChmodFileData {
-                    inner,
-                    new_mode: unsafe { extra_data.chmod.new },
-                    old_mode: unsafe { extra_data.chmod.old },
-                };
-                FileData::Chmod(data)
-            }
-            file_activity_type_t::FILE_ACTIVITY_CHOWN => {
-                let data = ChownFileData {
-                    inner,
-                    new_uid: unsafe { extra_data.chown.new.uid },
-                    new_gid: unsafe { extra_data.chown.new.gid },
-                    old_uid: unsafe { extra_data.chown.old.uid },
-                    old_gid: unsafe { extra_data.chown.old.gid },
-                };
-                FileData::Chown(data)
-            }
-            file_activity_type_t::FILE_ACTIVITY_RENAME => {
-                let old_filename = unsafe { extra_data.rename.filename };
-                let old_inode = unsafe { extra_data.rename.inode };
-                let old_monitored = unsafe { extra_data.rename.monitored };
-                let data = RenameFileData {
-                    new: inner,
-                    old: BaseFileData::new(
-                        old_filename,
-                        old_inode,
-                        Default::default(),
-                        old_monitored,
-                    )?,
-                };
-                FileData::Rename(data)
-            }
-            invalid => unreachable!("Invalid event type: {invalid:?}"),
-        };
-
-        Ok(file)
-    }
 }
 
 impl From<FileData> for fact_api::file_activity::File {
@@ -481,13 +396,13 @@ pub struct BaseFileData {
 
 impl BaseFileData {
     pub fn new(
-        filename: [c_char; PATH_MAX as usize],
+        filename: &[u8],
         inode: inode_key_t,
         parent_inode: inode_key_t,
         monitored: monitored_t,
     ) -> anyhow::Result<Self> {
         Ok(BaseFileData {
-            filename: sanitize_d_path(&filename),
+            filename: sanitize_d_path(filename),
             host_file: PathBuf::new(), // this field is set by HostScanner
             inode,
             parent_inode,
@@ -596,75 +511,8 @@ impl PartialEq for RenameFileData {
 }
 
 #[cfg(test)]
-mod test_utils {
-    use std::os::raw::c_char;
-
-    /// Helper function to convert raw bytes to a c_char array for testing
-    pub fn bytes_to_c_char_array<const N: usize>(bytes: &[u8]) -> [c_char; N] {
-        let mut array = [0 as c_char; N];
-        let len = bytes.len().min(N - 1);
-        for (i, &byte) in bytes.iter().take(len).enumerate() {
-            array[i] = byte as c_char;
-        }
-        array
-    }
-
-    /// Helper function to convert a Rust string to a c_char array for testing
-    pub fn string_to_c_char_array<const N: usize>(s: &str) -> [c_char; N] {
-        bytes_to_c_char_array(s.as_bytes())
-    }
-}
-
-#[cfg(test)]
 mod tests {
-    use super::test_utils::*;
     use super::*;
-
-    #[test]
-    fn slice_to_string_valid_utf8() {
-        let tests = [
-            ("hello", "ASCII"),
-            ("café", "French"),
-            ("файл", "Cyrillic"),
-            ("测试文件", "Chinese"),
-            ("test🚀file", "Emoji"),
-            ("test-файл-测试-🐛.txt", "Mixed Unicode"),
-            ("ملف", "Arabic"),
-            ("קובץ", "Hebrew"),
-            ("ファイル", "Japanese"),
-        ];
-
-        for (input, description) in tests {
-            let arr = string_to_c_char_array::<{ PATH_MAX as usize }>(input);
-            assert_eq!(
-                slice_to_string(&arr).unwrap(),
-                input,
-                "Failed for {}",
-                description
-            );
-        }
-    }
-
-    #[test]
-    fn slice_to_string_invalid_utf8() {
-        let tests: &[(&[u8], &str)] = &[
-            (&[0xFF, 0xFE, 0xFD], "Invalid continuation bytes"),
-            (b"test\xE2", "Truncated multi-byte sequence"),
-            (&[0xC0, 0x80], "Overlong encoding"),
-            (b"hello\x80world", "Invalid start byte"),
-            (&[0x80], "Lone continuation byte"),
-            (b"test\xFF\xFE", "Mixed valid and invalid bytes"),
-        ];
-
-        for (bytes, description) in tests {
-            let arr = bytes_to_c_char_array::<{ PATH_MAX as usize }>(bytes);
-            assert!(
-                slice_to_string(&arr).is_err(),
-                "Should fail for {}",
-                description
-            );
-        }
-    }
 
     #[test]
     fn sanitize_d_path_valid_utf8() {
@@ -687,9 +535,8 @@ mod tests {
         ];
 
         for (input, expected, description) in tests {
-            let arr = string_to_c_char_array::<{ PATH_MAX as usize }>(input);
             assert_eq!(
-                sanitize_d_path(&arr),
+                sanitize_d_path(input.as_bytes()),
                 PathBuf::from(expected),
                 "Failed for {}",
                 description
@@ -719,9 +566,8 @@ mod tests {
         ];
 
         for (input, expected, description) in tests {
-            let arr = string_to_c_char_array::<{ PATH_MAX as usize }>(input);
             assert_eq!(
-                sanitize_d_path(&arr),
+                sanitize_d_path(input.as_bytes()),
                 PathBuf::from(expected),
                 "Failed for {}",
                 description
@@ -757,8 +603,7 @@ mod tests {
         ];
 
         for (bytes, pattern, description) in tests {
-            let arr = bytes_to_c_char_array::<{ PATH_MAX as usize }>(bytes);
-            let result = sanitize_d_path(&arr);
+            let result = sanitize_d_path(bytes);
             let result_str = result.to_string_lossy();
 
             let re = Regex::new(pattern).expect("Invalid regex pattern");
@@ -774,9 +619,7 @@ mod tests {
 
     #[test]
     fn sanitize_d_path_invalid_utf8_with_deleted_suffix() {
-        let invalid_with_deleted =
-            bytes_to_c_char_array::<{ PATH_MAX as usize }>(b"/tmp/\xFF\xFE (deleted)");
-        let result = sanitize_d_path(&invalid_with_deleted);
+        let result = sanitize_d_path(b"/tmp/\xFF\xFE (deleted)");
         let result_str = result.to_string_lossy();
 
         assert!(result_str.contains("/tmp/"));

--- a/fact/src/event/parser.rs
+++ b/fact/src/event/parser.rs
@@ -1,0 +1,333 @@
+use std::ffi::{CStr, CString};
+
+use anyhow::bail;
+use aya::maps::ring_buf::RingBufItem;
+use byteorder::{ByteOrder, NativeEndian};
+use fact_ebpf::{file_activity_type_t, inode_key_t, monitored_t};
+use log::warn;
+
+use crate::{
+    event::{
+        BaseFileData, ChmodFileData, ChownFileData, Event, FileData, RenameFileData,
+        process::{Lineage, Process},
+        sanitize_d_path,
+    },
+    host_info,
+};
+
+pub(crate) struct Parser<'a> {
+    data: &'a [u8],
+}
+
+impl Parser<'_> {
+    fn read_u8(&mut self) -> Option<u8> {
+        let (val, data) = self.data.split_at_checked(size_of::<u8>())?;
+        self.data = data;
+        Some(val[0])
+    }
+
+    fn read_u16(&mut self) -> Option<u16> {
+        let (val, data) = self.data.split_at_checked(size_of::<u16>())?;
+        self.data = data;
+        Some(NativeEndian::read_u16(val))
+    }
+
+    fn read_u32(&mut self) -> Option<u32> {
+        let (val, data) = self.data.split_at_checked(size_of::<u32>())?;
+        self.data = data;
+        Some(NativeEndian::read_u32(val))
+    }
+
+    fn read_u64(&mut self) -> Option<u64> {
+        let (val, data) = self.data.split_at_checked(size_of::<u64>())?;
+        self.data = data;
+        Some(NativeEndian::read_u64(val))
+    }
+
+    /// Parse inode information from the inner data.
+    ///
+    /// Under the hood, inodes are represented by two u32 integers.
+    fn parse_inode(&mut self) -> Option<inode_key_t> {
+        let inode = self.read_u32()?;
+        let dev = self.read_u32()?;
+
+        Some(inode_key_t { inode, dev })
+    }
+
+    /// Parse a buffer from the inner data.
+    ///
+    /// This method parses buffers as they are added to the ringbuffer
+    /// by the kernel side BPF programs. The format these programs use
+    /// is relatively straightforward, they use 2 bytes to encode the
+    /// length of the buffer in bytes, then put the buffer right after,
+    /// looking something like this:
+    ///
+    /// |--|--------------|-------
+    /// |  |              | ^ rest of the event
+    /// |  |              ^ buffer end
+    /// |  ^ buffer start
+    /// ^ length of the buffer
+    ///
+    /// This allows parsing fairly easy in userspace, we can simply
+    /// read a u16 for the size of the buffer, then take as many bytes
+    /// as that value indicates.
+    ///
+    /// This representation also works for both strings and binary
+    /// blobs, so it allows for quite good flexibility, leaving the
+    /// specialization of the type to the caller.
+    fn parse_buffer(&mut self) -> Option<&[u8]> {
+        let len = self.read_u16()?;
+        let (buf, data) = self.data.split_at_checked(len as usize)?;
+        self.data = data;
+        Some(buf)
+    }
+
+    /// Parse the process comm value.
+    ///
+    /// For simplicity, the kernel side BPF program loads the result of
+    /// calling the bpf_get_current_comm helper directly onto the event.
+    /// The resulting value loaded in is 16 bytes with a guaranteed
+    /// null terminator and null padding if needed.
+    ///
+    /// We could save a few bytes if we were to retrieve the string
+    /// length in kernel side and load a generic buffer onto the event
+    /// like `Parser::parse_buffer` expects, but we would need to do a
+    /// bit more work kernel side that is not worth it.
+    fn parse_comm(&mut self) -> Option<CString> {
+        let (val, data) = self.data.split_at_checked(16)?;
+        let res = CStr::from_bytes_until_nul(val).ok()?;
+        self.data = data;
+        Some(res.to_owned())
+    }
+
+    /// Parse the arguments of a process.
+    ///
+    /// The kernel stores arguments as a sequence of null terminated
+    /// strings in a single buffer, we copy that blob directly onto the
+    /// ringbuffer and prepend the actual length we copied in the same
+    /// way `Event::parse_buffer` expects. This way we can read the
+    /// buffer and then iterate over the null strings, mapping them to
+    /// `CString`s in a vector.
+    ///
+    /// # Safety
+    ///
+    /// * The BPF program loading the arguments must ensure the last
+    ///   portion ends with a null terminator, even if we truncate it
+    ///   for performance reasons.
+    fn parse_args(&mut self) -> anyhow::Result<Vec<CString>> {
+        let Some(buf) = self.parse_buffer() else {
+            bail!("Failed to get arguments length");
+        };
+
+        let args = buf
+            .split_inclusive(|a| *a == 0)
+            .map(|arg| CString::from_vec_with_nul(arg.to_vec()))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(args)
+    }
+
+    /// Parse a `Lineage` object from a ringbuffer event.
+    ///
+    /// # Safety
+    ///
+    /// * The order of fields parsed must match the order used by the
+    ///   BPF programs.
+    fn parse_process_lineage(&mut self) -> anyhow::Result<Lineage> {
+        let Some(uid) = self.read_u32() else {
+            bail!("Failed to parse lineage uid");
+        };
+        let Some(exe_path) = self.parse_buffer() else {
+            bail!("Failed to parse lineage exe_path");
+        };
+        let exe_path = sanitize_d_path(exe_path);
+
+        let lineage = Lineage::new(uid, exe_path);
+
+        Ok(lineage)
+    }
+
+    /// Parse a `Process` from a ringbuffer event.
+    ///
+    /// # Safety
+    ///
+    /// * The order of fields must match the order used by the BPF
+    ///   programs.
+    fn parse_process(&mut self) -> anyhow::Result<Process> {
+        let Some(uid) = self.read_u32() else {
+            bail!("Failed to parse uid");
+        };
+        let username = host_info::get_username(uid);
+        let Some(gid) = self.read_u32() else {
+            bail!("Failed to parse gid");
+        };
+        let Some(login_uid) = self.read_u32() else {
+            bail!("Failed to parse login_uid");
+        };
+        let Some(pid) = self.read_u32() else {
+            bail!("Failed to parse pid");
+        };
+        let Some(comm) = self.parse_comm() else {
+            bail!("Failed to parse comm");
+        };
+        let args = self.parse_args()?;
+        let Some(exe_path) = self.parse_buffer() else {
+            bail!("Failed to parse exe_path");
+        };
+        let exe_path = sanitize_d_path(exe_path);
+        let Some(cgroup) = self.parse_buffer() else {
+            bail!("Failed to parse cgroup");
+        };
+        let cgroup = str::from_utf8(cgroup)?;
+        let container_id = Process::extract_container_id(cgroup);
+        let Some(in_root_mount_ns) = self.read_u8() else {
+            bail!("Failed to parse in_root_mount_ns");
+        };
+        let in_root_mount_ns = in_root_mount_ns != 0;
+        let Some(lineage_len) = self.read_u16() else {
+            bail!("Failed to parse lineage length");
+        };
+        let mut lineage = Vec::with_capacity(lineage_len as usize);
+        for _ in 0..lineage_len {
+            let l = self.parse_process_lineage()?;
+            lineage.push(l);
+        }
+
+        let process = Process::new(
+            comm,
+            args,
+            exe_path,
+            container_id,
+            uid,
+            username,
+            gid,
+            login_uid,
+            pid,
+            in_root_mount_ns,
+            lineage,
+        );
+
+        Ok(process)
+    }
+
+    /// Consume the parser and create an Event
+    ///
+    /// Parsing an event is a destructive operation, the parser is
+    /// created through a ringbuffer entry that has a single event in
+    /// it, so it cannot be reused.
+    pub(crate) fn parse(mut self) -> anyhow::Result<Event> {
+        let Some(event_type) = self.read_u16() else {
+            bail!("Failed to read event type");
+        };
+        let event_type = file_activity_type_t(event_type.into());
+
+        let Some(timestamp) = self.read_u64() else {
+            bail!("Failed to parse timestamp");
+        };
+        let timestamp = timestamp + host_info::get_boot_time();
+
+        let process = self.parse_process()?;
+
+        let Some(monitored) = self.read_u8() else {
+            bail!("Failed to parse monitored field");
+        };
+        let monitored = monitored_t(monitored.into());
+
+        let Some(inode) = self.parse_inode() else {
+            bail!("Failed to parse inode");
+        };
+
+        let Some(parent_inode) = self.parse_inode() else {
+            bail!("Failed to parse parent_inode");
+        };
+
+        let Some(filename) = self.parse_buffer() else {
+            bail!("Failed to parse filename");
+        };
+
+        let inner = BaseFileData::new(filename, inode, parent_inode, monitored)?;
+
+        let file = match event_type {
+            file_activity_type_t::FILE_ACTIVITY_CREATION => FileData::Creation(inner),
+            file_activity_type_t::FILE_ACTIVITY_OPEN => FileData::Open(inner),
+            file_activity_type_t::FILE_ACTIVITY_UNLINK => FileData::Unlink(inner),
+            file_activity_type_t::DIR_ACTIVITY_CREATION => FileData::MkDir(inner),
+            file_activity_type_t::DIR_ACTIVITY_UNLINK => FileData::RmDir(inner),
+            file_activity_type_t::FILE_ACTIVITY_CHMOD => {
+                let Some(new_mode) = self.read_u16() else {
+                    bail!("Failed to read new_mode field");
+                };
+                let Some(old_mode) = self.read_u16() else {
+                    bail!("Failed to read old_mode field");
+                };
+
+                FileData::Chmod(ChmodFileData {
+                    inner,
+                    new_mode,
+                    old_mode,
+                })
+            }
+            file_activity_type_t::FILE_ACTIVITY_CHOWN => {
+                let Some(new_uid) = self.read_u32() else {
+                    bail!("Failed to read new_uid field");
+                };
+                let Some(new_gid) = self.read_u32() else {
+                    bail!("Failed to read new_gid field");
+                };
+                let Some(old_uid) = self.read_u32() else {
+                    bail!("Failed to read old_uid field");
+                };
+                let Some(old_gid) = self.read_u32() else {
+                    bail!("Failed to read old_gid field");
+                };
+
+                FileData::Chown(ChownFileData {
+                    inner,
+                    new_uid,
+                    new_gid,
+                    old_uid,
+                    old_gid,
+                })
+            }
+            file_activity_type_t::FILE_ACTIVITY_RENAME => {
+                let Some(old_monitored) = self.read_u8() else {
+                    bail!("Failed to read old_monitored field");
+                };
+                let old_monitored = monitored_t(old_monitored.into());
+                let Some(old_inode) = self.parse_inode() else {
+                    bail!("Failed to read old_inode field");
+                };
+                let Some(old_filename) = self.parse_buffer() else {
+                    bail!("Failed to read old_filename field");
+                };
+
+                FileData::Rename(RenameFileData {
+                    new: inner,
+                    old: BaseFileData::new(
+                        old_filename,
+                        old_inode,
+                        Default::default(),
+                        old_monitored,
+                    )?,
+                })
+            }
+            invalid => unreachable!("Invalid event type: {invalid:?}"),
+        };
+
+        if !self.data.is_empty() {
+            warn!("Event has remaining data");
+        }
+
+        Ok(Event {
+            timestamp,
+            hostname: host_info::get_hostname(),
+            process,
+            file,
+        })
+    }
+}
+
+impl<'a> From<&'a RingBufItem<'a>> for Parser<'a> {
+    fn from(data: &'a RingBufItem<'a>) -> Self {
+        Parser { data }
+    }
+}

--- a/fact/src/event/process.rs
+++ b/fact/src/event/process.rs
@@ -1,30 +1,17 @@
-use std::{ffi::CStr, path::PathBuf};
+use std::{ffi::CString, path::PathBuf};
 
-use fact_ebpf::{lineage_t, process_t};
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeSeq};
 use uuid::Uuid;
 
-use crate::host_info;
-
-use super::{sanitize_d_path, slice_to_string};
-
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
-pub struct Lineage {
+pub(crate) struct Lineage {
     uid: u32,
     exe_path: PathBuf,
 }
 
-impl TryFrom<&lineage_t> for Lineage {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &lineage_t) -> Result<Self, Self::Error> {
-        let lineage_t { uid, exe_path } = value;
-        let exe_path = sanitize_d_path(exe_path);
-
-        Ok(Lineage {
-            uid: *uid,
-            exe_path,
-        })
+impl Lineage {
+    pub(crate) fn new(uid: u32, exe_path: PathBuf) -> Self {
+        Lineage { uid, exe_path }
     }
 }
 
@@ -38,10 +25,30 @@ impl From<Lineage> for fact_api::process_signal::LineageInfo {
     }
 }
 
+fn serialize_lossy_string<S>(value: &CString, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    value.to_string_lossy().serialize(serializer)
+}
+
+fn serialize_vector_lossy_string<S>(value: &Vec<CString>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut seq = serializer.serialize_seq(Some(value.len()))?;
+    for i in value {
+        seq.serialize_element(&i.to_string_lossy().to_string())?;
+    }
+    seq.end()
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct Process {
-    comm: String,
-    args: Vec<String>,
+    #[serde(serialize_with = "serialize_lossy_string")]
+    comm: CString,
+    #[serde(serialize_with = "serialize_vector_lossy_string")]
+    args: Vec<CString>,
     exe_path: PathBuf,
     container_id: Option<String>,
     uid: u32,
@@ -54,6 +61,41 @@ pub struct Process {
 }
 
 impl Process {
+    // This constructor is terribly ugly, but I don't want to make all
+    // the fields in the Process type public or put together a builder
+    // class for it just for Parser to be able to build it, so we allow
+    // the mostrosity for now.
+    //
+    // TODO: Figure out a cleaner way to do this.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        comm: CString,
+        args: Vec<CString>,
+        exe_path: PathBuf,
+        container_id: Option<String>,
+        uid: u32,
+        username: &'static str,
+        gid: u32,
+        login_uid: u32,
+        pid: u32,
+        in_root_mount_ns: bool,
+        lineage: Vec<Lineage>,
+    ) -> Self {
+        Process {
+            comm,
+            args,
+            exe_path,
+            container_id,
+            uid,
+            username,
+            gid,
+            login_uid,
+            pid,
+            in_root_mount_ns,
+            lineage,
+        }
+    }
+
     /// Create a representation of the current process as best as
     /// possible.
     #[cfg(test)]
@@ -61,7 +103,9 @@ impl Process {
         use crate::host_info::{get_host_mount_ns, get_mount_ns};
 
         let exe_path = std::env::current_exe().expect("Failed to get current exe");
-        let args = std::env::args().collect::<Vec<_>>();
+        let args = std::env::args()
+            .map(|arg| CString::new(arg).expect("Failed to convert argument to CString"))
+            .collect::<Vec<_>>();
         let cgroup = std::fs::read_to_string("/proc/self/cgroup").expect("Failed to read cgroup");
         let container_id = Process::extract_container_id(&cgroup);
         let uid = unsafe { libc::getuid() };
@@ -75,7 +119,7 @@ impl Process {
         let in_root_mount_ns = get_host_mount_ns() == get_mount_ns(&pid.to_string(), false);
 
         Self {
-            comm: "".to_string(),
+            comm: c"".to_owned(),
             args,
             exe_path,
             container_id,
@@ -89,7 +133,7 @@ impl Process {
         }
     }
 
-    fn extract_container_id(cgroup: &str) -> Option<String> {
+    pub(super) fn extract_container_id(cgroup: &str) -> Option<String> {
         let cgroup = if let Some(i) = cgroup.rfind(".scope") {
             cgroup.split_at(i).0
         } else {
@@ -127,53 +171,6 @@ impl PartialEq for Process {
     }
 }
 
-impl TryFrom<process_t> for Process {
-    type Error = anyhow::Error;
-
-    fn try_from(value: process_t) -> Result<Self, Self::Error> {
-        let comm = slice_to_string(value.comm.as_slice())?;
-        let exe_path = sanitize_d_path(value.exe_path.as_slice());
-        let memory_cgroup = unsafe { CStr::from_ptr(value.memory_cgroup.as_ptr()) }.to_str()?;
-        let container_id = Process::extract_container_id(memory_cgroup);
-        let in_root_mount_ns = value.in_root_mount_ns != 0;
-
-        let lineage = value.lineage[..value.lineage_len as usize]
-            .iter()
-            .map(Lineage::try_from)
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let mut converted_args = Vec::new();
-        let args_len = value.args_len as usize;
-        let mut offset = 0;
-        while offset < args_len {
-            let arg = unsafe { CStr::from_ptr(value.args.as_ptr().add(offset)) }
-                .to_str()?
-                .to_owned();
-            if arg.is_empty() {
-                break;
-            }
-            offset += arg.len() + 1;
-            converted_args.push(arg);
-        }
-
-        let username = host_info::get_username(value.uid);
-
-        Ok(Process {
-            comm,
-            args: converted_args,
-            exe_path,
-            container_id,
-            uid: value.uid,
-            username,
-            gid: value.gid,
-            login_uid: value.login_uid,
-            pid: value.pid,
-            in_root_mount_ns,
-            lineage,
-        })
-    }
-}
-
 impl From<Process> for fact_api::ProcessSignal {
     fn from(value: Process) -> Self {
         let Process {
@@ -192,9 +189,14 @@ impl From<Process> for fact_api::ProcessSignal {
 
         let container_id = container_id.unwrap_or("".to_string());
 
+        let args = args.iter().map(|s| s.to_string_lossy()).collect::<Vec<_>>();
+
         // try_join can fail if args contain nul bytes, though this should not happen
         // since args are parsed from C strings which are nul-terminated
-        let Ok(args) = shlex::try_join(args.iter().map(|s| s.as_str())) else {
+        let Ok(args) = shlex::try_join(args.iter().map(|s| match s {
+            std::borrow::Cow::Borrowed(s) => *s,
+            std::borrow::Cow::Owned(s) => s.as_str(),
+        })) else {
             unreachable!();
         };
 
@@ -202,7 +204,7 @@ impl From<Process> for fact_api::ProcessSignal {
             id: Uuid::new_v4().to_string(),
             container_id,
             creation_time: None,
-            name: comm,
+            name: comm.to_string_lossy().to_string(),
             args,
             exec_file_path: exe_path.to_string_lossy().to_string(),
             pid,
@@ -223,8 +225,6 @@ impl From<Process> for fact_api::ProcessSignal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::test_utils::*;
-    use fact_ebpf::PATH_MAX;
 
     #[test]
     fn extract_container_id() {
@@ -263,6 +263,7 @@ mod tests {
         }
     }
 
+    /* TODO: move these tests to the parser module
     #[test]
     fn process_conversion_valid_utf8_comm() {
         let tests = [
@@ -495,4 +496,5 @@ mod tests {
             lineage_path_str
         );
     }
+    */
 }

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -174,8 +174,8 @@ impl HostScanner {
 
         let metadata = path.metadata()?;
         let inode = inode_key_t {
-            inode: metadata.st_ino(),
-            dev: metadata.st_dev(),
+            inode: metadata.st_ino() as u32,
+            dev: metadata.st_dev() as u32,
         };
 
         let host_path = host_info::remove_host_mount(path);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,7 +192,7 @@ def fact(request, docker_client, fact_config, server, logs_dir, test_file):
 
     container_log = os.path.join(logs_dir, 'fact.log')
     # Wait for container to be ready
-    for _ in range(3):
+    for _ in range(5):
         try:
             resp = requests.get(
                 f'http://{config["endpoint"]["address"]}/health_check')
@@ -207,6 +207,8 @@ def fact(request, docker_client, fact_config, server, logs_dir, test_file):
         container.remove()
         pytest.fail('fact failed to start')
 
+    # fact seems to be taking a bit longer to startup, try adding a small delay
+    sleep(1)
     yield container
 
     # Capture prometheus metrics before stopping the container


### PR DESCRIPTION
## Description

Change from a fixed type for events from BPF to a variable length one. This is done by using a helper map in which we can write all the information for a given event, then submit it to the ringbuffer with the bpf_ringbuf_output helper.

On the userspace, we get a RingBufItem which can be treated as a slice of bytes we can split to retrieve fields one by one.

This change needs to be properly tested for performance, we should use a lot less space for each event in the ringbuffer but serializing and deserializing each event might require more CPU.

Supersedes #179

## Checklist
- [ ] Patch has a change log entry **OR** does not need one.
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TBD