### PR TITLE
chore: prepare release branch for 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "fact"
-version = "0.3.0-dev"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "aya",

--- a/constants.mk
+++ b/constants.mk
@@ -1,4 +1,4 @@
-RUST_VERSION ?= stable
+RUST_VERSION ?= 1.95
 
 FACT_TAG ?= $(shell git describe --always --tags --abbrev=10 --dirty)
 FACT_VERSION ?= $(FACT_TAG)

--- a/fact/Cargo.toml
+++ b/fact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fact"
-version = "0.3.0-dev"
+version = "0.3.0"
 edition = "2024"
 
 license.workspace = true


### PR DESCRIPTION
## Description

Pin the Rust version to 1.95 and update the version used by Cargo to 0.3.0

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
