### PR TITLE
fix(ci): restrict PR checklist by author

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Verify PR Checklist is Complete
-        if: github.actor != 'red-hat-konflux[bot]'
+        if: github.event.pull_request.user.login != 'red-hat-konflux[bot]'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -30,6 +30,6 @@ jobs:
           fi
 
       - name: Skip check for MintMaker
-        if: github.actor == 'red-hat-konflux[bot]'
+        if: github.event.pull_request.user.login  == 'red-hat-konflux[bot]'
         run: |
           echo "MintMaker PRs are exempted from this check"


### PR DESCRIPTION
## Description

The existing check reacts to whoever performs an action, so pushing a commit to a PR opened by konflux bot will trigger the checklist validation. This is not a huge deal, but since MintMaker PRs have predefined descriptions, we should never attempt to validate them.

With this change we restrict the validation to PRs that are not opened by konflux bot.

For an example of a MintMaker PR running the checklist validation test after a push from another user see #679.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

This will need to be fully tested by merging and letting a MintMaker PR be opened.
