### PR TITLE
backport: CI health improving changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - main
     - release-*
-    - konflux/**
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -115,6 +115,10 @@ jobs:
 
     - name: Store artifacts
       if: always()
+      # Don't fail the job on upload errors (e.g. ECONNRESET) —
+      # these are debug logs, not consumed by downstream jobs.
+      # Test failures still fail the job via the Run Tests step.
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.vm }}-test-logs

--- a/.github/workflows/konflux-tests.yml
+++ b/.github/workflows/konflux-tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - main
     - release-*
-    - konflux/**
     tags:
     - '*'
   pull_request:

--- a/.tekton/fact-build.yaml
+++ b/.tekton/fact-build.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest fact-on-push"
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "pull_request" && body.action != "ready_for_review") || (
-        event == "push" && target_branch.matches("^(main|release-.*|refs/tags/.*|konflux/.*)$")
+        event == "push" && target_branch.matches("^(main|release-.*|refs/tags/.*)$")
       )
   labels:
     appstudio.openshift.io/application: acs-4-10

--- a/tests/containers/self-deleter/Containerfile
+++ b/tests/containers/self-deleter/Containerfile
@@ -1,11 +1,12 @@
-FROM rust:1.84-alpine AS builder
+FROM quay.io/centos/centos:stream9 AS builder
 
 WORKDIR /app
 
 COPY . .
-RUN cargo build --release
+RUN dnf install -y rust cargo && \
+        cargo build --release
 
-FROM alpine:3.23
+FROM quay.io/centos/centos:stream9-minimal
 
 COPY --from=builder /app/target/release/self-deleter /usr/local/bin
 


### PR DESCRIPTION
## Description

This is a backport of 3 separate PRs that help in keeping CI happy:
- #193 
- #214 
- #572 

These may not seem like much, but the MintMaker PRs to the release-0.2 branch have been failing mostly with the errors to store artifacts and the self-deleter image being rate limited by dockerhub. Not running CI on the `konflux/**` is more for cleanup than getting CI to pass.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Change is merely backports that have already been tested by themselves on the main branch.