### PR TITLE
cleanup: improve error message when inode map is full (#729)

### DIFF
--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -520,7 +520,7 @@ pub struct FactCli {
     ///
     /// Going over this limit will prevent fact from tracking and
     /// filling in the host path correctly in events.
-    #[arg(long, short, env = "FACT_INODE_MAX")]
+    #[arg(long, short, env = "FACT_INODES_MAX")]
     inodes_max: Option<u32>,
 
     /// Whether configuration should be hotreloaded

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -20,6 +20,7 @@
 
 use std::{
     cell::RefCell,
+    io,
     os::linux::fs::MetadataExt,
     path::{Path, PathBuf},
     sync::Arc,
@@ -27,7 +28,10 @@ use std::{
 };
 
 use anyhow::{Context, bail};
-use aya::maps::MapData;
+use aya::{
+    maps::{MapData, MapError},
+    sys::SyscallError,
+};
 use fact_ebpf::{inode_key_t, inode_value_t, monitored_t};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use log::{debug, info, warn};
@@ -183,10 +187,25 @@ impl HostScanner {
 
     /// Similar to update_entry except we are are directly using the inode instead of the path.
     fn update_entry_with_inode(&self, inode: inode_key_t, path: PathBuf) -> anyhow::Result<()> {
-        self.kernel_inode_map
-            .borrow_mut()
-            .insert(inode, 0, 0)
-            .with_context(|| format!("Failed to insert kernel entry for {}", path.display()))?;
+        match self.kernel_inode_map.borrow_mut().insert(inode, 0, 0) {
+            Ok(_) => {}
+            Err(MapError::SyscallError(SyscallError { io_error, .. }))
+                if io_error.kind() == io::ErrorKind::ArgumentListTooLong =>
+            {
+                bail!(
+                    r#"Reached maximum number of inodes to track.
+You can increase this limit with:
+* The bpf.inodes_max configuration value.
+* The FACT_INODES_MAX environment variable.
+* The --inodes-max argument."#,
+                )
+            }
+            e => {
+                return e.with_context(|| {
+                    format!("Failed to insert kernel entry for {}", path.display())
+                });
+            }
+        }
 
         let mut inode_map = self.inode_map.borrow_mut();
         let entry = inode_map.entry(inode).or_default();


### PR DESCRIPTION

## Description

Backport of #729.

When reaching the maximum number of inodes that can be tracked, attempting to insert a new entry in the kernel map will produce an error message pointing the user to increase the value via:
* The bpf.inodes_max configuration value.
* The FACT_INODES_MAX environment variable.
* The --inodes-max argument.

There is also a minor cleanup on the name of the environment variable for consistency among all the configuration options.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Monitored a directory with lots of files and limited the amount to track with --inodes-max 64.

Without the change fact crashes with the message:
```
Error: Failed to update entry for /etc/***
Caused by:
    0: Failed to insert kernel entry for /etc/***
    1: `bpf_map_update_elem` failed
    2: Argument list too long (os error 7)
```
With the change:
```
Error: Failed to update entry for /etc/***

Caused by:
    Reached maximum number of inodes to track.
    You can increase this limit with:
    * The bpf.inodes_max configuration value.
    * The FACT_INODES_MAX environment variable.
    * The --inodes-max argument.
```