### PR TITLE
chore(deps): update rust crate shlex to v2 (#679)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -244,7 +244,7 @@ version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -457,7 +457,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "shlex",
+ "shlex 2.0.1",
  "tempfile",
  "tokio",
  "tokio-native-tls",
@@ -1427,7 +1427,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1530,6 +1530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,7 +1608,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ prost = "0.14.0"
 prost-types = "0.14.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
-shlex = "1.3.0"
+shlex = "2.0.1"
 tokio = { version = "1.40.0", default-features = false, features = [
     "fs",
     "macros",


### PR DESCRIPTION
## Description

This is a backport of #679.

The MintMaker `update all updates` workflow is broken on the `release-0.3` branch due to a version bump in the `shlex` dependency, said dependency needs to be bumped to 2.0.1 but some other dependencies still need version 1.*. For some reason, this does not seem to be supported by MintMaker, but doing the update manually is not too hard and should not happen very often. See #726 for the detailed error message from MintMaker.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

This version of shlex has been used in the main branch for the past couple of weeks with no problems.
