### PR TITLE
feat: add code coverage with cargo-llvm-cov and Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,44 @@ jobs:
       run: cargo +${{ matrix.rust-version }} test
 
 
+  coverage:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libbpf-dev \
+          protobuf-compiler
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-${{ runner.arch }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install cargo-llvm-cov
+      run: |
+        rustup component add llvm-tools-preview
+        cargo install cargo-llvm-cov
+
+    - name: Generate coverage
+      run: make coverage
+
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        files: codecov.json
+        token: ${{ secrets.CODECOV_TOKEN }}
+
   format-check:
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,6 @@ jobs:
           target/
         key: ${{ runner.os }}-${{ runner.arch }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Install cargo-llvm-cov
-      run: |
-        rustup component add llvm-tools-preview
-        cargo install cargo-llvm-cov
-
     - name: Generate coverage
       run: make coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ internalapi/
 results.xml
 logs/
 THIRD_PARTY_LICENSES.html
+codecov.json
 
 # clangd and compilation database
 .cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ possible include a PR number for easier tracking.
 
 ## Next
 
+* feat: add code coverage with cargo-llvm-cov and Codecov upload (#745)
+
 ## 0.3.0
 
 * ROX-34663: Migrate from ubi-minimal to ubi-micro (#653)

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,13 @@ integration-tests:
 performance-tests:
 	make -C performance-tests
 
+coverage:
+	cargo llvm-cov --workspace --codecov --output-path codecov.json
+
 clean:
 	make -C tests clean
 	rm -f THIRD_PARTY_LICENSES.html
+	rm -f codecov.json
 
 format-check:
 	cargo fmt --check
@@ -44,4 +48,4 @@ format:
 	cargo fmt
 	make -C fact-ebpf format
 
-.PHONY: tag mock-server integration-tests image image-name licenses clean
+.PHONY: tag mock-server integration-tests image image-name licenses coverage clean


### PR DESCRIPTION
## Description

Add a coverage job to CI that instruments unit tests with cargo-llvm-cov, generates a Codecov-compatible JSON report, and uploads it via the codecov/codecov-action. A `make coverage` target is provided for local use.

Assisted-by: Claude Code (claude-opus-4-6)

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Generated the code coverage report locally.
The coverage report for this change can be found at https://app.codecov.io/gh/stackrox/fact/tree/mauro%2Ffeat%2Fadd-code-coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now generates and uploads code coverage reports automatically and adds a dedicated coverage job.
  * Build tooling includes a new coverage target and cleans up generated coverage artifacts; generated coverage output is ignored from commits.
* **Documentation**
  * CHANGELOG updated to note the addition of automated code coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->