### PR TITLE
fix(ci): install cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,11 @@ jobs:
           target/
         key: ${{ runner.os }}-${{ runner.arch }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Install cargo-llvm-cov
+      run: |
+        rustup component add llvm-tools
+        cargo install cargo-llvm-cov
+
     - name: Generate coverage
       run: make coverage
 


### PR DESCRIPTION
## Description

When adding code coverage this tool seemed to be preinstalled, as soon as #745 was merged to main the workflow failed because this was not installed, so we are explicitly adding it.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now installs additional coverage tooling (adds a step to install required components and the coverage collector) prior to running coverage collection and upload. This change is limited to the coverage job; no other CI jobs or steps were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->