### PR TITLE
fix: install cargo-llvm-cov when not present in cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Install cargo-llvm-cov
       run: |
         rustup component add llvm-tools
-        cargo install cargo-llvm-cov
+        cargo install --force cargo-llvm-cov
 
     - name: Generate coverage
       run: make coverage


### PR DESCRIPTION
## Description

The cargo cache that is setup for the coverage job is also caching cargo-llvm-cov, causing the step to fail on subsequent runs. With this change we will always install the latest version of this crate.

We could also remove the `.bin` entry from the cache in the previous step, but I don't think it will make much difference, as long as there is no newer version of the crate we will end up simply linking the compiled object into the final binary.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal continuous integration configuration for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->