### PR TITLE
chore: add ruff linter and pyright for Python test code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,23 @@ jobs:
         files: codecov.json
         token: ${{ secrets.CODECOV_TOKEN }}
 
+  lint-tests:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.14"
+    - name: Lint
+      run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install ruff pyright
+        pip install -r tests/requirements.txt
+        make -C tests lint
+
   format-check:
     runs-on: ubuntu-24.04
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ possible include a PR number for easier tracking.
 
 ## Next
 
+* chore: add formatting and linting to integration test code (#783, #784)
 * feat: add code coverage with cargo-llvm-cov and Codecov upload (#745)
 
 ## 0.3.0

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ clean:
 	rm -f THIRD_PARTY_LICENSES.html
 	rm -f codecov.json
 
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+	make -C tests lint
+
 format-check:
 	cargo fmt --check
 	make -C fact-ebpf format-check
@@ -50,4 +54,4 @@ format:
 	make -C fact-ebpf format
 	ruff format tests/
 
-.PHONY: tag mock-server integration-tests image image-name licenses coverage clean
+.PHONY: tag mock-server integration-tests image image-name licenses coverage lint clean

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,0 @@
-line-length = 80
-
-[format]
-quote-style = "single"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,9 +20,13 @@ grpc-gen: ${ARTIFACTS}
 		--grpc_python_out=${PYOUT} \
 		${ARTIFACTS}
 
+lint: grpc-gen
+	ruff check .
+	pyright .
+
 clean:
 	rm -rf logs/
 	rm -rf logs.tar.gz
 	rm -f results.xml
 
-.PHONY: all pytest grpc-gen clean
+.PHONY: all pytest grpc-gen lint clean

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
 import os
 from shutil import rmtree
 from tempfile import NamedTemporaryFile, mkdtemp
 from time import sleep
 
 import docker
+import docker.errors
+import docker.models.containers
 import pytest
 import requests
 import yaml
 
 from server import FileActivityService
-
 
 # Declare files holding fixtures
 pytest_plugins = ['test_editors.commons']
@@ -27,7 +30,7 @@ def monitored_dir():
 
 
 @pytest.fixture
-def test_file(monitored_dir):
+def test_file(monitored_dir: str):
     """
     Create a temporary file for tests
 
@@ -37,7 +40,7 @@ def test_file(monitored_dir):
     fut = os.path.join(monitored_dir, 'test.txt')
     with open(fut, 'w') as f:
         f.write('test')
-    yield fut
+    return fut
 
 
 @pytest.fixture
@@ -76,7 +79,7 @@ def server():
 
 
 @pytest.fixture
-def logs_dir(request):
+def logs_dir(request: pytest.FixtureRequest):
     logs = os.path.join(
         os.getcwd(),
         'logs',
@@ -88,22 +91,30 @@ def logs_dir(request):
 
 
 @pytest.fixture(scope='session', autouse=True)
-def get_image(request, docker_client):
+def get_image(
+    request: pytest.FixtureRequest,
+    docker_client: docker.DockerClient,
+):
     image = request.config.getoption('--image')
+    assert isinstance(image, str)
     try:
         docker_client.images.get(image)
     except docker.errors.ImageNotFound:
         docker_client.images.pull(image)
 
 
-def dump_logs(container, file):
+def dump_logs(container: docker.models.containers.Container, file: str):
     logs = container.logs().decode('utf-8')
     with open(file, 'w') as f:
         f.write(logs)
 
 
 @pytest.fixture
-def fact_config(request, monitored_dir, logs_dir):
+def fact_config(
+    request: pytest.FixtureRequest,
+    monitored_dir: str,
+    logs_dir: str,
+):
     cwd = os.getcwd()
     config = {
         'paths': [
@@ -123,7 +134,7 @@ def fact_config(request, monitored_dir, logs_dir):
         'json': True,
         'scan_interval': 0,
     }
-    config_file = NamedTemporaryFile(
+    config_file = NamedTemporaryFile(  # noqa: SIM115
         prefix='fact-config-',
         suffix='.yml',
         dir=cwd,
@@ -132,14 +143,21 @@ def fact_config(request, monitored_dir, logs_dir):
     yaml.dump(config, config_file)
 
     yield config, config_file.name
-    with open(os.path.join(logs_dir, 'fact.yml'), 'w') as f:
-        with open(config_file.name, 'r') as r:
-            f.write(r.read())
+    with (
+        open(os.path.join(logs_dir, 'fact.yml'), 'w') as f,
+        open(config_file.name) as r,
+    ):
+        f.write(r.read())
     config_file.close()
 
 
 @pytest.fixture
-def test_container(request, docker_client, monitored_dir, ignored_dir):
+def test_container(
+    request: pytest.FixtureRequest,
+    docker_client: docker.DockerClient,
+    monitored_dir: str,
+    ignored_dir: str,
+):
     """
     Run a container for triggering events in.
     """
@@ -168,12 +186,20 @@ def test_container(request, docker_client, monitored_dir, ignored_dir):
 
 
 @pytest.fixture(autouse=True)
-def fact(request, docker_client, fact_config, server, logs_dir, test_file):
+def fact(
+    request: pytest.FixtureRequest,
+    docker_client: docker.DockerClient,
+    fact_config: tuple[dict, str],
+    server: FileActivityService,
+    logs_dir: str,
+    test_file: str,
+):
     """
     Run the fact docker container for integration tests.
     """
     config, config_file = fact_config
     image = request.config.getoption('--image')
+    assert isinstance(image, str)
     container = docker_client.containers.run(
         image,
         detach=True,
@@ -231,7 +257,7 @@ def fact(request, docker_client, fact_config, server, logs_dir, test_file):
     assert exit_status['StatusCode'] == 0
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest.Parser):
     parser.addoption(
         '--image',
         action='store',

--- a/tests/event.py
+++ b/tests/event.py
@@ -1,12 +1,12 @@
 import os
-from re import Pattern
 import string
 from enum import Enum
+from re import Pattern
 from typing import Any, override
 
+import utils
 from internalapi.sensor.collector_pb2 import ProcessSignal
 from internalapi.sensor.sfa_pb2 import FileActivity
-import utils
 
 
 def extract_container_id(cgroup: str) -> str:
@@ -65,12 +65,12 @@ class Process:
 
     @classmethod
     def from_proc(cls, pid: int | None = None):
-        pid: int = pid if pid is not None else os.getpid()
+        pid = pid if pid is not None else os.getpid()
         proc_dir = os.path.join('/proc', str(pid))
 
         uid = 0
         gid = 0
-        with open(os.path.join(proc_dir, 'status'), 'r') as f:
+        with open(os.path.join(proc_dir, 'status')) as f:
 
             def get_id(line: str, wanted_id: str) -> int | None:
                 if line.startswith(f'{wanted_id}:'):
@@ -94,13 +94,13 @@ class Process:
             ]
         args = utils.rust_style_join(args)
 
-        with open(os.path.join(proc_dir, 'comm'), 'r') as f:
+        with open(os.path.join(proc_dir, 'comm')) as f:
             name = f.read().strip()
 
-        with open(os.path.join(proc_dir, 'cgroup'), 'r') as f:
+        with open(os.path.join(proc_dir, 'cgroup')) as f:
             container_id = extract_container_id(f.read())
 
-        with open(os.path.join(proc_dir, 'loginuid'), 'r') as f:
+        with open(os.path.join(proc_dir, 'loginuid')) as f:
             loginuid = int(f.read())
 
         return Process(
@@ -271,7 +271,7 @@ class Event:
         return self._old_host_path
 
     @classmethod
-    def _diff_field(cls, diff, name, expected, actual):
+    def _diff_field(cls, diff: dict, name: str, expected: Any, actual: Any):
         if expected != actual:
             diff[name] = {
                 'expected': expected,
@@ -281,9 +281,9 @@ class Event:
     @classmethod
     def _diff_path(
         cls,
-        diff,
+        diff: dict,
         name: str,
-        expected: str | Pattern[str],
+        expected: str | Pattern[str] | None,
         actual: str,
     ):
         """
@@ -353,7 +353,8 @@ class Event:
             return diff if diff else None
 
         # Compare file and host_path (common to all event types)
-        # All event types have .activity.path and .activity.host_path except they're accessed differently
+        # All event types have .activity.path and .activity.host_path
+        # accessed differently
         Event._diff_path(diff, 'file', self.file, event_field.activity.path)
         Event._diff_path(
             diff,
@@ -395,7 +396,10 @@ class Event:
             s += f', owner=(uid={self.owner_uid}, gid={self.owner_gid})'
 
         if self.event_type == EventType.RENAME:
-            s += f', old_file="{self.old_file}", old_host_path="{self.old_host_path}"'
+            s += (
+                f', old_file="{self.old_file}"'
+                f', old_host_path="{self.old_host_path}"'
+            )
 
         s += ')'
 

--- a/tests/pyrightconfig.json
+++ b/tests/pyrightconfig.json
@@ -1,0 +1,6 @@
+{
+    "include": ["."],
+    "exclude": ["internalapi"],
+    "reportMissingModuleSource": false,
+    "reportMissingParameterType": "error"
+}

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -1,0 +1,16 @@
+line-length = 80
+
+[lint]
+select = [
+    "F",   # Pyflakes: unused imports, undefined names
+    "E",   # pycodestyle: style errors, line length
+    "I",   # isort: import sorting
+    "UP",  # pyupgrade: modernize syntax for newer Python
+    "B",   # flake8-bugbear: common bug patterns
+    "SIM", # flake8-simplify: unnecessary complexity
+    "PT",  # flake8-pytest-style: pytest best practices
+    "RUF", # Ruff-specific rules
+]
+
+[format]
+quote-style = "single"

--- a/tests/server.py
+++ b/tests/server.py
@@ -1,12 +1,18 @@
-from concurrent import futures
-from collections import deque
+from __future__ import annotations
+
 import json
+from collections import deque
+from concurrent import futures
 from threading import Event as ThreadingEvent
 from time import sleep
+from typing import TYPE_CHECKING, Any
 
 import grpc
 
 from internalapi.sensor import sfa_iservice_pb2_grpc
+
+if TYPE_CHECKING:
+    from event import Event
 
 
 class FileActivityService(sfa_iservice_pb2_grpc.FileActivityServiceServicer):
@@ -21,13 +27,13 @@ class FileActivityService(sfa_iservice_pb2_grpc.FileActivityServiceServicer):
         Sets up the GRPC server, a queue for incoming requests, and an
         event for other threads to know when the server stops.
         """
-        sfa_iservice_pb2_grpc.FileActivityService.__init__(self)
+        super().__init__()
         self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
         self.queue = deque()
         self.running = ThreadingEvent()
         self.executor = futures.ThreadPoolExecutor(max_workers=2)
 
-    def Communicate(self, request_iterator, context):
+    def Communicate(self, request_iterator: Any, context: Any):
         """
         GRPC method to receive a stream of file activity requests.
         Appends each incoming request to an internal queue.
@@ -84,7 +90,7 @@ class FileActivityService(sfa_iservice_pb2_grpc.FileActivityServiceServicer):
 
     def _wait_events(
         self,
-        events: list['Event'],
+        events: list[Event],
         strict: bool,
         cancel: ThreadingEvent,
     ):
@@ -105,7 +111,7 @@ class FileActivityService(sfa_iservice_pb2_grpc.FileActivityServiceServicer):
             elif strict:
                 raise ValueError(json.dumps(diff, indent=4))
 
-    def wait_events(self, events: list['Event'], strict: bool = True):
+    def wait_events(self, events: list[Event], strict: bool = True):
         """
         Continuously checks the server for incoming events until the
         specified events are found.

--- a/tests/test_config_hotreload.py
+++ b/tests/test_config_hotreload.py
@@ -1,23 +1,30 @@
+from __future__ import annotations
+
 import os
 from time import sleep
 
-from event import Event, EventType, Process
-
+import docker.models.containers
 import pytest
 import requests
 import yaml
 
+from event import Event, EventType, Process
 from server import FileActivityService
 
 DEFAULT_URL = 'http://127.0.0.1:9000'
 
 
-def assert_endpoint(endpoint, status_code=200):
+def assert_endpoint(endpoint: str, status_code: int = 200):
     resp = requests.get(f'{DEFAULT_URL}/{endpoint}')
     assert resp.status_code == status_code
 
 
-def reload_config(fact, config, file, delay=0.5):
+def reload_config(
+    fact: docker.models.containers.Container,
+    config: dict,
+    file: str,
+    delay: float = 0.5,
+):
     with open(file, 'w') as f:
         yaml.dump(config, f)
     fact.kill('SIGHUP')
@@ -28,7 +35,11 @@ cases = [('metrics', 'expose_metrics'), ('health_check', 'health_check')]
 
 
 @pytest.mark.parametrize('case', cases, ids=['metrics', 'health_check'])
-def test_endpoint(fact, fact_config, case):
+def test_endpoint(
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+    case: tuple[str, str],
+):
     """
     Test the endpoints configurability
     """
@@ -45,7 +56,10 @@ def test_endpoint(fact, fact_config, case):
     assert_endpoint(endpoint, 503)
 
 
-def test_endpoint_disable_all(fact, fact_config):
+def test_endpoint_disable_all(
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+):
     """
     Disable all endpoints and check the default port is not bound
     """
@@ -60,7 +74,10 @@ def test_endpoint_disable_all(fact, fact_config):
         requests.get(f'{DEFAULT_URL}/metrics')
 
 
-def test_endpoint_address_change(fact, fact_config):
+def test_endpoint_address_change(
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+):
     config, config_file = fact_config
     config['endpoint']['address'] = '127.0.0.1:9001'
     reload_config(fact, config, config_file)
@@ -88,11 +105,11 @@ def alternate_server():
 
 
 def test_output_grpc_address_change(
-    fact,
-    fact_config,
-    monitored_dir,
-    server,
-    alternate_server,
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+    monitored_dir: str,
+    server: FileActivityService,
+    alternate_server: FileActivityService,
 ):
     """
     Tests we can receive events on a new endpoint after a configuration
@@ -131,7 +148,13 @@ def test_output_grpc_address_change(
     alternate_server.wait_events([e])
 
 
-def test_paths(fact, fact_config, monitored_dir, ignored_dir, server):
+def test_paths(
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+    monitored_dir: str,
+    ignored_dir: str,
+    server: FileActivityService,
+):
     p = Process.from_proc()
 
     # Ignored file, must not show up in the server
@@ -171,7 +194,12 @@ def test_paths(fact, fact_config, monitored_dir, ignored_dir, server):
     server.wait_events([e])
 
 
-def test_no_paths_then_add(fact, fact_config, monitored_dir, server):
+def test_no_paths_then_add(
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+    monitored_dir: str,
+    server: FileActivityService,
+):
     """
     Start with no paths configured, verify no events are produced,
     then add paths via hot-reload and verify events appear.
@@ -205,7 +233,12 @@ def test_no_paths_then_add(fact, fact_config, monitored_dir, server):
     server.wait_events([e])
 
 
-def test_paths_then_remove(fact, fact_config, monitored_dir, server):
+def test_paths_then_remove(
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+    monitored_dir: str,
+    server: FileActivityService,
+):
     """
     Start with paths configured, verify events are produced,
     then remove all paths via hot-reload and verify events stop.
@@ -235,7 +268,13 @@ def test_paths_then_remove(fact, fact_config, monitored_dir, server):
         server.wait_events([e])
 
 
-def test_paths_addition(fact, fact_config, monitored_dir, ignored_dir, server):
+def test_paths_addition(
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+    monitored_dir: str,
+    ignored_dir: str,
+    server: FileActivityService,
+):
     p = Process.from_proc()
 
     # Ignored file, must not show up in the server

--- a/tests/test_editors/commons.py
+++ b/tests/test_editors/commons.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import os
 
+import docker
+import docker.models.containers
+import docker.models.images
 import pytest
 
 
-def get_vi_test_file(dir):
+def get_vi_test_file(dir: str):
     return os.path.join(dir, '4913')
 
 
 @pytest.fixture(scope='session')
-def build_editor_image(docker_client):
+def build_editor_image(docker_client: docker.DockerClient):
     image, _ = docker_client.images.build(
         path='containers/editors',
         tag='editors:latest',
@@ -17,7 +22,11 @@ def build_editor_image(docker_client):
     return image
 
 
-def run_editor_container(image, docker_client, ignored_dir):
+def run_editor_container(
+    image: str,
+    docker_client: docker.DockerClient,
+    ignored_dir: str,
+):
     container = docker_client.containers.run(
         image,
         detach=True,
@@ -39,7 +48,7 @@ def run_editor_container(image, docker_client, ignored_dir):
 
 
 @pytest.fixture
-def vi_container(docker_client, ignored_dir):
+def vi_container(docker_client: docker.DockerClient, ignored_dir: str):
     yield from run_editor_container(
         'quay.io/fedora/fedora:43',
         docker_client,
@@ -48,6 +57,10 @@ def vi_container(docker_client, ignored_dir):
 
 
 @pytest.fixture
-def editor_container(build_editor_image, docker_client, ignored_dir):
+def editor_container(
+    build_editor_image: docker.models.images.Image,
+    docker_client: docker.DockerClient,
+    ignored_dir: str,
+):
     image = build_editor_image.tags[0]
     yield from run_editor_container(image, docker_client, ignored_dir)

--- a/tests/test_editors/test_nvim.py
+++ b/tests/test_editors/test_nvim.py
@@ -1,9 +1,17 @@
-from event import Event, EventType, Process
+from __future__ import annotations
 
+import docker.models.containers
+
+from event import Event, EventType, Process
+from server import FileActivityService
 from test_editors.commons import get_vi_test_file
 
 
-def test_new_file(editor_container, server):
+def test_new_file(
+    editor_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert editor_container.id is not None
     fut = '/mounted/test.txt'
     cmd = f"nvim {fut} '+:normal iThis is a test<CR>' -c x"
 
@@ -27,7 +35,11 @@ def test_new_file(editor_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_open_file(editor_container, server):
+def test_open_file(
+    editor_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert editor_container.id is not None
     fut = '/mounted/test.txt'
     fut_backup = f'{fut}~'
     cmd = f"nvim {fut} '+:normal iThis is a test<CR>' -c x"
@@ -111,7 +123,11 @@ def test_open_file(editor_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_new_file_ovfs(editor_container, server):
+def test_new_file_ovfs(
+    editor_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert editor_container.id is not None
     fut = '/container-dir/test.txt'
     cmd = f"nvim {fut} '+:normal iThis is a test<CR>' -c x"
 
@@ -135,7 +151,11 @@ def test_new_file_ovfs(editor_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_open_file_ovfs(editor_container, server):
+def test_open_file_ovfs(
+    editor_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert editor_container.id is not None
     fut = '/container-dir/test.txt'
     fut_backup = f'{fut}~'
     cmd = f"nvim {fut} '+:normal iThis is a test<CR>' -c x"

--- a/tests/test_editors/test_sed.py
+++ b/tests/test_editors/test_sed.py
@@ -1,8 +1,18 @@
+from __future__ import annotations
+
 import re
+
+import docker.models.containers
+
 from event import Event, EventType, Process
+from server import FileActivityService
 
 
-def test_sed(vi_container, server):
+def test_sed(
+    vi_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert vi_container.id is not None
     # File Under Test
     fut = '/mounted/test.txt'
     create_cmd = f'sh -c "echo \'This is a test\' > {fut}"'
@@ -61,7 +71,11 @@ def test_sed(vi_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_sed_ovfs(vi_container, server):
+def test_sed_ovfs(
+    vi_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert vi_container.id is not None
     # File Under Test
     fut = '/container-dir/test.txt'
     create_cmd = f'sh -c "echo \'This is a test\' > {fut}"'

--- a/tests/test_editors/test_vi.py
+++ b/tests/test_editors/test_vi.py
@@ -1,8 +1,17 @@
+from __future__ import annotations
+
+import docker.models.containers
+
 from event import Event, EventType, Process
+from server import FileActivityService
 from test_editors.commons import get_vi_test_file
 
 
-def test_new_file(vi_container, server):
+def test_new_file(
+    vi_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert vi_container.id is not None
     fut = '/mounted/test.txt'
     swap_file = '/mounted/.test.txt.swp'
     swx_file = '/mounted/.test.txt.swx'
@@ -67,7 +76,11 @@ def test_new_file(vi_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_new_file_ovfs(vi_container, server):
+def test_new_file_ovfs(
+    vi_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert vi_container.id is not None
     fut = '/container-dir/test.txt'
     swap_file = '/container-dir/.test.txt.swp'
     swx_file = '/container-dir/.test.txt.swx'
@@ -132,7 +145,11 @@ def test_new_file_ovfs(vi_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_open_file(vi_container, server):
+def test_open_file(
+    vi_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert vi_container.id is not None
     fut = '/mounted/test.txt'
     fut_backup = f'{fut}~'
     swap_file = '/mounted/.test.txt.swp'
@@ -262,7 +279,11 @@ def test_open_file(vi_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_open_file_ovfs(vi_container, server):
+def test_open_file_ovfs(
+    vi_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert vi_container.id is not None
     fut = '/container-dir/test.txt'
     fut_backup = f'{fut}~'
     swap_file = '/container-dir/.test.txt.swp'

--- a/tests/test_editors/test_vim.py
+++ b/tests/test_editors/test_vim.py
@@ -1,8 +1,17 @@
+from __future__ import annotations
+
+import docker.models.containers
+
 from event import Event, EventType, Process
+from server import FileActivityService
 from test_editors.commons import get_vi_test_file
 
 
-def test_new_file(editor_container, server):
+def test_new_file(
+    editor_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert editor_container.id is not None
     fut = '/mounted/test.txt'
     swap_file = '/mounted/.test.txt.swp'
     swx_file = '/mounted/.test.txt.swx'
@@ -65,7 +74,11 @@ def test_new_file(editor_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_new_file_ovfs(editor_container, server):
+def test_new_file_ovfs(
+    editor_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert editor_container.id is not None
     fut = '/container-dir/test.txt'
     swap_file = '/container-dir/.test.txt.swp'
     swx_file = '/container-dir/.test.txt.swx'
@@ -128,7 +141,11 @@ def test_new_file_ovfs(editor_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_open_file(editor_container, server):
+def test_open_file(
+    editor_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert editor_container.id is not None
     fut = '/mounted/test.txt'
     fut_backup = f'{fut}~'
     swap_file = '/mounted/.test.txt.swp'
@@ -257,7 +274,11 @@ def test_open_file(editor_container, server):
     server.wait_events(events, strict=True)
 
 
-def test_open_file_ovfs(editor_container, server):
+def test_open_file_ovfs(
+    editor_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert editor_container.id is not None
     fut = '/container-dir/test.txt'
     fut_backup = f'{fut}~'
     swap_file = '/container-dir/.test.txt.swp'

--- a/tests/test_file_open.py
+++ b/tests/test_file_open.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import multiprocessing as mp
 import os
+from multiprocessing.synchronize import Event as MpEvent
 
+import docker.models.containers
 import pytest
 
-from utils import join_path_with_filename, path_to_string, rust_style_quote
 from event import Event, EventType, Process
+from server import FileActivityService
+from utils import join_path_with_filename, path_to_string
 
 
 @pytest.mark.parametrize(
@@ -18,7 +23,11 @@ from event import Event, EventType, Process
         pytest.param(b'test\xff\xfe.txt', id='Invalid'),
     ],
 )
-def test_open(monitored_dir, server, filename):
+def test_open(
+    monitored_dir: str,
+    server: FileActivityService,
+    filename: str | bytes,
+):
     """
     Tests the opening of a file and verifies that the corresponding
     event is captured by the server.
@@ -47,7 +56,7 @@ def test_open(monitored_dir, server, filename):
     server.wait_events([e])
 
 
-def test_multiple(monitored_dir, server):
+def test_multiple(monitored_dir: str, server: FileActivityService):
     """
     Tests the opening of multiple files and verifies that the
     corresponding events are captured by the server.
@@ -77,7 +86,7 @@ def test_multiple(monitored_dir, server):
     server.wait_events(events)
 
 
-def test_multiple_access(test_file, server):
+def test_multiple_access(test_file: str, server: FileActivityService):
     """
     Tests multiple opening of a file and verifies that the
     corresponding events are captured by the server.
@@ -87,7 +96,7 @@ def test_multiple_access(test_file, server):
         server: The server instance to communicate with.
     """
     events = []
-    for i in range(3):
+    for _i in range(3):
         with open(test_file, 'a+') as f:
             f.write('This is a test')
 
@@ -103,7 +112,7 @@ def test_multiple_access(test_file, server):
     server.wait_events(events)
 
 
-def test_ignored(test_file, ignored_dir, server):
+def test_ignored(test_file: str, ignored_dir: str, server: FileActivityService):
     """
     Tests that open events on ignored files are not captured by the
     server.
@@ -134,7 +143,7 @@ def test_ignored(test_file, ignored_dir, server):
     server.wait_events([e])
 
 
-def do_test(fut: str, stop_event: mp.Event):
+def do_test(fut: str, stop_event: MpEvent):
     with open(fut, 'w') as f:
         f.write('This is a test')
     with open(fut, 'a') as f:
@@ -144,7 +153,7 @@ def do_test(fut: str, stop_event: mp.Event):
     stop_event.wait()
 
 
-def test_external_process(monitored_dir, server):
+def test_external_process(monitored_dir: str, server: FileActivityService):
     """
     Tests the opening of a file by an external process and verifies that
     the corresponding event is captured by the server.
@@ -181,7 +190,11 @@ def test_external_process(monitored_dir, server):
         proc.join(1)
 
 
-def test_overlay(test_container, server):
+def test_overlay(
+    test_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert test_container.id is not None
     # File Under Test
     fut = '/container-dir/test.txt'
 
@@ -206,7 +219,12 @@ def test_overlay(test_container, server):
     server.wait_events(events)
 
 
-def test_mounted_dir(test_container, ignored_dir, server):
+def test_mounted_dir(
+    test_container: docker.models.containers.Container,
+    ignored_dir: str,
+    server: FileActivityService,
+):
+    assert test_container.id is not None
     # File Under Test
     fut = '/mounted/test.txt'
 
@@ -230,7 +248,12 @@ def test_mounted_dir(test_container, ignored_dir, server):
     server.wait_events([event])
 
 
-def test_unmonitored_mounted_dir(test_container, test_file, server):
+def test_unmonitored_mounted_dir(
+    test_container: docker.models.containers.Container,
+    test_file: str,
+    server: FileActivityService,
+):
+    assert test_container.id is not None
     # File Under Test
     fut = '/unmonitored/test.txt'
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
 import os
+
+import docker
+import docker.models.containers
+import docker.models.images
+import pytest
 
 from conftest import dump_logs
 from event import Event, EventType, Process
-
-import pytest
+from server import FileActivityService
 
 
 @pytest.fixture
-def build_self_deleter(docker_client):
+def build_self_deleter(docker_client: docker.DockerClient):
     image, _ = docker_client.images.build(
         path='containers/self-deleter',
         tag='self-deleter:latest',
@@ -18,11 +24,11 @@ def build_self_deleter(docker_client):
 
 @pytest.fixture
 def run_self_deleter(
-    fact,
-    monitored_dir,
-    logs_dir,
-    docker_client,
-    build_self_deleter,
+    fact: docker.models.containers.Container,
+    monitored_dir: str,
+    logs_dir: str,
+    docker_client: docker.DockerClient,
+    build_self_deleter: docker.models.images.Image,
 ):
     image = build_self_deleter.tags[0]
     container = docker_client.containers.run(
@@ -47,10 +53,10 @@ def run_self_deleter(
 
 
 def test_d_path_sanitization(
-    monitored_dir,
-    server,
-    run_self_deleter,
-    docker_client,
+    monitored_dir: str,
+    server: FileActivityService,
+    run_self_deleter: docker.models.containers.Container,
+    docker_client: docker.DockerClient,
 ):
     """
     Ensure the sanitization of paths obtained by calling the bpf_d_path
@@ -62,6 +68,7 @@ def test_d_path_sanitization(
     host_path = os.path.join(monitored_dir, 'test.txt')
 
     container = run_self_deleter
+    assert container.id is not None
 
     process = Process.in_container(
         exe_path='/usr/local/bin/self-deleter',

--- a/tests/test_path_chmod.py
+++ b/tests/test_path_chmod.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import multiprocessing as mp
 import os
+from multiprocessing.synchronize import Event as MpEvent
 
+import docker.models.containers
 import pytest
 
-from utils import join_path_with_filename, path_to_string
 from event import Event, EventType, Process
+from server import FileActivityService
+from utils import join_path_with_filename, path_to_string
 
 
 @pytest.mark.parametrize(
@@ -18,7 +23,11 @@ from event import Event, EventType, Process
         b'perm\xff\xfe.txt',
     ],
 )
-def test_chmod(monitored_dir, server, filename):
+def test_chmod(
+    monitored_dir: str,
+    server: FileActivityService,
+    filename: str | bytes,
+):
     """
     Tests changing permissions on a file and verifies the corresponding
     event is captured by the server
@@ -61,7 +70,7 @@ def test_chmod(monitored_dir, server, filename):
     server.wait_events(events)
 
 
-def test_multiple(monitored_dir, server):
+def test_multiple(monitored_dir: str, server: FileActivityService):
     """
     Tests modifying permissions on multiple files.
 
@@ -100,7 +109,7 @@ def test_multiple(monitored_dir, server):
     server.wait_events(events)
 
 
-def test_ignored(test_file, ignored_dir, server):
+def test_ignored(test_file: str, ignored_dir: str, server: FileActivityService):
     """
     Tests that permission events on ignored files are not captured.
 
@@ -132,7 +141,7 @@ def test_ignored(test_file, ignored_dir, server):
     server.wait_events([e])
 
 
-def do_test(fut: str, mode: int, stop_event: mp.Event):
+def do_test(fut: str, mode: int, stop_event: MpEvent):
     with open(fut, 'w') as f:
         f.write('This is a test')
     os.chmod(fut, mode)
@@ -141,7 +150,7 @@ def do_test(fut: str, mode: int, stop_event: mp.Event):
     stop_event.wait()
 
 
-def test_external_process(monitored_dir, server):
+def test_external_process(monitored_dir: str, server: FileActivityService):
     """
     Tests permission change of a file by an external process and
     verifies that the corresponding event is captured by the server.
@@ -182,7 +191,10 @@ def test_external_process(monitored_dir, server):
         proc.join(1)
 
 
-def test_overlay(test_container, server):
+def test_overlay(
+    test_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
     """
     Test permission changes on an overlayfs file (inside a container)
 
@@ -190,6 +202,7 @@ def test_overlay(test_container, server):
         test_container: A container for running commands in.
         server: The server instance to communicate with.
     """
+    assert test_container.id is not None
     # File Under Test
     fut = '/container-dir/test.txt'
     mode = '666'
@@ -229,15 +242,21 @@ def test_overlay(test_container, server):
     server.wait_events(events)
 
 
-def test_mounted_dir(test_container, ignored_dir, server):
+def test_mounted_dir(
+    test_container: docker.models.containers.Container,
+    ignored_dir: str,
+    server: FileActivityService,
+):
     """
     Test permission changes on a file bind mounted into a container
 
     Args:
         test_container: A container for running commands in.
-        ignored_dir: This directory is ignored on the host, and mounted to the container.
+        ignored_dir: This directory is ignored on the host,
+            and mounted to the container.
         server: The server instance to communicate with.
     """
+    assert test_container.id is not None
     # File Under Test
     fut = '/mounted/test.txt'
     mode = '666'
@@ -278,7 +297,11 @@ def test_mounted_dir(test_container, ignored_dir, server):
     server.wait_events(events)
 
 
-def test_unmonitored_mounted_dir(test_container, test_file, server):
+def test_unmonitored_mounted_dir(
+    test_container: docker.models.containers.Container,
+    test_file: str,
+    server: FileActivityService,
+):
     """
     Test permission changes on a file bind mounted to a container and
     monitored on the host.
@@ -288,6 +311,7 @@ def test_unmonitored_mounted_dir(test_container, test_file, server):
         test_file: File monitored on the host, mounted to the container.
         server: The server instance to communicate with.
     """
+    assert test_container.id is not None
     # File Under Test
     # The path corresponds to the container, `test_file` is the path on
     # host. Events on this path will trigger via inode tracking.

--- a/tests/test_path_chown.py
+++ b/tests/test_path_chown.py
@@ -1,10 +1,11 @@
-import os
-import shlex
+from __future__ import annotations
 
+import docker.models.containers
 import pytest
 
-from utils import path_to_string, rust_style_quote
 from event import Event, EventType, Process
+from server import FileActivityService
+from utils import path_to_string, rust_style_quote
 
 # Tests here have to use a container to do 'chown',
 # otherwise they would require to run as root.
@@ -25,7 +26,11 @@ TEST_GID = 2345
         b'own\xff\xfe.txt',
     ],
 )
-def test_chown(test_container, server, filename):
+def test_chown(
+    test_container: docker.models.containers.Container,
+    server: FileActivityService,
+    filename: str | bytes,
+):
     """
     Execute a chown operation on a file and verifies the corresponding event is
     captured by the server.
@@ -35,6 +40,7 @@ def test_chown(test_container, server, filename):
         server: The server instance to communicate with.
         filename: Name of the file to create (includes UTF-8 test cases).
     """
+    assert test_container.id is not None
 
     # File Under Test
     fut = f'/container-dir/{path_to_string(filename)}'
@@ -80,7 +86,10 @@ def test_chown(test_container, server, filename):
     server.wait_events(events)
 
 
-def test_multiple(test_container, server):
+def test_multiple(
+    test_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
     """
     Tests ownership operations on multiple files and verifies the corresponding
     events are captured by the server.
@@ -89,6 +98,7 @@ def test_multiple(test_container, server):
         test_container: A container for running commands in.
         server: The server instance to communicate with.
     """
+    assert test_container.id is not None
     events = []
 
     # File Under Test
@@ -134,7 +144,10 @@ def test_multiple(test_container, server):
     server.wait_events(events)
 
 
-def test_ignored(test_container, server):
+def test_ignored(
+    test_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
     """
     Tests that ownership events on ignored files are not captured by the
     server.
@@ -143,6 +156,7 @@ def test_ignored(test_container, server):
         test_container: A container for running commands in.
         server: The server instance to communicate with.
     """
+    assert test_container.id is not None
     ignored_file = '/test.txt'
     monitored_file = '/container-dir/test.txt'
 
@@ -188,7 +202,10 @@ def test_ignored(test_container, server):
     server.wait_events(events=events)
 
 
-def test_no_change(test_container, server):
+def test_no_change(
+    test_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
     """
     Tests that chown to the same UID/GID triggers events for all calls.
 
@@ -196,6 +213,7 @@ def test_no_change(test_container, server):
         test_container: A container for running commands in.
         server: The server instance to communicate with.
     """
+    assert test_container.id is not None
     # File Under Test
     fut = '/container-dir/test.txt'
 

--- a/tests/test_path_mkdir.py
+++ b/tests/test_path_mkdir.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import os
 
 import pytest
 
 from event import Event, EventType, Process
+from server import FileActivityService
 
 
 @pytest.mark.parametrize(
@@ -14,7 +17,11 @@ from event import Event, EventType, Process
         pytest.param('日本語', id='Japanese'),
     ],
 )
-def test_mkdir_nested(monitored_dir, server, dirname):
+def test_mkdir_nested(
+    monitored_dir: str,
+    server: FileActivityService,
+    dirname: str,
+):
     """
     Tests that creating nested directories tracks all inodes correctly.
 
@@ -48,7 +55,11 @@ def test_mkdir_nested(monitored_dir, server, dirname):
     server.wait_events(events)
 
 
-def test_mkdir_ignored(monitored_dir, ignored_dir, server):
+def test_mkdir_ignored(
+    monitored_dir: str,
+    ignored_dir: str,
+    server: FileActivityService,
+):
     """
     Tests that directories created outside monitored paths are ignored.
 
@@ -73,7 +84,8 @@ def test_mkdir_ignored(monitored_dir, ignored_dir, server):
     with open(monitored_file, 'w') as f:
         f.write('monitored')
 
-    # Only the monitored file should generate an event (directories are tracked internally)
+    # Only the monitored file should generate an event
+    # (directories are tracked internally)
     e = Event(
         process=process,
         event_type=EventType.CREATION,

--- a/tests/test_path_rename.py
+++ b/tests/test_path_rename.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import os
 
+import docker.models.containers
 import pytest
 
-from utils import join_path_with_filename, path_to_string
 from event import Event, EventType, Process
+from server import FileActivityService
+from utils import join_path_with_filename, path_to_string
 
 
 @pytest.mark.parametrize(
@@ -17,7 +21,11 @@ from event import Event, EventType, Process
         pytest.param(b'test\xff\xfe.txt', id='Invalid'),
     ],
 )
-def test_rename(monitored_dir, server, filename):
+def test_rename(
+    monitored_dir: str,
+    server: FileActivityService,
+    filename: str | bytes,
+):
     """
     Tests the renaming of a file and verifies that the corresponding
     events are captured by the server.
@@ -68,7 +76,11 @@ def test_rename(monitored_dir, server, filename):
     )
 
 
-def test_ignored(monitored_dir, ignored_dir, server):
+def test_ignored(
+    monitored_dir: str,
+    ignored_dir: str,
+    server: FileActivityService,
+):
     """
     Tests that rename events on ignored files are not captured by the
     server.
@@ -122,7 +134,9 @@ def test_ignored(monitored_dir, ignored_dir, server):
     )
 
 
-def test_rename_dir(monitored_dir, ignored_dir, server):
+def test_rename_dir(
+    monitored_dir: str, ignored_dir: str, server: FileActivityService
+):
     """
     Test renaming a directory is caught
 
@@ -139,7 +153,9 @@ def test_rename_dir(monitored_dir, ignored_dir, server):
         server: The server instance to communicate with.
     """
 
-    def touch_test_files(directory, process=None) -> list[Event]:
+    def touch_test_files(
+        directory: str, process: Process | None = None
+    ) -> list[Event]:
         events = []
         for i in range(3):
             with open(os.path.join(directory, f'{i}.txt'), 'w') as f:
@@ -221,7 +237,7 @@ def test_rename_dir(monitored_dir, ignored_dir, server):
 
 
 @pytest.mark.parametrize(
-    'from_monitored,to_monitored',
+    ('from_monitored', 'to_monitored'),
     [
         pytest.param(True, True, id='both_monitored'),
         pytest.param(False, True, id='target_monitored'),
@@ -229,11 +245,11 @@ def test_rename_dir(monitored_dir, ignored_dir, server):
     ],
 )
 def test_rename_overwrite(
-    from_monitored,
-    to_monitored,
-    monitored_dir,
-    ignored_dir,
-    server,
+    from_monitored: bool,
+    to_monitored: bool,
+    monitored_dir: str,
+    ignored_dir: str,
+    server: FileActivityService,
 ):
     events = []
     p = Process.from_proc()
@@ -296,7 +312,11 @@ def test_rename_overwrite(
     server.wait_events(events)
 
 
-def test_overlay(test_container, server):
+def test_overlay(
+    test_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert test_container.id is not None
     # File Under Test
     fut = '/container-dir/test.txt'
     new_fut = '/container-dir/rename.txt'
@@ -337,7 +357,12 @@ def test_overlay(test_container, server):
     server.wait_events(events)
 
 
-def test_mounted_dir(test_container, ignored_dir, server):
+def test_mounted_dir(
+    test_container: docker.models.containers.Container,
+    ignored_dir: str,
+    server: FileActivityService,
+):
+    assert test_container.id is not None
     # File Under Test
     fut = '/mounted/test.txt'
     new_fut = '/mounted/rename.txt'
@@ -379,7 +404,11 @@ def test_mounted_dir(test_container, ignored_dir, server):
     server.wait_events(events)
 
 
-def test_cross_mountpoints(test_container, monitored_dir, server):
+def test_cross_mountpoints(
+    test_container: docker.models.containers.Container,
+    monitored_dir: str,
+    server: FileActivityService,
+):
     """
     Attempt to rename files/directories across mountpoints
 
@@ -388,6 +417,7 @@ def test_cross_mountpoints(test_container, monitored_dir, server):
     defintely not triggered when an inode crosses a mount point, so it
     doesn't fit but it kind of does? ¯\\_(ツ)_/¯
     """
+    assert test_container.id is not None
     mounted_file = '/unmonitored/test.txt'
     host_path = os.path.join(monitored_dir, 'test.txt')
     ovfs_file = '/container-dir/test.txt'

--- a/tests/test_path_rmdir.py
+++ b/tests/test_path_rmdir.py
@@ -1,21 +1,26 @@
+from __future__ import annotations
+
 import os
 import shutil
 
 import pytest
 
 from event import Event, EventType, Process
+from server import FileActivityService
 from utils import get_metric_value
 
 
-def get_inode_removed_count(fact_config):
+def get_inode_removed_count(fact_config: tuple[dict, str]):
     """
     Query Prometheus metrics to get the count of removed inodes.
 
     Args:
-        fact_config: The fact configuration tuple (config dict, config file path).
+        fact_config: The fact configuration tuple
+            (config dict, config file path).
 
     Returns:
-        The current value of host_scanner_scan{label="InodeRemoved"} metric.
+        The current value of
+        host_scanner_scan{label="InodeRemoved"} metric.
     """
     value = get_metric_value(
         fact_config,
@@ -25,12 +30,14 @@ def get_inode_removed_count(fact_config):
     return int(value) if value is not None else 0
 
 
-def get_kernel_rmdir_processed(fact_config):
+def get_kernel_rmdir_processed(fact_config: tuple[dict, str]):
     """
-    Query Prometheus metrics to get the count of processed (non-ignored) rmdir events.
+    Query Prometheus metrics to get the count of processed
+    (non-ignored) rmdir events.
 
     Args:
-        fact_config: The fact configuration tuple (config dict, config file path).
+        fact_config: The fact configuration tuple
+            (config dict, config file path).
 
     Returns:
         The difference between Total and Ignored kernel_path_rmdir_events.
@@ -61,11 +68,17 @@ def get_kernel_rmdir_processed(fact_config):
         pytest.param('日本語', id='Japanese'),
     ],
 )
-def test_rmdir_empty(monitored_dir, server, fact_config, dirname):
+def test_rmdir_empty(
+    monitored_dir: str,
+    server: FileActivityService,
+    fact_config: tuple[dict, str],
+    dirname: str,
+):
     """
     Tests that removing an empty directory properly cleans up inode tracking.
 
-    Scenario: File is removed first, leaving an empty directory, then rmdir is called.
+    Scenario: File is removed first, leaving an empty directory,
+    then rmdir is called.
 
     We use exact delta matching because:
     - Each test has an isolated monitored_dir
@@ -141,11 +154,17 @@ def test_rmdir_empty(monitored_dir, server, fact_config, dirname):
     )
 
 
-def test_rmdir_recursive(monitored_dir, server, fact_config):
+def test_rmdir_recursive(
+    monitored_dir: str,
+    server: FileActivityService,
+    fact_config: tuple[dict, str],
+):
     """
-    Tests that removing a directory tree recursively cleans up all inode tracking.
+    Tests that removing a directory tree recursively cleans up
+    all inode tracking.
 
-    Scenario: Directory with nested subdirectories and files is removed recursively
+    Scenario: Directory with nested subdirectories and files is
+    removed recursively
     using the rm -rf command via subprocess.
 
     This tests that all inodes (both files and directories) are properly removed
@@ -243,16 +262,23 @@ def test_rmdir_recursive(monitored_dir, server, fact_config):
     kernel_delta = final_kernel_rmdir - initial_kernel_rmdir
 
     assert inode_delta == 6, (
-        f'Expected exactly 6 inodes removed (3 files + 3 dirs), got {inode_delta}'
+        'Expected exactly 6 inodes removed '
+        f'(3 files + 3 dirs), got {inode_delta}'
     )
     assert kernel_delta == 3, (
         f'Expected exactly 3 kernel rmdir events processed, got {kernel_delta}'
     )
 
 
-def test_rmdir_ignored(monitored_dir, ignored_dir, server, fact_config):
+def test_rmdir_ignored(
+    monitored_dir: str,
+    ignored_dir: str,
+    server: FileActivityService,
+    fact_config: tuple[dict, str],
+):
     """
-    Tests that directories removed outside monitored paths don't affect tracking.
+    Tests that directories removed outside monitored paths
+    don't affect tracking.
 
     Verifies that inode_removed metric only increments for monitored paths.
 
@@ -275,7 +301,8 @@ def test_rmdir_ignored(monitored_dir, ignored_dir, server, fact_config):
     with open(ignored_file, 'w') as f:
         f.write('ignored')
 
-    # Remove ignored file and directory - should NOT generate events or increment metrics
+    # Remove ignored file and directory - should NOT
+    # generate events or increment metrics
     os.remove(ignored_file)
     os.rmdir(ignored_subdir)
 
@@ -283,10 +310,11 @@ def test_rmdir_ignored(monitored_dir, ignored_dir, server, fact_config):
     inode_after_ignored = get_inode_removed_count(fact_config)
     kernel_after_ignored = get_kernel_rmdir_processed(fact_config)
     assert inode_after_ignored == initial_inode_removed, (
-        f'Ignored path operations should not increment inode_removed metric'
+        'Ignored path operations should not increment inode_removed metric'
     )
     assert kernel_after_ignored == initial_kernel_rmdir, (
-        f'Ignored path operations should not increment kernel_rmdir_processed metric'
+        'Ignored path operations should not increment '
+        'kernel_rmdir_processed metric'
     )
 
     # Create and remove directory in monitored path
@@ -329,19 +357,24 @@ def test_rmdir_ignored(monitored_dir, ignored_dir, server, fact_config):
     kernel_delta = final_kernel_rmdir - initial_kernel_rmdir
 
     assert inode_delta == 2, (
-        f'Expected exactly 2 inodes removed from monitored path, got {inode_delta}'
+        'Expected exactly 2 inodes removed '
+        f'from monitored path, got {inode_delta}'
     )
     assert kernel_delta == 1, (
         f'Expected exactly 1 kernel rmdir event processed, got {kernel_delta}'
     )
 
 
-def test_rmdir_with_parent_inode(monitored_dir, server, fact_config):
+def test_rmdir_with_parent_inode(
+    monitored_dir: str,
+    server: FileActivityService,
+    fact_config: tuple[dict, str],
+):
     """
     Tests that directory deletion properly handles parent inode relationships.
 
-    This is important because after deleting a subdirectory, the parent directory
-    should still be tracked and able to track new files created in it.
+    This is important because after deleting a subdirectory, the parent
+    directory should still be tracked and able to track new files created in it.
 
     Args:
         monitored_dir: Temporary directory path for creating test directories.

--- a/tests/test_path_unlink.py
+++ b/tests/test_path_unlink.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import multiprocessing as mp
 import os
+from multiprocessing.synchronize import Event as MpEvent
 
-import docker
+import docker.models.containers
 import pytest
 
-from utils import join_path_with_filename, path_to_string
 from event import Event, EventType, Process
+from server import FileActivityService
+from utils import join_path_with_filename, path_to_string
 
 
 @pytest.mark.parametrize(
@@ -19,7 +23,11 @@ from event import Event, EventType, Process
         b'rm\xff\xfe.txt',
     ],
 )
-def test_remove(monitored_dir, server, filename):
+def test_remove(
+    monitored_dir: str,
+    server: FileActivityService,
+    filename: str | bytes,
+):
     """
     Tests the removal of a file and verifies the corresponding event is
     captured by the server.
@@ -27,7 +35,8 @@ def test_remove(monitored_dir, server, filename):
     Args:
         monitored_dir: Temporary directory path for creating the test file.
         server: The server instance to communicate with.
-        filename: Name of the file to create and remove (includes UTF-8 test cases).
+        filename: Name of the file to create and remove
+            (includes UTF-8 test cases).
     """
 
     # File under test
@@ -40,7 +49,8 @@ def test_remove(monitored_dir, server, filename):
     # Remove the file
     os.remove(fut)
 
-    # Convert test_file to string for the Event, replacing invalid UTF-8 with U+FFFD
+    # Convert test_file to string for the Event,
+    # replacing invalid UTF-8 with U+FFFD
     fut = path_to_string(fut)
 
     process = Process.from_proc()
@@ -63,7 +73,7 @@ def test_remove(monitored_dir, server, filename):
     server.wait_events(events)
 
 
-def test_multiple(monitored_dir, server):
+def test_multiple(monitored_dir: str, server: FileActivityService):
     """
     Tests the removal of multiple files and verifies the corresponding
     events are captured by the server.
@@ -102,7 +112,7 @@ def test_multiple(monitored_dir, server):
     server.wait_events(events)
 
 
-def test_ignored(test_file, ignored_dir, server):
+def test_ignored(test_file: str, ignored_dir: str, server: FileActivityService):
     """
     Tests that unlink events on ignored files are not captured by the
     server.
@@ -133,7 +143,7 @@ def test_ignored(test_file, ignored_dir, server):
     server.wait_events([e])
 
 
-def do_test(fut: str, stop_event: mp.Event):
+def do_test(fut: str, stop_event: MpEvent):
     with open(fut, 'w') as f:
         f.write('This is a test')
     os.remove(fut)
@@ -142,7 +152,7 @@ def do_test(fut: str, stop_event: mp.Event):
     stop_event.wait()
 
 
-def test_external_process(monitored_dir, server):
+def test_external_process(monitored_dir: str, server: FileActivityService):
     """
     Tests the removal of a file by an external process and verifies that
     the corresponding event is captured by the server.
@@ -180,7 +190,11 @@ def test_external_process(monitored_dir, server):
         proc.join(1)
 
 
-def test_overlay(test_container, server):
+def test_overlay(
+    test_container: docker.models.containers.Container,
+    server: FileActivityService,
+):
+    assert test_container.id is not None
     # File Under Test
     fut = '/container-dir/test.txt'
 
@@ -218,7 +232,12 @@ def test_overlay(test_container, server):
     server.wait_events(events)
 
 
-def test_mounted_dir(test_container, ignored_dir, server):
+def test_mounted_dir(
+    test_container: docker.models.containers.Container,
+    ignored_dir: str,
+    server: FileActivityService,
+):
+    assert test_container.id is not None
     # File Under Test
     fut = '/mounted/test.txt'
 
@@ -257,7 +276,12 @@ def test_mounted_dir(test_container, ignored_dir, server):
     server.wait_events(events)
 
 
-def test_unmonitored_mounted_dir(test_container, test_file, server):
+def test_unmonitored_mounted_dir(
+    test_container: docker.models.containers.Container,
+    test_file: str,
+    server: FileActivityService,
+):
+    assert test_container.id is not None
     # File Under Test
     fut = '/unmonitored/test.txt'
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,16 +1,24 @@
+from __future__ import annotations
+
 import os
 import time
 from time import sleep
 
+import docker.models.containers
 import pytest
 import requests
 import yaml
 
 from event import Event, EventType, Process
+from server import FileActivityService
 
 
 @pytest.fixture
-def rate_limited_config(fact, fact_config, monitored_dir):
+def rate_limited_config(
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+    monitored_dir: str,
+):
     """
     Configure rate limiting after fact has started, then hot-reload.
     Sets rate_limit to 10 events/second.
@@ -25,7 +33,11 @@ def rate_limited_config(fact, fact_config, monitored_dir):
     return config, config_file
 
 
-def test_rate_limit_drops_events(rate_limited_config, monitored_dir, server):
+def test_rate_limit_drops_events(
+    rate_limited_config: tuple[dict, str],
+    monitored_dir: str,
+    server: FileActivityService,
+):
     """
     Test that the rate limiter drops events when the rate limit is exceeded.
     """
@@ -51,7 +63,8 @@ def test_rate_limit_drops_events(rate_limited_config, monitored_dir, server):
     print(f'Received {received_count} events out of {num_files}')
 
     assert received_count < num_files, (
-        f'Expected rate limiting to drop some events, but received all {received_count}'
+        'Expected rate limiting to drop some events, '
+        f'but received all {received_count}'
     )
 
     metrics_response = requests.get(
@@ -83,7 +96,11 @@ def test_rate_limit_drops_events(rate_limited_config, monitored_dir, server):
     )
 
 
-def test_rate_limit_unlimited(monitored_dir, server, fact_config):
+def test_rate_limit_unlimited(
+    monitored_dir: str,
+    server: FileActivityService,
+    fact_config: tuple[dict, str],
+):
     """
     Test that the default config (rate_limit=0) allows all events through.
     """
@@ -124,5 +141,6 @@ def test_rate_limit_unlimited(monitored_dir, server, fact_config):
                 break
 
     assert dropped_count == 0, (
-        f'Expected no dropped events with unlimited rate limiting, but got {dropped_count}'
+        'Expected no dropped events with unlimited '
+        f'rate limiting, but got {dropped_count}'
     )

--- a/tests/test_wildcard.py
+++ b/tests/test_wildcard.py
@@ -1,14 +1,22 @@
-from time import sleep
-import os
+from __future__ import annotations
 
+import os
+from time import sleep
+
+import docker.models.containers
 import pytest
 import yaml
 
 from event import Event, EventType, Process
+from server import FileActivityService
 
 
 @pytest.fixture
-def wildcard_config(fact, fact_config, monitored_dir):
+def wildcard_config(
+    fact: docker.models.containers.Container,
+    fact_config: tuple[dict, str],
+    monitored_dir: str,
+):
     config, config_file = fact_config
     config['paths'] = [
         f'{monitored_dir}/**/*.txt',
@@ -24,7 +32,11 @@ def wildcard_config(fact, fact_config, monitored_dir):
     return config, config_file
 
 
-def test_extension_wildcard(wildcard_config, monitored_dir, server):
+def test_extension_wildcard(
+    wildcard_config: tuple[dict, str],
+    monitored_dir: str,
+    server: FileActivityService,
+):
     process = Process.from_proc()
 
     # Should not match any pattern
@@ -36,8 +48,9 @@ def test_extension_wildcard(wildcard_config, monitored_dir, server):
     with open(txt_file, 'w') as f:
         f.write('This should be captured')
 
-    # TODO: host_path is empty because wildcard patterns don't include the parent
-    # directory, so the parent inode isn't tracked for path construction
+    # TODO: host_path is empty because wildcard patterns
+    # don't include the parent directory, so the parent
+    # inode isn't tracked for path construction
     e = Event(
         process=process,
         event_type=EventType.CREATION,
@@ -48,7 +61,11 @@ def test_extension_wildcard(wildcard_config, monitored_dir, server):
     server.wait_events([e])
 
 
-def test_prefix_wildcard(wildcard_config, monitored_dir, server):
+def test_prefix_wildcard(
+    wildcard_config: tuple[dict, str],
+    monitored_dir: str,
+    server: FileActivityService,
+):
     process = Process.from_proc()
 
     # Wrong prefix - should not match
@@ -60,8 +77,9 @@ def test_prefix_wildcard(wildcard_config, monitored_dir, server):
     with open(test_log, 'w') as f:
         f.write('This should be captured')
 
-    # TODO: host_path is empty because wildcard patterns don't include the parent
-    # directory, so the parent inode isn't tracked for path construction
+    # TODO: host_path is empty because wildcard patterns
+    # don't include the parent directory, so the parent
+    # inode isn't tracked for path construction
     e = Event(
         process=process,
         event_type=EventType.CREATION,
@@ -72,7 +90,11 @@ def test_prefix_wildcard(wildcard_config, monitored_dir, server):
     server.wait_events([e])
 
 
-def test_recursive_wildcard(wildcard_config, monitored_dir, server):
+def test_recursive_wildcard(
+    wildcard_config: tuple[dict, str],
+    monitored_dir: str,
+    server: FileActivityService,
+):
     process = Process.from_proc()
 
     nested_dir = os.path.join(monitored_dir, 'level1', 'level2')
@@ -91,8 +113,9 @@ def test_recursive_wildcard(wildcard_config, monitored_dir, server):
     with open(nested_txt, 'w') as f:
         f.write('Nested txt')
 
-    # TODO: host_path is empty because wildcard patterns don't include the parent
-    # directory, so the parent inode isn't tracked for path construction
+    # TODO: host_path is empty because wildcard patterns
+    # don't include the parent directory, so the parent
+    # inode isn't tracked for path construction
     events = [
         Event(
             process=process,
@@ -111,15 +134,20 @@ def test_recursive_wildcard(wildcard_config, monitored_dir, server):
     server.wait_events(events)
 
 
-def test_nonrecursive_wildcard(wildcard_config, monitored_dir, server):
+def test_nonrecursive_wildcard(
+    wildcard_config: tuple[dict, str],
+    monitored_dir: str,
+    server: FileActivityService,
+):
     process = Process.from_proc()
 
     fut = os.path.join(monitored_dir, 'app.conf')
     with open(fut, 'w') as f:
         f.write('This should be captured')
 
-    # TODO: host_path is empty because wildcard patterns don't include the parent
-    # directory, so the parent inode isn't tracked for path construction
+    # TODO: host_path is empty because wildcard patterns
+    # don't include the parent directory, so the parent
+    # inode isn't tracked for path construction
     e = Event(
         process=process,
         event_type=EventType.CREATION,
@@ -130,7 +158,11 @@ def test_nonrecursive_wildcard(wildcard_config, monitored_dir, server):
     server.wait_events([e])
 
 
-def test_multiple_patterns(wildcard_config, monitored_dir, server):
+def test_multiple_patterns(
+    wildcard_config: tuple[dict, str],
+    monitored_dir: str,
+    server: FileActivityService,
+):
     process = Process.from_proc()
 
     # Matches no pattern
@@ -146,8 +178,9 @@ def test_multiple_patterns(wildcard_config, monitored_dir, server):
     with open(log_file, 'w') as f:
         f.write('Log file')
 
-    # TODO: host_path is empty because wildcard patterns don't include the parent
-    # directory, so the parent inode isn't tracked for path construction
+    # TODO: host_path is empty because wildcard patterns
+    # don't include the parent directory, so the parent
+    # inode isn't tracked for path construction
     events = [
         Event(
             process=process,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import os
 import re
 
 import requests
 
 
-def join_path_with_filename(directory, filename):
+def join_path_with_filename(directory: str, filename: str | bytes):
     """
     Join a directory path with a filename, handling bytes filenames properly.
 
@@ -24,7 +26,7 @@ def join_path_with_filename(directory, filename):
         return os.path.join(directory, filename)
 
 
-def path_to_string(path):
+def path_to_string(path: str | bytes):
     """
     Convert a filesystem path to string, replacing invalid UTF-8 with U+FFFD.
 
@@ -35,7 +37,8 @@ def path_to_string(path):
         path: Filesystem path (str or bytes)
 
     Returns:
-        String representation with invalid UTF-8 replaced by replacement character
+        String representation with invalid UTF-8
+        replaced by replacement character
     """
     if isinstance(path, bytes):
         return path.decode('utf-8', errors='replace')
@@ -43,7 +46,7 @@ def path_to_string(path):
         return path
 
 
-def rust_style_quote(s):
+def rust_style_quote(s: str):
     """
     Quote a string in the manner of shlex::try_join() rust function.
 
@@ -57,14 +60,14 @@ def rust_style_quote(s):
         return "''"
     if re.search(r'[^a-zA-Z0-9_.:/-]', s):
         # Try to match the behavior of shlex.try_join()
-        if "'" in s and not '"' in s:
+        if "'" in s and '"' not in s:
             return f'"{s}"'
         escaped = s.replace("'", "\\'")
         return f"'{escaped}'"
     return s
 
 
-def rust_style_join(args):
+def rust_style_join(args: list[str]):
     """
     Concatenate arguments after quoting them. Each argument is separated
     by a single space.
@@ -75,14 +78,21 @@ def rust_style_join(args):
     return ' '.join(rust_style_quote(arg) for arg in args)
 
 
-def get_metric_value(fact_config, metric_name, labels=None):
+def get_metric_value(
+    fact_config: tuple[dict, str],
+    metric_name: str,
+    labels: dict[str, str] | None = None,
+):
     """
     Query Prometheus metrics endpoint to get the value of a metric.
 
     Args:
-        fact_config: The fact configuration tuple (config dict, config file path).
-        metric_name: Name of the metric to query (e.g., "host_scanner_scan").
-        labels: Optional dict of label filters (e.g., {"label": "InodeRemoved"}).
+        fact_config: The fact configuration tuple
+            (config dict, config file path).
+        metric_name: Name of the metric to query
+            (e.g., "host_scanner_scan").
+        labels: Optional dict of label filters
+            (e.g., {"label": "InodeRemoved"}).
 
     Returns:
         The metric value as a string if found, None otherwise.


### PR DESCRIPTION
## Description

This add linter checks via [ruff](https://docs.astral.sh/ruff/) and static type analysis with [pyright](https://github.com/microsoft/pyright). In order to make it easier to review, there are 2 commits in this PR:

* First one adds the required bits for running `ruff` and `pyright`, both on CI and locally.
* Second one fixes all reported issues.

Most of the issues were pretty trivial and were fixed with `ruff check --fix`, most invasive change is adding type annotations to all functions and methods so `pyright` can work properly.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run the new make targets locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Integrated automated linting and type checking into the CI pipeline for continuous validation of test code quality.
  * Added comprehensive type annotations across all integration tests to improve code robustness and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->