### PR TITLE
ROX-34502: read TLS certificates from disk on each gRPC connection attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ possible include a PR number for easier tracking.
 
 ## Next
 
+* ROX-34502: reload mTLS certificates on each gRPC connection attempt (#788)
 * chore: add formatting and linting to integration test code (#783, #784)
 * feat: add code coverage with cargo-llvm-cov and Codecov upload (#745)
 

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -121,10 +121,12 @@ impl Client {
     }
 
     async fn run(&mut self) -> anyhow::Result<bool> {
-        let connector = self.get_connector().await?;
         loop {
+            // Re-read certs on each connection attempt so rotated certificates
+            // on disk are picked up on the next reconnect.
+            let connector = self.get_connector().await?;
             info!("Attempting to connect to gRPC server...");
-            let channel = match self.create_channel(connector.clone()).await {
+            let channel = match self.create_channel(connector).await {
                 Ok(channel) => channel,
                 Err(e) => {
                     debug!("Failed to connect to server: {e:?}");


### PR DESCRIPTION
## Description

The gRPC client previously read mTLS certificates once per `run()` invocation and reused the same TLS connector for all reconnection attempts. After certificate rotation on disk, fact would keep using the old certs until a config change forced a full client restart.

Move `get_connector()` inside the reconnection loop so certificates are re-read from the configured directory (`ca.pem`, `cert.pem`, `key.pem`) on each connection attempt. Active streams are not dropped; new certs are used only when establishing the next connection (after a disconnect, stream error, or config reload).

In Kubernetes, secret volume mounts update atomically via a symlink swap, so all three cert files change together. There should be no race condition where fact reads a mix of old and new certificates.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested certificate hot-reloading end-to-end on a OpenShift cluster with StackRox installed via the operator.

### Setup

1. Enabled FACT in the SecuredCluster CR (`spec.perNode.fileActivityMonitoring.mode: Enabled`)
2. Generated a new collector certificate signed by the same CA (from `central-tls`), with a distinct CN (`COLLECTOR_SERVICE: regenerated-<timestamp>`) and fingerprint to distinguish it from the original
3. Scaled down the operator and real sensor
4. Deployed a **fake sensor**, a minimal gRPC server that only implements `FileActivityService.Communicate`, so every logged connection is guaranteed to be from FACT (not collector or compliance)

### Results

#### Baseline (mainline FACT, no hot-reload)

  | Step | Observed cert | Result |
  |---|---|---|
  | FACT connects to fake sensor | Original cert (`03d391ae...`) | OK |
  | Replace `tls-cert-collector` secret, wait, kill fake-sensor to force reconnect | Original cert (`03d391ae...`) | No hot-reload - FACT kept using the cert loaded at startup |

#### PR build (`quay.io/stackrox-io/fact:0.3.x-64-g94f0d82e55`)

  | Step | Observed cert | Result |
  |---|---|---|
  | FACT starts with regenerated cert in secret | Regenerated cert (`44e491aa...`) | Loaded at startup |
  | Swap secret to original, wait 2 minutes, kill fake-sensor | Original cert (`03d391ae...`) | Hot-reload works |
  | Swap secret back to regenerated, wait 2 minutes, kill fake-sensor | Regenerated cert (`44e491aa...`) | Hot-reload works |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * mTLS certificates are now reloaded on every gRPC connection attempt. This ensures the most recent certificate configuration is applied across retries, improving connection reliability after certificate or keystore updates and reducing connection failures caused by stale credentials. Connection retry behavior and logging remain consistent for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->