### PR TITLE
feat(grpc): add exponential backoff for reconnection attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ possible include a PR number for easier tracking.
 
 ## Next
 
+* feat(grpc): add exponential backoff for reconnection attempts (#789)
 * ROX-34502: reload mTLS certificates on each gRPC connection attempt (#788)
 * chore: add formatting and linting to integration test code (#783, #784)
 * feat: add code coverage with cargo-llvm-cov and Codecov upload (#745)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +354,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -454,6 +474,7 @@ dependencies = [
  "prometheus-client",
  "prost",
  "prost-types",
+ "rand 0.10.1",
  "regex",
  "serde",
  "serde_json",
@@ -606,6 +627,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -646,7 +668,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.9.3",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1342,7 +1364,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1352,7 +1385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1363,6 +1396,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-cpuid"
@@ -1427,7 +1466,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1605,10 +1644,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ openssl = "0.10.75"
 prometheus-client = { version = "0.24.0", default-features = false }
 prost = "0.14.0"
 prost-types = "0.14.0"
+rand = { version = "0.10.1", default-features = false, features = ["thread_rng"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 shlex = "2.0.1"

--- a/fact/Cargo.toml
+++ b/fact/Cargo.toml
@@ -28,6 +28,7 @@ tokio-stream = { workspace = true }
 prometheus-client = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shlex = { workspace = true }

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -16,43 +16,19 @@ pub mod reloader;
 #[cfg(test)]
 mod tests;
 
-fn yaml_to_duration_secs(v: &Yaml) -> Option<Duration> {
-    v.as_f64()
-        .or_else(|| v.as_i64().map(|i| i as f64))
-        .filter(|s| s.is_finite() && *s >= 0.0)
-        .map(Duration::from_secs_f64)
-}
-
-fn parse_duration_secs(s: &str) -> anyhow::Result<Duration> {
-    let f: f64 = s.parse()?;
-    if !f.is_finite() || f < 0.0 {
-        bail!("value must be a non-negative finite number, got {f}");
-    }
-    Ok(Duration::from_secs_f64(f))
-}
-
-fn parse_positive_duration_secs(s: &str) -> anyhow::Result<Duration> {
-    let d = parse_duration_secs(s)?;
-    if d.is_zero() {
-        bail!("value must be greater than zero");
-    }
-    Ok(d)
-}
-
-fn parse_multiplier(s: &str) -> anyhow::Result<f64> {
-    let mult = s.parse::<f64>()?;
-    if !mult.is_finite() || mult <= 1.0 {
-        bail!("multiplier must be > 1.0, got {mult}");
-    }
-    Ok(mult)
-}
-
 const CONFIG_FILES: [&str; 4] = [
     "/etc/stackrox/fact.yml",
     "/etc/stackrox/fact.yaml",
     "fact.yml",
     "fact.yaml",
 ];
+
+fn yaml_to_duration_secs(v: &Yaml) -> Option<Duration> {
+    v.as_f64()
+        .or_else(|| v.as_i64().map(|i| i as f64))
+        .filter(|s| s.is_finite() && *s >= 0.0)
+        .map(Duration::from_secs_f64)
+}
 
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct FactConfig {
@@ -250,10 +226,10 @@ impl TryFrom<Vec<Yaml>> for FactConfig {
                 }
                 "scan_interval" => {
                     // scan_interval == 0 disables the scanner
-                    config.scan_interval = Some(
-                        yaml_to_duration_secs(v)
-                            .with_context(|| format!("invalid scan_interval: {v:?}"))?,
-                    );
+                    let Some(scan_interval) = yaml_to_duration_secs(v) else {
+                        bail!("invalid scan_interval: {v:?}");
+                    };
+                    config.scan_interval = Some(scan_interval);
                 }
                 "rate_limit" => {
                     // rate_limit == 0 means unlimited (no throttling)
@@ -402,18 +378,16 @@ impl TryFrom<&yaml::Hash> for BackoffConfig {
             };
             match k {
                 "initial" => {
-                    backoff.initial = Some(
-                        yaml_to_duration_secs(v)
-                            .filter(|d| !d.is_zero())
-                            .with_context(|| format!("invalid grpc.backoff.initial: {v:?}"))?,
-                    );
+                    let Some(initial) = yaml_to_duration_secs(v).filter(|d| !d.is_zero()) else {
+                        bail!("invalid grpc.backoff.initial: {v:?}");
+                    };
+                    backoff.initial = Some(initial);
                 }
                 "max" => {
-                    backoff.max = Some(
-                        yaml_to_duration_secs(v)
-                            .filter(|d| !d.is_zero())
-                            .with_context(|| format!("invalid grpc.backoff.max: {v:?}"))?,
-                    );
+                    let Some(max) = yaml_to_duration_secs(v).filter(|d| !d.is_zero()) else {
+                        bail!("invalid grpc.backoff.max: {v:?}");
+                    };
+                    backoff.max = Some(max);
                 }
                 "jitter" => {
                     let Some(jitter) = v.as_bool() else {
@@ -422,14 +396,12 @@ impl TryFrom<&yaml::Hash> for BackoffConfig {
                     backoff.jitter = Some(jitter);
                 }
                 "multiplier" => {
-                    let multiplier = match v.as_f64().or_else(|| v.as_i64().map(|v| v as f64)) {
-                        Some(m) if !m.is_finite() || m <= 1.0 => {
-                            bail!("invalid grpc.backoff.multiplier: {v:?}")
-                        }
-                        None => {
-                            bail!("invalid grpc.backoff.multiplier: {v:?}")
-                        }
-                        Some(m) => m,
+                    let Some(multiplier) = v
+                        .as_f64()
+                        .or_else(|| v.as_i64().map(|v| v as f64))
+                        .filter(|mult| mult.is_finite() && *mult > 1.0)
+                    else {
+                        bail!("invalid grpc.backoff.multiplier: {v:?}");
                     };
                     backoff.multiplier = Some(multiplier);
                 }
@@ -571,6 +543,30 @@ impl TryFrom<&yaml::Hash> for BpfConfig {
     }
 }
 
+fn parse_duration_secs(s: &str) -> anyhow::Result<Duration> {
+    let f = s.parse::<f64>()?;
+    if !f.is_finite() || f < 0.0 {
+        bail!("value must be a non-negative finite number, got {f}");
+    }
+    Ok(Duration::from_secs_f64(f))
+}
+
+fn parse_positive_duration_secs(s: &str) -> anyhow::Result<Duration> {
+    let d = parse_duration_secs(s)?;
+    if d.is_zero() {
+        bail!("value must be greater than zero");
+    }
+    Ok(d)
+}
+
+fn parse_multiplier(s: &str) -> anyhow::Result<f64> {
+    let mult = s.parse::<f64>()?;
+    if !mult.is_finite() || mult <= 1.0 {
+        bail!("multiplier must be > 1.0, got {mult}");
+    }
+    Ok(mult)
+}
+
 #[derive(Debug, Parser)]
 #[clap(version = crate::version::FACT_VERSION, about)]
 pub struct FactCli {
@@ -607,14 +603,8 @@ pub struct FactCli {
     /// Enable jitter for gRPC reconnection backoff
     ///
     /// Default value is true
-    #[arg(long, overrides_with = "no_backoff_jitter", hide = true)]
-    backoff_jitter: bool,
-    #[arg(
-        long,
-        overrides_with = "backoff_jitter",
-        env = "FACT_GRPC_NO_BACKOFF_JITTER"
-    )]
-    no_backoff_jitter: bool,
+    #[arg(long, env = "FACT_GRPC_BACKOFF_JITTER")]
+    backoff_jitter: Option<bool>,
 
     /// The port to bind for all exposed endpoints
     #[arg(long, short, env = "FACT_ENDPOINT_ADDRESS")]
@@ -709,7 +699,7 @@ impl FactCli {
                 backoff: BackoffConfig {
                     initial: self.backoff_initial,
                     max: self.backoff_max,
-                    jitter: resolve_bool_arg(self.backoff_jitter, self.no_backoff_jitter),
+                    jitter: self.backoff_jitter,
                     multiplier: self.backoff_multiplier,
                 },
             },

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -585,13 +585,13 @@ pub struct FactCli {
     /// Initial backoff delay in seconds for gRPC reconnection
     ///
     /// Default value is 1 second
-    #[arg(long, env = "FACT_GRPC_BACKOFF_INITIAL", value_parser = parse_positive_duration_secs)]
+    #[arg(long, env = "FACT_GRPC_BACKOFF_INITIAL_DURATION", value_parser = parse_positive_duration_secs)]
     backoff_initial: Option<Duration>,
 
     /// Maximum backoff delay in seconds for gRPC reconnection
     ///
     /// Default value is 60 seconds
-    #[arg(long, env = "FACT_GRPC_BACKOFF_MAX", value_parser = parse_positive_duration_secs)]
+    #[arg(long, env = "FACT_GRPC_BACKOFF_MAX_DURATION", value_parser = parse_positive_duration_secs)]
     backoff_max: Option<Duration>,
 
     /// Backoff multiplier for gRPC reconnection

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -16,6 +16,29 @@ pub mod reloader;
 #[cfg(test)]
 mod tests;
 
+fn yaml_to_duration_secs(v: &Yaml) -> Option<Duration> {
+    v.as_f64()
+        .or_else(|| v.as_i64().map(|i| i as f64))
+        .filter(|s| s.is_finite() && *s >= 0.0)
+        .map(Duration::from_secs_f64)
+}
+
+fn parse_duration_secs(s: &str) -> anyhow::Result<Duration> {
+    let f: f64 = s.parse()?;
+    if !f.is_finite() || f < 0.0 {
+        bail!("value must be a non-negative finite number, got {f}");
+    }
+    Ok(Duration::from_secs_f64(f))
+}
+
+fn parse_positive_duration_secs(s: &str) -> anyhow::Result<Duration> {
+    let d = parse_duration_secs(s)?;
+    if d.is_zero() {
+        bail!("value must be greater than zero");
+    }
+    Ok(d)
+}
+
 const CONFIG_FILES: [&str; 4] = [
     "/etc/stackrox/fact.yml",
     "/etc/stackrox/fact.yaml",
@@ -218,20 +241,11 @@ impl TryFrom<Vec<Yaml>> for FactConfig {
                     config.hotreload = Some(hotreload);
                 }
                 "scan_interval" => {
-                    // scan_internal == 0 disables the scanner
-                    if let Some(scan_interval) = v.as_f64() {
-                        if scan_interval < 0.0 {
-                            bail!("invalid scan_interval: {scan_interval}");
-                        }
-                        config.scan_interval = Some(Duration::from_secs_f64(scan_interval));
-                    } else if let Some(scan_interval) = v.as_i64() {
-                        if scan_interval < 0 {
-                            bail!("invalid scan_interval: {scan_interval}");
-                        }
-                        config.scan_interval = Some(Duration::from_secs(scan_interval as u64))
-                    } else {
-                        bail!("scan_interval field has incorrect type: {v:?}");
-                    }
+                    // scan_interval == 0 disables the scanner
+                    config.scan_interval = Some(
+                        yaml_to_duration_secs(v)
+                            .with_context(|| format!("invalid scan_interval: {v:?}"))?,
+                    );
                 }
                 "rate_limit" => {
                     // rate_limit == 0 means unlimited (no throttling)
@@ -329,9 +343,66 @@ impl TryFrom<&yaml::Hash> for EndpointConfig {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct BackoffConfig {
+    initial: Option<Duration>,
+    max: Option<Duration>,
+}
+
+impl BackoffConfig {
+    fn update(&mut self, from: &BackoffConfig) {
+        if let Some(initial) = from.initial {
+            self.initial = Some(initial);
+        }
+        if let Some(max) = from.max {
+            self.max = Some(max);
+        }
+    }
+
+    pub fn initial(&self) -> Duration {
+        self.initial.unwrap_or(Duration::from_secs(1))
+    }
+
+    pub fn max(&self) -> Duration {
+        self.max.unwrap_or(Duration::from_secs(60))
+    }
+}
+
+impl TryFrom<&yaml::Hash> for BackoffConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &yaml::Hash) -> Result<Self, Self::Error> {
+        let mut backoff = BackoffConfig::default();
+        for (k, v) in value.iter() {
+            let Some(k) = k.as_str() else {
+                bail!("key is not string: {k:?}");
+            };
+            match k {
+                "initial" => {
+                    backoff.initial = Some(
+                        yaml_to_duration_secs(v)
+                            .filter(|d| !d.is_zero())
+                            .with_context(|| format!("invalid grpc.backoff.initial: {v:?}"))?,
+                    );
+                }
+                "max" => {
+                    backoff.max = Some(
+                        yaml_to_duration_secs(v)
+                            .filter(|d| !d.is_zero())
+                            .with_context(|| format!("invalid grpc.backoff.max: {v:?}"))?,
+                    );
+                }
+                name => bail!("Invalid field 'grpc.backoff.{name}' with value: {v:?}"),
+            }
+        }
+        Ok(backoff)
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct GrpcConfig {
     url: Option<String>,
     certs: Option<PathBuf>,
+    pub backoff: BackoffConfig,
 }
 
 impl GrpcConfig {
@@ -343,6 +414,8 @@ impl GrpcConfig {
         if let Some(certs) = from.certs.as_deref() {
             self.certs = Some(certs.to_owned());
         }
+
+        self.backoff.update(&from.backoff);
     }
 
     pub fn url(&self) -> Option<&str> {
@@ -376,6 +449,12 @@ impl TryFrom<&yaml::Hash> for GrpcConfig {
                         bail!("certs field has incorrect type: {v:?}");
                     };
                     grpc.certs = Some(PathBuf::from(certs));
+                }
+                "backoff" => {
+                    let Some(backoff) = v.as_hash() else {
+                        bail!("grpc.backoff section has incorrect type: {v:?}");
+                    };
+                    grpc.backoff = BackoffConfig::try_from(backoff)?;
                 }
                 name => bail!("Invalid field 'grpc.{name}' with value: {v:?}"),
             }
@@ -465,6 +544,18 @@ pub struct FactCli {
     #[arg(short, long, env = "FACT_CERTS")]
     certs: Option<PathBuf>,
 
+    /// Initial backoff delay in seconds for gRPC reconnection
+    ///
+    /// Default value is 1 second
+    #[arg(long, env = "FACT_GRPC_BACKOFF_INITIAL", value_parser = parse_positive_duration_secs)]
+    backoff_initial: Option<Duration>,
+
+    /// Maximum backoff delay in seconds for gRPC reconnection
+    ///
+    /// Default value is 60 seconds
+    #[arg(long, env = "FACT_GRPC_BACKOFF_MAX", value_parser = parse_positive_duration_secs)]
+    backoff_max: Option<Duration>,
+
     /// The port to bind for all exposed endpoints
     #[arg(long, short, env = "FACT_ENDPOINT_ADDRESS")]
     address: Option<SocketAddr>,
@@ -535,8 +626,8 @@ pub struct FactCli {
     /// The seconds can use a decimal point for fractions of seconds.
     ///
     /// Default value is 30 seconds
-    #[arg(long, short, env = "FACT_SCAN_INTERVAL")]
-    scan_interval: Option<f64>,
+    #[arg(long, short, env = "FACT_SCAN_INTERVAL", value_parser = parse_duration_secs)]
+    scan_interval: Option<Duration>,
 
     /// Maximum number of file events to allow per second
     ///
@@ -555,6 +646,10 @@ impl FactCli {
             grpc: GrpcConfig {
                 url: self.url.clone(),
                 certs: self.certs.clone(),
+                backoff: BackoffConfig {
+                    initial: self.backoff_initial,
+                    max: self.backoff_max,
+                },
             },
             endpoint: EndpointConfig {
                 address: self.address,
@@ -568,7 +663,7 @@ impl FactCli {
             skip_pre_flight: resolve_bool_arg(self.skip_pre_flight, self.no_skip_pre_flight),
             json: resolve_bool_arg(self.json, self.no_json),
             hotreload: resolve_bool_arg(self.hotreload, self.no_hotreload),
-            scan_interval: self.scan_interval.map(Duration::from_secs_f64),
+            scan_interval: self.scan_interval,
             rate_limit: self.rate_limit,
         }
     }

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -39,6 +39,14 @@ fn parse_positive_duration_secs(s: &str) -> anyhow::Result<Duration> {
     Ok(d)
 }
 
+fn parse_multiplier(s: &str) -> anyhow::Result<f64> {
+    let mult = s.parse::<f64>()?;
+    if !mult.is_finite() || mult <= 1.0 {
+        bail!("multiplier must be > 1.0, got {mult}");
+    }
+    Ok(mult)
+}
+
 const CONFIG_FILES: [&str; 4] = [
     "/etc/stackrox/fact.yml",
     "/etc/stackrox/fact.yaml",
@@ -46,7 +54,7 @@ const CONFIG_FILES: [&str; 4] = [
     "fact.yaml",
 ];
 
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct FactConfig {
     paths: Option<Vec<PathBuf>>,
     pub grpc: GrpcConfig,
@@ -342,11 +350,12 @@ impl TryFrom<&yaml::Hash> for EndpointConfig {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct BackoffConfig {
     initial: Option<Duration>,
     max: Option<Duration>,
     jitter: Option<bool>,
+    multiplier: Option<f64>,
 }
 
 impl BackoffConfig {
@@ -360,6 +369,9 @@ impl BackoffConfig {
         if let Some(jitter) = from.jitter {
             self.jitter = Some(jitter);
         }
+        if let Some(multiplier) = from.multiplier {
+            self.multiplier = Some(multiplier);
+        }
     }
 
     pub fn initial(&self) -> Duration {
@@ -372,6 +384,10 @@ impl BackoffConfig {
 
     pub fn jitter(&self) -> bool {
         self.jitter.unwrap_or(true)
+    }
+
+    pub fn multiplier(&self) -> f64 {
+        self.multiplier.unwrap_or(1.5)
     }
 }
 
@@ -405,6 +421,18 @@ impl TryFrom<&yaml::Hash> for BackoffConfig {
                     };
                     backoff.jitter = Some(jitter);
                 }
+                "multiplier" => {
+                    let multiplier = match v.as_f64().or_else(|| v.as_i64().map(|v| v as f64)) {
+                        Some(m) if !m.is_finite() || m <= 1.0 => {
+                            bail!("invalid grpc.backoff.multiplier: {v:?}")
+                        }
+                        None => {
+                            bail!("invalid grpc.backoff.multiplier: {v:?}")
+                        }
+                        Some(m) => m,
+                    };
+                    backoff.multiplier = Some(multiplier);
+                }
                 name => bail!("Invalid field 'grpc.backoff.{name}' with value: {v:?}"),
             }
         }
@@ -412,7 +440,7 @@ impl TryFrom<&yaml::Hash> for BackoffConfig {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct GrpcConfig {
     url: Option<String>,
     certs: Option<PathBuf>,
@@ -570,6 +598,12 @@ pub struct FactCli {
     #[arg(long, env = "FACT_GRPC_BACKOFF_MAX", value_parser = parse_positive_duration_secs)]
     backoff_max: Option<Duration>,
 
+    /// Backoff multiplier for gRPC reconnection
+    ///
+    /// Must be > 1.0. Default value is 1.5
+    #[arg(long, env = "FACT_GRPC_BACKOFF_MULTIPLIER", value_parser = parse_multiplier)]
+    backoff_multiplier: Option<f64>,
+
     /// Enable jitter for gRPC reconnection backoff
     ///
     /// Default value is true
@@ -676,6 +710,7 @@ impl FactCli {
                     initial: self.backoff_initial,
                     max: self.backoff_max,
                     jitter: resolve_bool_arg(self.backoff_jitter, self.no_backoff_jitter),
+                    multiplier: self.backoff_multiplier,
                 },
             },
             endpoint: EndpointConfig {

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -346,6 +346,7 @@ impl TryFrom<&yaml::Hash> for EndpointConfig {
 pub struct BackoffConfig {
     initial: Option<Duration>,
     max: Option<Duration>,
+    jitter: Option<bool>,
 }
 
 impl BackoffConfig {
@@ -356,6 +357,9 @@ impl BackoffConfig {
         if let Some(max) = from.max {
             self.max = Some(max);
         }
+        if let Some(jitter) = from.jitter {
+            self.jitter = Some(jitter);
+        }
     }
 
     pub fn initial(&self) -> Duration {
@@ -364,6 +368,10 @@ impl BackoffConfig {
 
     pub fn max(&self) -> Duration {
         self.max.unwrap_or(Duration::from_secs(60))
+    }
+
+    pub fn jitter(&self) -> bool {
+        self.jitter.unwrap_or(true)
     }
 }
 
@@ -390,6 +398,12 @@ impl TryFrom<&yaml::Hash> for BackoffConfig {
                             .filter(|d| !d.is_zero())
                             .with_context(|| format!("invalid grpc.backoff.max: {v:?}"))?,
                     );
+                }
+                "jitter" => {
+                    let Some(jitter) = v.as_bool() else {
+                        bail!("grpc.backoff.jitter field has incorrect type: {v:?}");
+                    };
+                    backoff.jitter = Some(jitter);
                 }
                 name => bail!("Invalid field 'grpc.backoff.{name}' with value: {v:?}"),
             }
@@ -556,6 +570,18 @@ pub struct FactCli {
     #[arg(long, env = "FACT_GRPC_BACKOFF_MAX", value_parser = parse_positive_duration_secs)]
     backoff_max: Option<Duration>,
 
+    /// Enable jitter for gRPC reconnection backoff
+    ///
+    /// Default value is true
+    #[arg(long, overrides_with = "no_backoff_jitter", hide = true)]
+    backoff_jitter: bool,
+    #[arg(
+        long,
+        overrides_with = "backoff_jitter",
+        env = "FACT_GRPC_NO_BACKOFF_JITTER"
+    )]
+    no_backoff_jitter: bool,
+
     /// The port to bind for all exposed endpoints
     #[arg(long, short, env = "FACT_ENDPOINT_ADDRESS")]
     address: Option<SocketAddr>,
@@ -649,6 +675,7 @@ impl FactCli {
                 backoff: BackoffConfig {
                     initial: self.backoff_initial,
                     max: self.backoff_max,
+                    jitter: resolve_bool_arg(self.backoff_jitter, self.no_backoff_jitter),
                 },
             },
             endpoint: EndpointConfig {

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -1726,8 +1726,8 @@ fn env_vars() {
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_NO_BACKOFF_JITTER",
-                value: "true",
+                name: "FACT_GRPC_BACKOFF_JITTER",
+                value: "false",
             },
             FactConfig {
                 grpc: GrpcConfig {
@@ -2167,10 +2167,10 @@ fn env_vars_invalid_values() {
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_NO_BACKOFF_JITTER",
+                name: "FACT_GRPC_BACKOFF_JITTER",
                 value: "not_a_boolean",
             },
-            "error: invalid value 'not_a_boolean' for '--no-backoff-jitter'",
+            "error: invalid value 'not_a_boolean' for '--backoff-jitter <BACKOFF_JITTER>'",
         ),
         (
             EnvVar {

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -1694,7 +1694,7 @@ fn env_vars() {
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_INITIAL",
+                name: "FACT_GRPC_BACKOFF_INITIAL_DURATION",
                 value: "5",
             },
             FactConfig {
@@ -1710,7 +1710,7 @@ fn env_vars() {
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_MAX",
+                name: "FACT_GRPC_BACKOFF_MAX_DURATION",
                 value: "120",
             },
             FactConfig {
@@ -1869,7 +1869,7 @@ fn env_vars_override_yaml() {
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_INITIAL",
+                name: "FACT_GRPC_BACKOFF_INITIAL_DURATION",
                 value: "5",
             },
             "grpc:\n  backoff:\n    initial: 2",
@@ -1886,7 +1886,7 @@ fn env_vars_override_yaml() {
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_MAX",
+                name: "FACT_GRPC_BACKOFF_MAX_DURATION",
                 value: "120",
             },
             "grpc:\n  backoff:\n    max: 30",
@@ -2118,42 +2118,42 @@ fn env_vars_invalid_values() {
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_INITIAL",
+                name: "FACT_GRPC_BACKOFF_INITIAL_DURATION",
                 value: "not_a_number",
             },
             "error: invalid value 'not_a_number' for '--backoff-initial <BACKOFF_INITIAL>': invalid float literal",
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_MAX",
+                name: "FACT_GRPC_BACKOFF_MAX_DURATION",
                 value: "not_a_number",
             },
             "error: invalid value 'not_a_number' for '--backoff-max <BACKOFF_MAX>': invalid float literal",
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_INITIAL",
+                name: "FACT_GRPC_BACKOFF_INITIAL_DURATION",
                 value: "0",
             },
             "error: invalid value '0' for '--backoff-initial <BACKOFF_INITIAL>': value must be greater than zero",
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_MAX",
+                name: "FACT_GRPC_BACKOFF_MAX_DURATION",
                 value: "0",
             },
             "error: invalid value '0' for '--backoff-max <BACKOFF_MAX>': value must be greater than zero",
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_INITIAL",
+                name: "FACT_GRPC_BACKOFF_INITIAL_DURATION",
                 value: "-1",
             },
             "error: invalid value '-1' for '--backoff-initial <BACKOFF_INITIAL>': value must be a non-negative finite number, got -1",
         ),
         (
             EnvVar {
-                name: "FACT_GRPC_BACKOFF_MAX",
+                name: "FACT_GRPC_BACKOFF_MAX_DURATION",
                 value: "-1",
             },
             "error: invalid value '-1' for '--backoff-max <BACKOFF_MAX>': value must be a non-negative finite number, got -1",

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -293,14 +293,33 @@ fn parsing() {
             r#"
             grpc:
               backoff:
+                jitter: false
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        jitter: Some(false),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
                 initial: 0.5
                 max: 120
+                jitter: false
             "#,
             FactConfig {
                 grpc: GrpcConfig {
                     backoff: BackoffConfig {
                         initial: Some(Duration::from_secs_f64(0.5)),
                         max: Some(Duration::from_secs(120)),
+                        jitter: Some(false),
                     },
                     ..Default::default()
                 },
@@ -317,6 +336,7 @@ fn parsing() {
               backoff:
                 initial: 0.5
                 max: 120
+                jitter: false
             endpoint:
               address: 0.0.0.0:8080
               expose_metrics: true
@@ -337,6 +357,7 @@ fn parsing() {
                     backoff: BackoffConfig {
                         initial: Some(Duration::from_secs_f64(0.5)),
                         max: Some(Duration::from_secs(120)),
+                        jitter: Some(false),
                     },
                 },
                 endpoint: EndpointConfig {
@@ -459,6 +480,14 @@ paths:
                 max: -5
             "#,
             "invalid grpc.backoff.max: Integer(-5)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                jitter: 4
+            "#,
+            "grpc.backoff.jitter field has incorrect type: Integer(4)",
         ),
         (
             r#"
@@ -1295,6 +1324,7 @@ fn update() {
               backoff:
                 initial: 0.5
                 max: 120
+                jitter: false
             endpoint:
               address: 127.0.0.1:8080
               expose_metrics: true
@@ -1315,6 +1345,7 @@ fn update() {
                     backoff: BackoffConfig {
                         initial: Some(Duration::from_secs(15)),
                         max: Some(Duration::from_secs(30)),
+                        jitter: Some(true),
                     },
                 },
                 endpoint: EndpointConfig {
@@ -1340,6 +1371,7 @@ fn update() {
                     backoff: BackoffConfig {
                         initial: Some(Duration::from_secs_f64(0.5)),
                         max: Some(Duration::from_secs(120)),
+                        jitter: Some(false),
                     },
                 },
                 endpoint: EndpointConfig {
@@ -1389,6 +1421,7 @@ fn defaults() {
     assert!(config.hotreload());
     assert_eq!(config.grpc.backoff.initial(), Duration::from_secs(1));
     assert_eq!(config.grpc.backoff.max(), Duration::from_secs(60));
+    assert!(config.grpc.backoff.jitter());
 }
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -1581,6 +1614,22 @@ fn env_vars() {
                 grpc: GrpcConfig {
                     backoff: BackoffConfig {
                         max: Some(Duration::from_secs(120)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_NO_BACKOFF_JITTER",
+                value: "true",
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        jitter: Some(false),
                         ..Default::default()
                     },
                     ..Default::default()
@@ -1996,6 +2045,13 @@ fn env_vars_invalid_values() {
                 value: "-1",
             },
             "error: invalid value '-1' for '--scan-interval <SCAN_INTERVAL>': value must be a non-negative finite number, got -1",
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_NO_BACKOFF_JITTER",
+                value: "not_a_boolean",
+            },
+            "error: invalid value 'not_a_boolean' for '--no-backoff-jitter'",
         ),
     ];
     for (env, expected) in tests {

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -257,11 +257,66 @@ fn parsing() {
         ),
         (
             r#"
+            grpc:
+              backoff:
+                initial: 2
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(2)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                max: 30
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        max: Some(Duration::from_secs(30)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                initial: 0.5
+                max: 120
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs_f64(0.5)),
+                        max: Some(Duration::from_secs(120)),
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
             paths:
             - /etc
             grpc:
               url: 'https://svc.sensor.stackrox:9090'
               certs: /etc/stackrox/certs
+              backoff:
+                initial: 0.5
+                max: 120
             endpoint:
               address: 0.0.0.0:8080
               expose_metrics: true
@@ -279,6 +334,10 @@ fn parsing() {
                 grpc: GrpcConfig {
                     url: Some(String::from("https://svc.sensor.stackrox:9090")),
                     certs: Some(PathBuf::from("/etc/stackrox/certs")),
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs_f64(0.5)),
+                        max: Some(Duration::from_secs(120)),
+                    },
                 },
                 endpoint: EndpointConfig {
                     address: Some(SocketAddr::from(([0, 0, 0, 0], 8080))),
@@ -345,6 +404,69 @@ paths:
               certs: true
             "#,
             "certs field has incorrect type: Boolean(true)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff: true
+            "#,
+            "grpc.backoff section has incorrect type: Boolean(true)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                initial: true
+            "#,
+            "invalid grpc.backoff.initial: Boolean(true)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                max: true
+            "#,
+            "invalid grpc.backoff.max: Boolean(true)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                initial: 0
+            "#,
+            "invalid grpc.backoff.initial: Integer(0)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                initial: -1
+            "#,
+            "invalid grpc.backoff.initial: Integer(-1)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                max: 0
+            "#,
+            "invalid grpc.backoff.max: Integer(0)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                max: -5
+            "#,
+            "invalid grpc.backoff.max: Integer(-5)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                unknown: 4
+            "#,
+            "Invalid field 'grpc.backoff.unknown' with value: Integer(4)",
         ),
         (
             "endpoint: true",
@@ -483,10 +605,16 @@ paths:
         ),
         (
             "scan_interval: true",
-            "scan_interval field has incorrect type: Boolean(true)",
+            "invalid scan_interval: Boolean(true)",
         ),
-        ("scan_interval: -128", "invalid scan_interval: -128"),
-        ("scan_interval: -128.5", "invalid scan_interval: -128.5"),
+        (
+            "scan_interval: -128",
+            "invalid scan_interval: Integer(-128)",
+        ),
+        (
+            "scan_interval: -128.5",
+            "invalid scan_interval: Real(\"-128.5\")",
+        ),
         ("unknown:", "Invalid field 'unknown' with value: Null"),
     ];
     for (input, expected) in tests {
@@ -653,6 +781,150 @@ fn update() {
             FactConfig {
                 grpc: GrpcConfig {
                     certs: Some(PathBuf::from("/etc/stackrox/certs")),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                initial: 5
+            "#,
+            FactConfig::default(),
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(5)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                initial: 5
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(2)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(5)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                initial: 5
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(5)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(5)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                max: 120
+            "#,
+            FactConfig::default(),
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        max: Some(Duration::from_secs(120)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                max: 120
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        max: Some(Duration::from_secs(30)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        max: Some(Duration::from_secs(120)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                max: 120
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        max: Some(Duration::from_secs(120)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        max: Some(Duration::from_secs(120)),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 ..Default::default()
@@ -1020,6 +1292,9 @@ fn update() {
             grpc:
               url: 'https://svc.sensor.stackrox:9090'
               certs: /etc/stackrox/certs
+              backoff:
+                initial: 0.5
+                max: 120
             endpoint:
               address: 127.0.0.1:8080
               expose_metrics: true
@@ -1037,6 +1312,10 @@ fn update() {
                 grpc: GrpcConfig {
                     url: Some(String::from("http://localhost")),
                     certs: Some(PathBuf::from("/etc/certs")),
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(15)),
+                        max: Some(Duration::from_secs(30)),
+                    },
                 },
                 endpoint: EndpointConfig {
                     address: Some(SocketAddr::from(([0, 0, 0, 0], 9000))),
@@ -1058,6 +1337,10 @@ fn update() {
                 grpc: GrpcConfig {
                     url: Some(String::from("https://svc.sensor.stackrox:9090")),
                     certs: Some(PathBuf::from("/etc/stackrox/certs")),
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs_f64(0.5)),
+                        max: Some(Duration::from_secs(120)),
+                    },
                 },
                 endpoint: EndpointConfig {
                     address: Some(SocketAddr::from(([127, 0, 0, 1], 8080))),
@@ -1104,6 +1387,8 @@ fn defaults() {
     assert_eq!(config.bpf.ringbuf_size(), 8192);
     assert_eq!(config.bpf.inodes_max(), 65536);
     assert!(config.hotreload());
+    assert_eq!(config.grpc.backoff.initial(), Duration::from_secs(1));
+    assert_eq!(config.grpc.backoff.max(), Duration::from_secs(60));
 }
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -1227,6 +1512,16 @@ fn env_vars() {
         ),
         (
             EnvVar {
+                name: "FACT_SCAN_INTERVAL",
+                value: "0",
+            },
+            FactConfig {
+                scan_interval: Some(Duration::ZERO),
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
                 name: "FACT_RATE_LIMIT",
                 value: "500",
             },
@@ -1256,6 +1551,38 @@ fn env_vars() {
             FactConfig {
                 grpc: GrpcConfig {
                     certs: Some(PathBuf::from("/etc/stackrox/certs")),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_INITIAL",
+                value: "5",
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(5)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_MAX",
+                value: "120",
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        max: Some(Duration::from_secs(120)),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 ..Default::default()
@@ -1367,6 +1694,40 @@ fn env_vars_override_yaml() {
             FactConfig {
                 grpc: GrpcConfig {
                     url: Some(String::from("https://override:9090")),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_INITIAL",
+                value: "5",
+            },
+            "grpc:\n  backoff:\n    initial: 2",
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(5)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_MAX",
+                value: "120",
+            },
+            "grpc:\n  backoff:\n    max: 30",
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        max: Some(Duration::from_secs(120)),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 ..Default::default()
@@ -1586,6 +1947,55 @@ fn env_vars_invalid_values() {
                 value: "not_a_boolean",
             },
             "error: invalid value 'not_a_boolean' for '--hotreload'",
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_INITIAL",
+                value: "not_a_number",
+            },
+            "error: invalid value 'not_a_number' for '--backoff-initial <BACKOFF_INITIAL>': invalid float literal",
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_MAX",
+                value: "not_a_number",
+            },
+            "error: invalid value 'not_a_number' for '--backoff-max <BACKOFF_MAX>': invalid float literal",
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_INITIAL",
+                value: "0",
+            },
+            "error: invalid value '0' for '--backoff-initial <BACKOFF_INITIAL>': value must be greater than zero",
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_MAX",
+                value: "0",
+            },
+            "error: invalid value '0' for '--backoff-max <BACKOFF_MAX>': value must be greater than zero",
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_INITIAL",
+                value: "-1",
+            },
+            "error: invalid value '-1' for '--backoff-initial <BACKOFF_INITIAL>': value must be a non-negative finite number, got -1",
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_MAX",
+                value: "-1",
+            },
+            "error: invalid value '-1' for '--backoff-max <BACKOFF_MAX>': value must be a non-negative finite number, got -1",
+        ),
+        (
+            EnvVar {
+                name: "FACT_SCAN_INTERVAL",
+                value: "-1",
+            },
+            "error: invalid value '-1' for '--scan-interval <SCAN_INTERVAL>': value must be a non-negative finite number, got -1",
         ),
     ];
     for (env, expected) in tests {

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -310,9 +310,44 @@ fn parsing() {
             r#"
             grpc:
               backoff:
+                multiplier: 2
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        multiplier: Some(2.0),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                multiplier: 3.5
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        multiplier: Some(3.5),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
                 initial: 0.5
                 max: 120
                 jitter: false
+                multiplier: 2
             "#,
             FactConfig {
                 grpc: GrpcConfig {
@@ -320,6 +355,7 @@ fn parsing() {
                         initial: Some(Duration::from_secs_f64(0.5)),
                         max: Some(Duration::from_secs(120)),
                         jitter: Some(false),
+                        multiplier: Some(2.0),
                     },
                     ..Default::default()
                 },
@@ -337,6 +373,7 @@ fn parsing() {
                 initial: 0.5
                 max: 120
                 jitter: false
+                multiplier: 2
             endpoint:
               address: 0.0.0.0:8080
               expose_metrics: true
@@ -358,6 +395,7 @@ fn parsing() {
                         initial: Some(Duration::from_secs_f64(0.5)),
                         max: Some(Duration::from_secs(120)),
                         jitter: Some(false),
+                        multiplier: Some(2.0),
                     },
                 },
                 endpoint: EndpointConfig {
@@ -488,6 +526,22 @@ paths:
                 jitter: 4
             "#,
             "grpc.backoff.jitter field has incorrect type: Integer(4)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                multiplier: true
+            "#,
+            "invalid grpc.backoff.multiplier: Boolean(true)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                multiplier: 0.5
+            "#,
+            "invalid grpc.backoff.multiplier: Real(\"0.5\")",
         ),
         (
             r#"
@@ -961,6 +1015,51 @@ fn update() {
         ),
         (
             r#"
+            grpc:
+              backoff:
+                multiplier: 2
+            "#,
+            FactConfig::default(),
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        multiplier: Some(2.0),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                multiplier: 2
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        multiplier: Some(1.5),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        multiplier: Some(2.0),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
             endpoint:
               expose_metrics: true
             "#,
@@ -1325,6 +1424,7 @@ fn update() {
                 initial: 0.5
                 max: 120
                 jitter: false
+                multiplier: 3.0
             endpoint:
               address: 127.0.0.1:8080
               expose_metrics: true
@@ -1346,6 +1446,7 @@ fn update() {
                         initial: Some(Duration::from_secs(15)),
                         max: Some(Duration::from_secs(30)),
                         jitter: Some(true),
+                        multiplier: Some(2.0),
                     },
                 },
                 endpoint: EndpointConfig {
@@ -1372,6 +1473,7 @@ fn update() {
                         initial: Some(Duration::from_secs_f64(0.5)),
                         max: Some(Duration::from_secs(120)),
                         jitter: Some(false),
+                        multiplier: Some(3.0),
                     },
                 },
                 endpoint: EndpointConfig {
@@ -1422,6 +1524,7 @@ fn defaults() {
     assert_eq!(config.grpc.backoff.initial(), Duration::from_secs(1));
     assert_eq!(config.grpc.backoff.max(), Duration::from_secs(60));
     assert!(config.grpc.backoff.jitter());
+    assert_eq!(config.grpc.backoff.multiplier(), 1.5);
 }
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -1630,6 +1733,22 @@ fn env_vars() {
                 grpc: GrpcConfig {
                     backoff: BackoffConfig {
                         jitter: Some(false),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_MULTIPLIER",
+                value: "2.5",
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        multiplier: Some(2.5),
                         ..Default::default()
                     },
                     ..Default::default()
@@ -2052,6 +2171,20 @@ fn env_vars_invalid_values() {
                 value: "not_a_boolean",
             },
             "error: invalid value 'not_a_boolean' for '--no-backoff-jitter'",
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_MULTIPLIER",
+                value: "not_a_number",
+            },
+            "error: invalid value 'not_a_number' for '--backoff-multiplier <BACKOFF_MULTIPLIER>': invalid float literal",
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_MULTIPLIER",
+                value: "0.5",
+            },
+            "error: invalid value '0.5' for '--backoff-multiplier <BACKOFF_MULTIPLIER>': multiplier must be > 1.0, got 0.5",
         ),
     ];
     for (env, expected) in tests {

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -48,10 +48,8 @@ impl Backoff {
     }
 
     fn next(&mut self) -> Duration {
-        let delay = self.current;
-        self.current = Duration::from_secs_f64(
-            (self.current.as_secs_f64() * self.multiplier).min(self.max.as_secs_f64()),
-        );
+        let delay = self.current.min(self.max);
+        self.current = self.current.mul_f64(self.multiplier).min(self.max);
         if self.jitter {
             let nanos = rand::random_range(0..=delay.as_nanos() as u64);
             Duration::from_nanos(nanos)

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -18,7 +18,11 @@ use tokio_stream::{
 };
 use tonic::transport::Channel;
 
-use crate::{config::GrpcConfig, event::Event, metrics::EventCounter};
+use crate::{
+    config::{BackoffConfig, GrpcConfig},
+    event::Event,
+    metrics::EventCounter,
+};
 
 struct Backoff {
     initial: Duration,
@@ -43,6 +47,12 @@ impl Backoff {
 
     fn reset(&mut self) {
         self.current = self.initial;
+    }
+}
+
+impl From<&BackoffConfig> for Backoff {
+    fn from(value: &BackoffConfig) -> Self {
+        Backoff::new(value.initial(), value.max())
     }
 }
 
@@ -147,8 +157,7 @@ impl Client {
     }
 
     async fn run(&mut self) -> anyhow::Result<bool> {
-        let backoff_config = self.config.borrow().backoff.clone();
-        let mut backoff = Backoff::new(backoff_config.initial(), backoff_config.max());
+        let mut backoff = Backoff::from(&self.config.borrow().backoff);
         loop {
             // Re-read certs on each connection attempt so rotated certificates
             // on disk are picked up on the next reconnect.
@@ -189,9 +198,6 @@ impl Client {
                         Ok(_) => info!("gRPC stream ended"),
                         Err(e) => warn!("gRPC stream error: {e:?}"),
                     }
-                    let delay = backoff.next();
-                    warn!("Reconnecting in {delay:?}...");
-                    sleep(delay).await;
                 }
                 _ = self.config.changed() => return Ok(true),
                 _ = self.running.changed() => return Ok(*self.running.borrow()),
@@ -237,9 +243,9 @@ mod tests {
     #[test]
     fn backoff_reset() {
         let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60));
-        b.next();
-        b.next();
-        b.next();
+        assert_eq!(b.next(), Duration::from_secs(1));
+        assert_eq!(b.next(), Duration::from_secs(2));
+        assert_eq!(b.next(), Duration::from_secs(4));
         b.reset();
         assert_eq!(b.next(), Duration::from_secs(1));
         assert_eq!(b.next(), Duration::from_secs(2));

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -147,7 +147,8 @@ impl Client {
     }
 
     async fn run(&mut self) -> anyhow::Result<bool> {
-        let mut backoff = Backoff::new(Duration::from_secs(1), Duration::from_secs(60));
+        let backoff_config = self.config.borrow().backoff.clone();
+        let mut backoff = Backoff::new(backoff_config.initial(), backoff_config.max());
         loop {
             // Re-read certs on each connection attempt so rotated certificates
             // on disk are picked up on the next reconnect.

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -28,21 +28,28 @@ struct Backoff {
     initial: Duration,
     current: Duration,
     max: Duration,
+    jitter: bool,
 }
 
 impl Backoff {
-    fn new(initial: Duration, max: Duration) -> Self {
+    fn new(initial: Duration, max: Duration, jitter: bool) -> Self {
         Self {
             initial,
             current: initial,
             max,
+            jitter,
         }
     }
 
     fn next(&mut self) -> Duration {
         let delay = self.current;
         self.current = (self.current * 2).min(self.max);
-        delay
+        if self.jitter {
+            let nanos = rand::random_range(0..=delay.as_nanos() as u64);
+            Duration::from_nanos(nanos)
+        } else {
+            delay
+        }
     }
 
     fn reset(&mut self) {
@@ -52,7 +59,7 @@ impl Backoff {
 
 impl From<&BackoffConfig> for Backoff {
     fn from(value: &BackoffConfig) -> Self {
-        Backoff::new(value.initial(), value.max())
+        Backoff::new(value.initial(), value.max(), value.jitter())
     }
 }
 
@@ -223,7 +230,7 @@ mod tests {
 
     #[test]
     fn backoff_exponential() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60));
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false);
         assert_eq!(b.next(), Duration::from_secs(1));
         assert_eq!(b.next(), Duration::from_secs(2));
         assert_eq!(b.next(), Duration::from_secs(4));
@@ -234,7 +241,7 @@ mod tests {
 
     #[test]
     fn backoff_caps_at_max() {
-        let mut b = Backoff::new(Duration::from_secs(32), Duration::from_secs(60));
+        let mut b = Backoff::new(Duration::from_secs(32), Duration::from_secs(60), false);
         assert_eq!(b.next(), Duration::from_secs(32));
         assert_eq!(b.next(), Duration::from_secs(60));
         assert_eq!(b.next(), Duration::from_secs(60));
@@ -242,12 +249,40 @@ mod tests {
 
     #[test]
     fn backoff_reset() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60));
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false);
         assert_eq!(b.next(), Duration::from_secs(1));
         assert_eq!(b.next(), Duration::from_secs(2));
         assert_eq!(b.next(), Duration::from_secs(4));
         b.reset();
         assert_eq!(b.next(), Duration::from_secs(1));
         assert_eq!(b.next(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn backoff_jitter_within_range() {
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), true);
+        let mut expected_max = Duration::from_secs(1);
+        for _ in 0..100 {
+            let delay = b.next();
+            assert!(
+                delay <= expected_max,
+                "delay {delay:?} exceeded expected max {expected_max:?}"
+            );
+            expected_max = (expected_max * 2).min(Duration::from_secs(60));
+        }
+    }
+
+    #[test]
+    fn backoff_jitter_reset() {
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), true);
+        for _ in 0..5 {
+            b.next();
+        }
+        b.reset();
+        let delay = b.next();
+        assert!(
+            delay <= Duration::from_secs(1),
+            "delay {delay:?} exceeded 1s after reset"
+        );
     }
 }

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -20,6 +20,32 @@ use tonic::transport::Channel;
 
 use crate::{config::GrpcConfig, event::Event, metrics::EventCounter};
 
+struct Backoff {
+    initial: Duration,
+    current: Duration,
+    max: Duration,
+}
+
+impl Backoff {
+    fn new(initial: Duration, max: Duration) -> Self {
+        Self {
+            initial,
+            current: initial,
+            max,
+        }
+    }
+
+    fn next(&mut self) -> Duration {
+        let delay = self.current;
+        self.current = (self.current * 2).min(self.max);
+        delay
+    }
+
+    fn reset(&mut self) {
+        self.current = self.initial;
+    }
+}
+
 pub struct Client {
     rx: broadcast::Receiver<Arc<Event>>,
     running: watch::Receiver<bool>,
@@ -121,6 +147,7 @@ impl Client {
     }
 
     async fn run(&mut self) -> anyhow::Result<bool> {
+        let mut backoff = Backoff::new(Duration::from_secs(1), Duration::from_secs(60));
         loop {
             // Re-read certs on each connection attempt so rotated certificates
             // on disk are picked up on the next reconnect.
@@ -129,12 +156,14 @@ impl Client {
             let channel = match self.create_channel(connector).await {
                 Ok(channel) => channel,
                 Err(e) => {
-                    debug!("Failed to connect to server: {e:?}");
-                    sleep(Duration::from_secs(1)).await;
+                    let delay = backoff.next();
+                    debug!("Failed to connect to server: {e:?}, retrying in {delay:?}");
+                    sleep(delay).await;
                     continue;
                 }
             };
             info!("Successfully connected to gRPC server");
+            backoff.reset();
 
             let mut client = FileActivityServiceClient::new(channel);
 
@@ -159,6 +188,9 @@ impl Client {
                         Ok(_) => info!("gRPC stream ended"),
                         Err(e) => warn!("gRPC stream error: {e:?}"),
                     }
+                    let delay = backoff.next();
+                    warn!("Reconnecting in {delay:?}...");
+                    sleep(delay).await;
                 }
                 _ = self.config.changed() => return Ok(true),
                 _ = self.running.changed() => return Ok(*self.running.borrow()),
@@ -175,5 +207,40 @@ impl Client {
             _ = self.config.changed() => Ok(true),
             _ = self.running.changed() => Ok(*self.running.borrow()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_exponential() {
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60));
+        assert_eq!(b.next(), Duration::from_secs(1));
+        assert_eq!(b.next(), Duration::from_secs(2));
+        assert_eq!(b.next(), Duration::from_secs(4));
+        assert_eq!(b.next(), Duration::from_secs(8));
+        assert_eq!(b.next(), Duration::from_secs(16));
+        assert_eq!(b.next(), Duration::from_secs(32));
+    }
+
+    #[test]
+    fn backoff_caps_at_max() {
+        let mut b = Backoff::new(Duration::from_secs(32), Duration::from_secs(60));
+        assert_eq!(b.next(), Duration::from_secs(32));
+        assert_eq!(b.next(), Duration::from_secs(60));
+        assert_eq!(b.next(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn backoff_reset() {
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60));
+        b.next();
+        b.next();
+        b.next();
+        b.reset();
+        assert_eq!(b.next(), Duration::from_secs(1));
+        assert_eq!(b.next(), Duration::from_secs(2));
     }
 }

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -29,21 +29,25 @@ struct Backoff {
     current: Duration,
     max: Duration,
     jitter: bool,
+    multiplier: f64,
 }
 
 impl Backoff {
-    fn new(initial: Duration, max: Duration, jitter: bool) -> Self {
+    fn new(initial: Duration, max: Duration, jitter: bool, multiplier: f64) -> Self {
         Self {
             initial,
             current: initial,
             max,
             jitter,
+            multiplier,
         }
     }
 
     fn next(&mut self) -> Duration {
         let delay = self.current;
-        self.current = (self.current * 2).min(self.max);
+        self.current = Duration::from_secs_f64(
+            (self.current.as_secs_f64() * self.multiplier).min(self.max.as_secs_f64()),
+        );
         if self.jitter {
             let nanos = rand::random_range(0..=delay.as_nanos() as u64);
             Duration::from_nanos(nanos)
@@ -59,7 +63,12 @@ impl Backoff {
 
 impl From<&BackoffConfig> for Backoff {
     fn from(value: &BackoffConfig) -> Self {
-        Backoff::new(value.initial(), value.max(), value.jitter())
+        Backoff::new(
+            value.initial(),
+            value.max(),
+            value.jitter(),
+            value.multiplier(),
+        )
     }
 }
 
@@ -229,8 +238,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn backoff_exponential() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false);
+    fn backoff_exponential_2x() {
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false, 2.0);
         assert_eq!(b.next(), Duration::from_secs(1));
         assert_eq!(b.next(), Duration::from_secs(2));
         assert_eq!(b.next(), Duration::from_secs(4));
@@ -240,8 +249,17 @@ mod tests {
     }
 
     #[test]
+    fn backoff_default_multiplier() {
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false, 1.5);
+        assert_eq!(b.next(), Duration::from_secs(1));
+        assert_eq!(b.next(), Duration::from_millis(1500));
+        assert_eq!(b.next(), Duration::from_millis(2250));
+        assert_eq!(b.next(), Duration::from_millis(3375));
+    }
+
+    #[test]
     fn backoff_caps_at_max() {
-        let mut b = Backoff::new(Duration::from_secs(32), Duration::from_secs(60), false);
+        let mut b = Backoff::new(Duration::from_secs(32), Duration::from_secs(60), false, 2.0);
         assert_eq!(b.next(), Duration::from_secs(32));
         assert_eq!(b.next(), Duration::from_secs(60));
         assert_eq!(b.next(), Duration::from_secs(60));
@@ -249,7 +267,7 @@ mod tests {
 
     #[test]
     fn backoff_reset() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false);
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false, 2.0);
         assert_eq!(b.next(), Duration::from_secs(1));
         assert_eq!(b.next(), Duration::from_secs(2));
         assert_eq!(b.next(), Duration::from_secs(4));
@@ -260,7 +278,7 @@ mod tests {
 
     #[test]
     fn backoff_jitter_within_range() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), true);
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), true, 1.5);
         let mut expected_max = Duration::from_secs(1);
         for _ in 0..100 {
             let delay = b.next();
@@ -268,13 +286,14 @@ mod tests {
                 delay <= expected_max,
                 "delay {delay:?} exceeded expected max {expected_max:?}"
             );
-            expected_max = (expected_max * 2).min(Duration::from_secs(60));
+            let nanos = expected_max.as_nanos() as u64 * 1500 / 1000;
+            expected_max = Duration::from_nanos(nanos).min(Duration::from_secs(60));
         }
     }
 
     #[test]
     fn backoff_jitter_reset() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), true);
+        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), true, 1.5);
         for _ in 0..5 {
             b.next();
         }

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -34,6 +34,10 @@ struct Backoff {
 
 impl Backoff {
     fn new(initial: Duration, max: Duration, jitter: bool, multiplier: f64) -> Self {
+        if initial >= max {
+            warn!("Initial backoff value is equal or greater than max.");
+        }
+
         Self {
             initial,
             current: initial,


### PR DESCRIPTION
## Description

If connection to a gRPC server fails, fact was into a loop trying to reconnect every second which is pretty noisy and not really needed. With this change we add an exponential backoff algorithm that will try to reconnect with some leeway.

In the interest of making it obvious `fact` is failing to connect on k8s, we probably want to crash the application if we reach the maximum backoff, but there is currently no easy way to do that, so I'll leave it to a follow up.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed



<details>
  <summary>Without this change, reconnection attempts every second</summary>

```
[DEBUG 2026-06-10T11:35:37Z] (fact/src/output/grpc.rs:130) Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111)
[DEBUG 2026-06-10T11:35:37Z] (fact/src/host_scanner.rs:184) Added entry for /etc/sensitive-files/something: inode_key_t { inode: 202489561, dev: 39 }
[DEBUG 2026-06-10T11:35:37Z] (fact/src/host_scanner.rs:184) Added entry for /etc/sensitive-files/test: inode_key_t { inode: 196873539, dev: 39 }
[DEBUG 2026-06-10T11:35:37Z] (fact/src/host_scanner.rs:184) Added entry for /etc/sensitive-files: inode_key_t { inode: 126382982, dev: 39 }
[DEBUG 2026-06-10T11:35:37Z] (fact/src/host_scanner.rs:139) Host scan done
[INFO  2026-06-10T11:35:38Z] (fact/src/output/grpc.rs:126) Attempting to connect to gRPC server...
[WARN  2026-06-10T11:35:38Z] (fact/src/output/grpc.rs:116) Using unencrypted gRPC channel
[DEBUG 2026-06-10T11:35:38Z] (fact/src/output/grpc.rs:130) Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111)
[INFO  2026-06-10T11:35:39Z] (fact/src/output/grpc.rs:126) Attempting to connect to gRPC server...
[WARN  2026-06-10T11:35:39Z] (fact/src/output/grpc.rs:116) Using unencrypted gRPC channel
[DEBUG 2026-06-10T11:35:39Z] (fact/src/output/grpc.rs:130) Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111)
[INFO  2026-06-10T11:35:40Z] (fact/src/output/grpc.rs:126) Attempting to connect to gRPC server...
[WARN  2026-06-10T11:35:40Z] (fact/src/output/grpc.rs:116) Using unencrypted gRPC channel
[DEBUG 2026-06-10T11:35:40Z] (fact/src/output/grpc.rs:130) Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111)
[INFO  2026-06-10T11:35:41Z] (fact/src/output/grpc.rs:126) Attempting to connect to gRPC server...
[WARN  2026-06-10T11:35:41Z] (fact/src/output/grpc.rs:116) Using unencrypted gRPC channel
[DEBUG 2026-06-10T11:35:41Z] (fact/src/output/grpc.rs:130) Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111)
```

</details>

<details>
  <summary>With this change, exponential attempts</summary>

```
[DEBUG 2026-06-10T11:41:03Z] (fact/src/output/grpc.rs:168) Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111), retrying in 1s
[DEBUG 2026-06-10T11:41:03Z] (fact/src/host_scanner.rs:184) Added entry for /etc/sensitive-files/my-dir/nested: inode_key_t { inode: 194573388, dev: 39 }
[DEBUG 2026-06-10T11:41:03Z] (fact/src/host_scanner.rs:184) Added entry for /etc/sensitive-files/my-dir/nested/something: inode_key_t { inode: 194573419, dev: 39 }
[DEBUG 2026-06-10T11:41:03Z] (fact/src/host_scanner.rs:184) Added entry for /etc/sensitive-files/my-dir/something: inode_key_t { inode: 200442630, dev: 39 }
[DEBUG 2026-06-10T11:41:03Z] (fact/src/host_scanner.rs:184) Added entry for /etc/sensitive-files/something: inode_key_t { inode: 202489561, dev: 39 }
[DEBUG 2026-06-10T11:41:03Z] (fact/src/host_scanner.rs:184) Added entry for /etc/sensitive-files/test: inode_key_t { inode: 196873539, dev: 39 }
[DEBUG 2026-06-10T11:41:03Z] (fact/src/host_scanner.rs:184) Added entry for /etc/sensitive-files: inode_key_t { inode: 126382982, dev: 39 }
[DEBUG 2026-06-10T11:41:03Z] (fact/src/host_scanner.rs:139) Host scan done
[INFO  2026-06-10T11:41:04Z] (fact/src/output/grpc.rs:163) Attempting to connect to gRPC server...
[WARN  2026-06-10T11:41:04Z] (fact/src/output/grpc.rs:152) Using unencrypted gRPC channel
[DEBUG 2026-06-10T11:41:04Z] (fact/src/output/grpc.rs:168) Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111), retrying in 2s
[INFO  2026-06-10T11:41:06Z] (fact/src/output/grpc.rs:163) Attempting to connect to gRPC server...
[WARN  2026-06-10T11:41:06Z] (fact/src/output/grpc.rs:152) Using unencrypted gRPC channel
[DEBUG 2026-06-10T11:41:06Z] (fact/src/output/grpc.rs:168) Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111), retrying in 4s
[INFO  2026-06-10T11:41:10Z] (fact/src/output/grpc.rs:163) Attempting to connect to gRPC server...
[WARN  2026-06-10T11:41:10Z] (fact/src/output/grpc.rs:152) Using unencrypted gRPC channel
[DEBUG 2026-06-10T11:41:10Z] (fact/src/output/grpc.rs:168) Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111), retrying in 8s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable gRPC backoff (initial/max durations, multiplier, jitter) via YAML, CLI flags, and environment variables.

* **Improvements**
  * gRPC reconnection now uses exponential backoff with configurable timing, jitter, reset after success, and improved retry logging (replacing the fixed delay).
  * `scan_interval` and backoff durations now parse directly into `Duration` with stricter validation and clearer error handling.

* **Tests**
  * Expanded config parsing/validation, override behavior, merge/update logic, defaults, and error-case assertions for `scan_interval` and gRPC backoff.

* **Documentation**
  * Changelog updated to highlight the gRPC backoff behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->