### PR TITLE
ROX-35107: Add Konflux pipeline check for post-quantum crypto policy

### DIFF
--- a/.tekton/fact-component-pipeline.yaml
+++ b/.tekton/fact-component-pipeline.yaml
@@ -520,6 +520,25 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+  - name: verify-pq-crypto-policies
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    taskRef:
+      params:
+      - name: name
+        value: verify-pq-crypto-policies
+      - name: bundle
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:4d05c7ad1bcf63015b6b67787e9f024466fd2c864b69f7939a1925e307afb9b0
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
   - name: push-dockerfile
     params:
     - name: IMAGE


### PR DESCRIPTION
## Description

Verify that the built fact image has `X25519MLKEM768` in `/etc/crypto-policies/back-ends/opensslcnf.config`, guarding against regressions of the `DEFAULT:PQ` crypto-policy setting.

Identical to https://github.com/stackrox/collector/pull/3463
See also https://github.com/stackrox/konflux-tasks/pull/105

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [x] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient
