### PR TITLE
fix: release workflow needs to start on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-          ref: release-${{ inputs.version }}
           token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
 
       - uses: ./.github/actions/validate-version
@@ -38,6 +37,7 @@ jobs:
       - name: Determine patch version
         id: patch
         run: |
+          git checkout release-"${VERSION}"
           last_tag="$(git describe --tags --abbrev=0)"
 
           if [[ "$last_tag" =~ ^"${VERSION}"\.x$ ]]; then


### PR DESCRIPTION

## Description

The release workflow is currently broken because it checks out the release-* branch and attempts to run an action from there, this action does not exist in the release-* branch and should instead be using the version from main.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Run the release workflow in dry-run mode successfully: https://github.com/stackrox/fact/actions/runs/27958946486


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to improve the patch version determination process during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->