### PR TITLE
feat(grpc): enforce a maximum number of reconnection attempts

### DIFF
--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -332,6 +332,7 @@ pub struct BackoffConfig {
     max: Option<Duration>,
     jitter: Option<bool>,
     multiplier: Option<f64>,
+    retries_max: Option<u64>,
 }
 
 impl BackoffConfig {
@@ -347,6 +348,9 @@ impl BackoffConfig {
         }
         if let Some(multiplier) = from.multiplier {
             self.multiplier = Some(multiplier);
+        }
+        if let Some(retries) = from.retries_max {
+            self.retries_max = Some(retries);
         }
     }
 
@@ -364,6 +368,10 @@ impl BackoffConfig {
 
     pub fn multiplier(&self) -> f64 {
         self.multiplier.unwrap_or(1.5)
+    }
+
+    pub fn retries(&self) -> u64 {
+        self.retries_max.unwrap_or(10)
     }
 }
 
@@ -404,6 +412,12 @@ impl TryFrom<&yaml::Hash> for BackoffConfig {
                         bail!("invalid grpc.backoff.multiplier: {v:?}");
                     };
                     backoff.multiplier = Some(multiplier);
+                }
+                "retries" => {
+                    let Some(retries) = v.as_i64() else {
+                        bail!("invalid grpc.backoff.retries: {v:?}");
+                    };
+                    backoff.retries_max = Some(retries as u64);
                 }
                 name => bail!("Invalid field 'grpc.backoff.{name}' with value: {v:?}"),
             }
@@ -606,6 +620,13 @@ pub struct FactCli {
     #[arg(long, env = "FACT_GRPC_BACKOFF_JITTER")]
     backoff_jitter: Option<bool>,
 
+    /// Maximum number of times a gRPC connection will be attempted
+    /// before giving up
+    ///
+    /// 0 means infinite retries
+    #[arg(long, env = "FACT_GRPC_BACKOFF_RETRIES_MAX")]
+    backoff_retries_max: Option<u64>,
+
     /// The port to bind for all exposed endpoints
     #[arg(long, short, env = "FACT_ENDPOINT_ADDRESS")]
     address: Option<SocketAddr>,
@@ -701,6 +722,7 @@ impl FactCli {
                     max: self.backoff_max,
                     jitter: self.backoff_jitter,
                     multiplier: self.backoff_multiplier,
+                    retries_max: self.backoff_retries_max,
                 },
             },
             endpoint: EndpointConfig {

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -414,7 +414,7 @@ impl TryFrom<&yaml::Hash> for BackoffConfig {
                     backoff.multiplier = Some(multiplier);
                 }
                 "retries" => {
-                    let Some(retries) = v.as_i64() else {
+                    let Some(retries) = v.as_i64().filter(|r| *r >= 0) else {
                         bail!("invalid grpc.backoff.retries: {v:?}");
                     };
                     backoff.retries_max = Some(retries as u64);

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -344,10 +344,28 @@ fn parsing() {
             r#"
             grpc:
               backoff:
+                retries: 5
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        retries_max: Some(5),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
                 initial: 0.5
                 max: 120
                 jitter: false
                 multiplier: 2
+                retries: 5
             "#,
             FactConfig {
                 grpc: GrpcConfig {
@@ -356,6 +374,7 @@ fn parsing() {
                         max: Some(Duration::from_secs(120)),
                         jitter: Some(false),
                         multiplier: Some(2.0),
+                        retries_max: Some(5),
                     },
                     ..Default::default()
                 },
@@ -374,6 +393,7 @@ fn parsing() {
                 max: 120
                 jitter: false
                 multiplier: 2
+                retries: 5
             endpoint:
               address: 0.0.0.0:8080
               expose_metrics: true
@@ -396,6 +416,7 @@ fn parsing() {
                         max: Some(Duration::from_secs(120)),
                         jitter: Some(false),
                         multiplier: Some(2.0),
+                        retries_max: Some(5),
                     },
                 },
                 endpoint: EndpointConfig {
@@ -542,6 +563,22 @@ paths:
                 multiplier: 0.5
             "#,
             "invalid grpc.backoff.multiplier: Real(\"0.5\")",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                retries: 0.5
+            "#,
+            "invalid grpc.backoff.retries: Real(\"0.5\")",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                retries: true
+            "#,
+            "invalid grpc.backoff.retries: Boolean(true)",
         ),
         (
             r#"
@@ -1060,6 +1097,51 @@ fn update() {
         ),
         (
             r#"
+            grpc:
+              backoff:
+                retries: 5
+            "#,
+            FactConfig::default(),
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        retries_max: Some(5),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                retries: 5
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        retries_max: Some(10),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        retries_max: Some(5),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
             endpoint:
               expose_metrics: true
             "#,
@@ -1425,6 +1507,7 @@ fn update() {
                 max: 120
                 jitter: false
                 multiplier: 3.0
+                retries: 5
             endpoint:
               address: 127.0.0.1:8080
               expose_metrics: true
@@ -1447,6 +1530,7 @@ fn update() {
                         max: Some(Duration::from_secs(30)),
                         jitter: Some(true),
                         multiplier: Some(2.0),
+                        retries_max: Some(20),
                     },
                 },
                 endpoint: EndpointConfig {
@@ -1474,6 +1558,7 @@ fn update() {
                         max: Some(Duration::from_secs(120)),
                         jitter: Some(false),
                         multiplier: Some(3.0),
+                        retries_max: Some(5),
                     },
                 },
                 endpoint: EndpointConfig {
@@ -1525,6 +1610,7 @@ fn defaults() {
     assert_eq!(config.grpc.backoff.max(), Duration::from_secs(60));
     assert!(config.grpc.backoff.jitter());
     assert_eq!(config.grpc.backoff.multiplier(), 1.5);
+    assert_eq!(config.grpc.backoff.retries(), 10);
 }
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -1749,6 +1835,22 @@ fn env_vars() {
                 grpc: GrpcConfig {
                     backoff: BackoffConfig {
                         multiplier: Some(2.5),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
+                name: "FACT_GRPC_BACKOFF_RETRIES_MAX",
+                value: "5",
+            },
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        retries_max: Some(5),
                         ..Default::default()
                     },
                     ..Default::default()

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -584,6 +584,14 @@ paths:
             r#"
             grpc:
               backoff:
+                retries: -10
+            "#,
+            "invalid grpc.backoff.retries: Integer(-10)",
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
                 unknown: 4
             "#,
             "Invalid field 'grpc.backoff.unknown' with value: Integer(4)",

--- a/fact/src/lib.rs
+++ b/fact/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{borrow::BorrowMut, io::Write, str::FromStr};
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use bpf::Bpf;
 use host_info::{SystemInfo, get_distro, get_hostname};
 use host_scanner::HostScanner;
@@ -10,6 +10,7 @@ use rate_limiter::RateLimiter;
 use tokio::{
     signal::unix::{SignalKind, signal},
     sync::watch,
+    task::JoinError,
 };
 
 mod bpf;
@@ -64,6 +65,19 @@ pub fn log_system_information() {
     info!("Hostname: {}", get_hostname());
 }
 
+fn flatten_task_result(
+    component: &str,
+    res: Result<anyhow::Result<()>, JoinError>,
+) -> anyhow::Result<()> {
+    match res {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(e)) => {
+            bail!("{component} worker errored out: {e:?}");
+        }
+        Err(e) => bail!("{component} task errored out: {e:?}"),
+    }
+}
+
 pub async fn run(config: FactConfig) -> anyhow::Result<()> {
     // Log system information as early as possible so we have it
     // available in case of a crash
@@ -99,13 +113,13 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
         exporter.metrics.rate_limiter.clone(),
     )?;
 
-    output::start(
+    let mut output_handle = output::start(
         rx,
         running.subscribe(),
         exporter.metrics.output.clone(),
         reloader.grpc(),
         reloader.config().json(),
-    )?;
+    );
     let mut host_scanner_handle = host_scanner.start();
     let mut rate_limiter_handle = rate_limiter.start();
     endpoints::Server::new(exporter.clone(), reloader.endpoint(), running.subscribe()).start();
@@ -114,43 +128,28 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
 
     let mut sigterm = signal(SignalKind::terminate())?;
     let mut sighup = signal(SignalKind::hangup())?;
-    loop {
+    let res = loop {
         tokio::select! {
-            _ = tokio::signal::ctrl_c() => break,
-            _ = sigterm.recv() => break,
+            _ = tokio::signal::ctrl_c() => break Ok(()),
+            _ = sigterm.recv() => break Ok(()),
             _ = sighup.recv() => config_trigger.notify_one(),
-            res = bpf_handle.borrow_mut() => {
-                match res {
-                    Ok(res) => if let Err(e) = res {
-                        warn!("BPF worker errored out: {e:?}");
-                    }
-                    Err(e) => warn!("BPF task errored out: {e:?}"),
-                }
-                break;
+            task_res = bpf_handle.borrow_mut() => {
+                break flatten_task_result("BPF", task_res);
             }
-            res = host_scanner_handle.borrow_mut() => {
-                match res {
-                    Ok(res) => if let Err(e) = res {
-                        warn!("HostScanner worker errored out: {e:?}");
-                    }
-                    Err(e) => warn!("HostScanner task errored out: {e:?}"),
-                }
-                break;
+            task_res = host_scanner_handle.borrow_mut() => {
+                break flatten_task_result("HostScanner", task_res);
             }
-            res = rate_limiter_handle.borrow_mut() => {
-                match res {
-                    Ok(res) => if let Err(e) = res {
-                        warn!("Rate limiter worker errored out: {e:?}");
-                    }
-                    Err(e) => warn!("Rate limiter task errored out: {e:?}"),
-                }
-                break;
+            task_res = rate_limiter_handle.borrow_mut() => {
+                break flatten_task_result("Rate limiter", task_res);
+            }
+            task_res = output_handle.borrow_mut() => {
+                break flatten_task_result("Output", task_res);
             }
         }
-    }
+    };
 
     running.send(false)?;
     info!("Exiting...");
 
-    Ok(())
+    res
 }

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -215,9 +215,11 @@ impl Client {
                 Ok(channel) => channel,
                 Err(e) => {
                     let Some(delay) = backoff.next() else {
-                        bail!("Failed to connect to server: reconnection attempts exhausted");
+                        bail!(
+                            "Failed to connect to server: Reconnection attempts exhausted: {e:?}"
+                        );
                     };
-                    info!("Failed to connect to server: {e:?}, retrying in {delay:?}");
+                    warn!("Failed to connect to server: {e:?}\nRetrying in {delay:?}");
                     sleep(delay).await;
                     continue;
                 }

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -4,12 +4,13 @@ use anyhow::{Context, bail};
 use fact_api::file_activity_service_client::FileActivityServiceClient;
 use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
-use log::{debug, info, warn};
+use log::{info, warn};
 use native_tls::{Certificate, Identity};
 use openssl::{ec::EcKey, pkey::PKey};
 use tokio::{
     fs,
     sync::{broadcast, watch},
+    task::JoinHandle,
     time::sleep,
 };
 use tokio_stream::{
@@ -30,13 +31,28 @@ struct Backoff {
     max: Duration,
     jitter: bool,
     multiplier: f64,
+    retries_max: u64,
+    retries_curr: u64,
 }
 
 impl Backoff {
-    fn new(initial: Duration, max: Duration, jitter: bool, multiplier: f64) -> Self {
-        if initial >= max {
-            warn!("Initial backoff value is equal or greater than max.");
-        }
+    fn new(
+        initial: Duration,
+        max: Duration,
+        jitter: bool,
+        multiplier: f64,
+        retries_max: u64,
+    ) -> Self {
+        let initial = if initial >= max {
+            warn!(
+                "Invalid initial value: {} >= {}",
+                initial.as_secs_f64(),
+                max.as_secs_f64()
+            );
+            max
+        } else {
+            initial
+        };
 
         Self {
             initial,
@@ -44,22 +60,34 @@ impl Backoff {
             max,
             jitter,
             multiplier,
+            retries_max,
+            retries_curr: 0,
         }
     }
 
-    fn next(&mut self) -> Duration {
-        let delay = self.current.min(self.max);
+    fn next(&mut self) -> Option<Duration> {
+        if self.retries_max != 0 {
+            if self.retries_curr >= self.retries_max {
+                return None;
+            }
+            self.retries_curr += 1;
+        }
+
+        let delay = self.current;
         self.current = self.current.mul_f64(self.multiplier).min(self.max);
-        if self.jitter {
+        let delay = if self.jitter {
             let nanos = rand::random_range(0..=delay.as_nanos() as u64);
             Duration::from_nanos(nanos)
         } else {
             delay
-        }
+        };
+
+        Some(delay)
     }
 
     fn reset(&mut self) {
         self.current = self.initial;
+        self.retries_curr = 0;
     }
 }
 
@@ -70,6 +98,7 @@ impl From<&BackoffConfig> for Backoff {
             value.max(),
             value.jitter(),
             value.multiplier(),
+            value.retries(),
         )
     }
 }
@@ -96,7 +125,7 @@ impl Client {
         }
     }
 
-    pub fn start(mut self) {
+    pub fn start(mut self) -> JoinHandle<anyhow::Result<()>> {
         tokio::spawn(async move {
             loop {
                 let res = if self.is_enabled() {
@@ -111,10 +140,11 @@ impl Client {
                         info!("Stopping gRPC output...");
                         break;
                     }
-                    Err(e) => warn!("gRPC error: {e:?}"),
+                    Err(e) => bail!("gRPC error: {e:?}"),
                 }
             }
-        });
+            Ok(())
+        })
     }
 
     async fn get_connector(&self) -> anyhow::Result<Option<HttpsConnector<HttpConnector>>> {
@@ -184,8 +214,10 @@ impl Client {
             let channel = match self.create_channel(connector).await {
                 Ok(channel) => channel,
                 Err(e) => {
-                    let delay = backoff.next();
-                    debug!("Failed to connect to server: {e:?}, retrying in {delay:?}");
+                    let Some(delay) = backoff.next() else {
+                        bail!("Failed to connect to server: reconnection attempts exhausted");
+                    };
+                    info!("Failed to connect to server: {e:?}, retrying in {delay:?}");
                     sleep(delay).await;
                     continue;
                 }
@@ -241,49 +273,79 @@ mod tests {
 
     #[test]
     fn backoff_exponential_2x() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false, 2.0);
-        assert_eq!(b.next(), Duration::from_secs(1));
-        assert_eq!(b.next(), Duration::from_secs(2));
-        assert_eq!(b.next(), Duration::from_secs(4));
-        assert_eq!(b.next(), Duration::from_secs(8));
-        assert_eq!(b.next(), Duration::from_secs(16));
-        assert_eq!(b.next(), Duration::from_secs(32));
+        let mut b = Backoff::new(
+            Duration::from_secs(1),
+            Duration::from_secs(60),
+            false,
+            2.0,
+            0,
+        );
+        assert_eq!(b.next(), Some(Duration::from_secs(1)));
+        assert_eq!(b.next(), Some(Duration::from_secs(2)));
+        assert_eq!(b.next(), Some(Duration::from_secs(4)));
+        assert_eq!(b.next(), Some(Duration::from_secs(8)));
+        assert_eq!(b.next(), Some(Duration::from_secs(16)));
+        assert_eq!(b.next(), Some(Duration::from_secs(32)));
     }
 
     #[test]
     fn backoff_default_multiplier() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false, 1.5);
-        assert_eq!(b.next(), Duration::from_secs(1));
-        assert_eq!(b.next(), Duration::from_millis(1500));
-        assert_eq!(b.next(), Duration::from_millis(2250));
-        assert_eq!(b.next(), Duration::from_millis(3375));
+        let mut b = Backoff::new(
+            Duration::from_secs(1),
+            Duration::from_secs(60),
+            false,
+            1.5,
+            0,
+        );
+        assert_eq!(b.next(), Some(Duration::from_secs(1)));
+        assert_eq!(b.next(), Some(Duration::from_millis(1500)));
+        assert_eq!(b.next(), Some(Duration::from_millis(2250)));
+        assert_eq!(b.next(), Some(Duration::from_millis(3375)));
     }
 
     #[test]
     fn backoff_caps_at_max() {
-        let mut b = Backoff::new(Duration::from_secs(32), Duration::from_secs(60), false, 2.0);
-        assert_eq!(b.next(), Duration::from_secs(32));
-        assert_eq!(b.next(), Duration::from_secs(60));
-        assert_eq!(b.next(), Duration::from_secs(60));
+        let mut b = Backoff::new(
+            Duration::from_secs(32),
+            Duration::from_secs(60),
+            false,
+            2.0,
+            0,
+        );
+        assert_eq!(b.next(), Some(Duration::from_secs(32)));
+        assert_eq!(b.next(), Some(Duration::from_secs(60)));
+        assert_eq!(b.next(), Some(Duration::from_secs(60)));
     }
 
     #[test]
     fn backoff_reset() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), false, 2.0);
-        assert_eq!(b.next(), Duration::from_secs(1));
-        assert_eq!(b.next(), Duration::from_secs(2));
-        assert_eq!(b.next(), Duration::from_secs(4));
+        let mut b = Backoff::new(
+            Duration::from_secs(1),
+            Duration::from_secs(60),
+            false,
+            2.0,
+            0,
+        );
+        assert_eq!(b.next(), Some(Duration::from_secs(1)));
+        assert_eq!(b.next(), Some(Duration::from_secs(2)));
+        assert_eq!(b.next(), Some(Duration::from_secs(4)));
         b.reset();
-        assert_eq!(b.next(), Duration::from_secs(1));
-        assert_eq!(b.next(), Duration::from_secs(2));
+        assert_eq!(b.next(), Some(Duration::from_secs(1)));
+        assert_eq!(b.next(), Some(Duration::from_secs(2)));
     }
 
     #[test]
     fn backoff_jitter_within_range() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), true, 1.5);
+        let mut b = Backoff::new(
+            Duration::from_secs(1),
+            Duration::from_secs(60),
+            true,
+            1.5,
+            0,
+        );
         let mut expected_max = Duration::from_secs(1);
         for _ in 0..100 {
-            let delay = b.next();
+            let delay = b.next().expect("retries exhausted");
             assert!(
                 delay <= expected_max,
                 "delay {delay:?} exceeded expected max {expected_max:?}"
@@ -295,15 +357,68 @@ mod tests {
 
     #[test]
     fn backoff_jitter_reset() {
-        let mut b = Backoff::new(Duration::from_secs(1), Duration::from_secs(60), true, 1.5);
+        let mut b = Backoff::new(
+            Duration::from_secs(1),
+            Duration::from_secs(60),
+            true,
+            1.5,
+            0,
+        );
         for _ in 0..5 {
             b.next();
         }
         b.reset();
-        let delay = b.next();
+        let delay = b.next().expect("retries exhausted");
         assert!(
             delay <= Duration::from_secs(1),
             "delay {delay:?} exceeded 1s after reset"
         );
+    }
+
+    #[test]
+    fn backoff_reconnection_give_up() {
+        let mut b = Backoff::new(
+            Duration::from_secs(1),
+            Duration::from_secs(60),
+            false,
+            2.0,
+            3,
+        );
+        assert_eq!(b.next(), Some(Duration::from_secs(1)));
+        assert_eq!(b.next(), Some(Duration::from_secs(2)));
+        assert_eq!(b.next(), Some(Duration::from_secs(4)));
+        assert_eq!(b.next(), None);
+    }
+
+    #[test]
+    fn backoff_reconnection_reset() {
+        let mut b = Backoff::new(
+            Duration::from_secs(1),
+            Duration::from_secs(60),
+            false,
+            2.0,
+            3,
+        );
+        assert_eq!(b.next(), Some(Duration::from_secs(1)));
+        assert_eq!(b.next(), Some(Duration::from_secs(2)));
+        b.reset();
+        assert_eq!(b.next(), Some(Duration::from_secs(1)));
+        assert_eq!(b.next(), Some(Duration::from_secs(2)));
+        assert_eq!(b.next(), Some(Duration::from_secs(4)));
+        assert_eq!(b.next(), None);
+    }
+
+    #[test]
+    fn backoff_initial_greater_than_max() {
+        let mut b = Backoff::new(
+            Duration::from_secs(120),
+            Duration::from_secs(60),
+            false,
+            2.0,
+            0,
+        );
+        assert_eq!(b.next(), Some(Duration::from_secs(60)));
+        assert_eq!(b.next(), Some(Duration::from_secs(60)));
+        assert_eq!(b.next(), Some(Duration::from_secs(60)));
     }
 }

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -73,7 +73,7 @@ impl Backoff {
             self.retries_curr += 1;
         }
 
-        let delay = self.current;
+        let delay = self.current.min(self.max);
         self.current = self.current.mul_f64(self.multiplier).min(self.max);
         let delay = if self.jitter {
             let nanos = rand::random_range(0..=delay.as_nanos() as u64);

--- a/fact/src/output/mod.rs
+++ b/fact/src/output/mod.rs
@@ -62,8 +62,8 @@ pub fn start(
                 res = grpc_handle.borrow_mut() => {
                     match res {
                         Ok(Ok(_)) => break,
-                        Ok(Err(e)) => bail!("grpc worker errored out: {e:?}"),
-                        Err(e) => bail!("grpc task errored out: {e:?}"),
+                        Ok(Err(e)) => bail!("gRPC worker errored out: {e:?}"),
+                        Err(e) => bail!("gRPC task errored out: {e:?}"),
                     }
                 }
                 _ = run.changed() => if !*run.borrow() { break; }

--- a/fact/src/output/mod.rs
+++ b/fact/src/output/mod.rs
@@ -1,7 +1,11 @@
-use std::sync::Arc;
+use std::{borrow::BorrowMut, sync::Arc};
 
+use anyhow::bail;
 use log::{debug, warn};
-use tokio::sync::{broadcast, mpsc, watch};
+use tokio::{
+    sync::{broadcast, mpsc, watch},
+    task::JoinHandle,
+};
 
 use crate::{config::GrpcConfig, event::Event, metrics::OutputMetrics};
 
@@ -18,27 +22,9 @@ pub fn start(
     metrics: OutputMetrics,
     config: watch::Receiver<GrpcConfig>,
     stdout_enabled: bool,
-) -> anyhow::Result<()> {
+) -> JoinHandle<anyhow::Result<()>> {
     let (broad_tx, broad_rx) = broadcast::channel(100);
     let mut run = running.clone();
-    tokio::spawn(async move {
-        debug!("Starting output component...");
-        loop {
-            tokio::select! {
-                event = rx.recv() => {
-                    let Some(event) = event else {
-                        break;
-                    };
-
-                    if let Err(e) = broad_tx.send(Arc::new(event)) {
-                        warn!("Failed to forward output event: {e}");
-                    }
-                }
-                _ = run.changed() => if !*run.borrow() { break; }
-            }
-        }
-        debug!("Stopping output component...");
-    });
 
     let grpc_client = grpc::Client::new(
         broad_rx.resubscribe(),
@@ -58,7 +44,32 @@ pub fn start(
         .start();
     }
 
-    grpc_client.start();
+    let mut grpc_handle = grpc_client.start();
 
-    Ok(())
+    tokio::spawn(async move {
+        debug!("Starting output component...");
+        loop {
+            tokio::select! {
+                event = rx.recv() => {
+                    let Some(event) = event else {
+                        break;
+                    };
+
+                    if let Err(e) = broad_tx.send(Arc::new(event)) {
+                        warn!("Failed to forward output event: {e}");
+                    }
+                }
+                res = grpc_handle.borrow_mut() => {
+                    match res {
+                        Ok(Ok(_)) => break,
+                        Ok(Err(e)) => bail!("grpc worker errored out: {e:?}"),
+                        Err(e) => bail!("grpc task errored out: {e:?}"),
+                    }
+                }
+                _ = run.changed() => if !*run.borrow() { break; }
+            }
+        }
+        debug!("Stopping output component...");
+        Ok(())
+    })
 }


### PR DESCRIPTION
## Description

If fact fails to connect to the gRPC server in the specified number of attemtps it will crash, which can be used as a clear signal in k8s that something is not working as expected. If the number of retries is set to 0, there will be no limit to the amount of times fact attempts to reconnect.

In order to allow the reconnection failure to trigger an application wide crash, the main output task monitors the result of the grpc task's handle propagating the error further up. This method should allow for other output components to be added in the future and follow this same pattern without having to change anything outside the output module. The stdout component is not included in this logic because it has no condition that could merit an application wide crash.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Pointed fact to connect to a non-existant gRPC server and got it to crash as expected.

<details>
  <summary>fact output on crash</summary>

```
[INFO  2026-06-24T16:55:17Z] FactConfig {
    paths: Some(
        [
            "/etc/sensitive-files/**/*",
            "/etc/sensitive-files",
        ],
    ),
    grpc: GrpcConfig {
        url: Some(
            "http://localhost:9999",
        ),
        certs: None,
        backoff: BackoffConfig {
            initial: None,
            max: Some(
                1s,
            ),
            jitter: Some(
                false,
            ),
            multiplier: None,
            retries_max: Some(
                3,
            ),
        },
    },
    endpoint: EndpointConfig {
        address: None,
        expose_metrics: Some(
            true,
        ),
        health_check: None,
    },
    bpf: BpfConfig {
        ringbuf_size: None,
        inodes_max: None,
    },
    skip_pre_flight: None,
    json: None,
    hotreload: None,
    scan_interval: None,
    rate_limit: None,
}
[INFO  2026-06-24T16:55:17Z] fact version: 0.3.x-104-g669f5be002
[INFO  2026-06-24T16:55:17Z] OS: Fedora Linux 44 (Workstation Edition)
[INFO  2026-06-24T16:55:17Z] Kernel version: 7.0.12-201.fc44.x86_64
[INFO  2026-06-24T16:55:17Z] Architecture: x86_64
[INFO  2026-06-24T16:55:17Z] Hostname: mmoltras-thinkpadp1gen5.remote.csb
[INFO  2026-06-24T16:55:17Z] Starting BPF worker...
[WARN  2026-06-24T16:55:17Z] Invalid initial value: 1 >= 1
[INFO  2026-06-24T16:55:17Z] Attempting to connect to gRPC server...
[INFO  2026-06-24T16:55:17Z] Starting host scanner...
[WARN  2026-06-24T16:55:17Z] Using unencrypted gRPC channel
[INFO  2026-06-24T16:55:17Z] Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111), retrying in 1s
[INFO  2026-06-24T16:55:18Z] Attempting to connect to gRPC server...
[WARN  2026-06-24T16:55:18Z] Using unencrypted gRPC channel
[INFO  2026-06-24T16:55:18Z] Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111), retrying in 1s
[INFO  2026-06-24T16:55:19Z] Attempting to connect to gRPC server...
[WARN  2026-06-24T16:55:19Z] Using unencrypted gRPC channel
[INFO  2026-06-24T16:55:19Z] Failed to connect to server: transport error

Caused by:
    0: tcp connect error
    1: tcp connect error
    2: Connection refused (os error 111), retrying in 1s
[INFO  2026-06-24T16:55:20Z] Attempting to connect to gRPC server...
[WARN  2026-06-24T16:55:20Z] Using unencrypted gRPC channel
[INFO  2026-06-24T16:55:20Z] Exiting...
[INFO  2026-06-24T16:55:20Z] Stopping config reloader...
[INFO  2026-06-24T16:55:20Z] Stopping endpoints...
Error: Output worker errored out: grpc worker errored out: gRPC error: Failed to connect to server: reconnection attempts exhausted

```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for gRPC reconnect retries via config/YAML, environment variable, or CLI.
  * When not set, a default retry limit is used.
* **Bug Fixes**
  * Updated gRPC reconnect logic to stop retrying after the configured limit, including clearer “give up” behavior.
  * Improved shutdown and background-task failure propagation for more reliable termination and error reporting.
* **Tests**
  * Expanded parsing, validation, environment-variable, and reconnection retry coverage for the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->