### PR TITLE
fix(tests): retry fact health_check more times

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,7 +224,7 @@ def fact(
 
     container_log = os.path.join(logs_dir, 'fact.log')
     # Wait for container to be ready
-    for _ in range(3):
+    for _ in range(10):
         try:
             resp = requests.get(
                 f'http://{config["endpoint"]["address"]}/health_check'


### PR DESCRIPTION
## Description

After adding some more test platforms through #760, some tests have started failing with the claim that fact failed to start. Upon reviewing the logs it turns out fact sometimes take slightly longer to start, so increasing the number of times we retry the health_check endpoint should be enough to mitigate this flake.

Examples of the flake:
- https://github.com/stackrox/fact/actions/runs/28161189666?pr=902
- https://github.com/stackrox/fact/actions/runs/28142441160
- https://github.com/stackrox/fact/actions/runs/28126991314

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough. Will monitor CI after merging to check the flake is properly gone.

