### PR TITLE
fix(tests): use regexes for better exclusions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         repository: stackrox/collector
         path: collector
-        ref: master
+        ref: mauro/ansible/exclude-by-regex
     - uses: actions/setup-python@v5
       with:
         python-version: "3.10"
@@ -88,14 +88,11 @@ jobs:
         # RHEL 8 doesn't handle file creation properly,
         # need more investigation
         - rhel-8
-        - rhcos-412-86-202402272018-0-gcp-x86-64
-        - rhcos-414-92-202407091253-0-gcp-x86-64
+        - rhcos-4[-0-9]+-gcp-x86-64
         # BPF trampolines are only implemented starting with RHEL 10
         - rhel-9-arm64
-        - rhcos-9-8-20260520-0-gcp-aarch64
-        - rhcos-9-6-20260512-0-gcp-aarch64
-        - rhcos-418-94-202602022246-0-gcp-aarch64
-        - rhcos-416-94-202510081640-0-gcp-aarch64
+        - rhcos-9-[-0-9]+-gcp-aarch64
+        - rhcos-4[-0-9]+-gcp-aarch64
         EOF
 
     - name: Create Test VMs

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,9 +88,13 @@ jobs:
         # RHEL 8 doesn't handle file creation properly,
         # need more investigation
         - rhel-8
-        - rhcos-41[0-4]-[-0-9]+-gcp-x86-64
         # BPF trampolines are only implemented starting with RHEL 10
         - rhel-9-arm64
+        excluded_images:
+        # RHEL 8 doesn't handle file creation properly,
+        # need more investigation
+        - rhcos-41[0-4]-[-0-9]+-gcp-x86-64
+        # BPF trampolines are only implemented starting with RHEL 10
         - rhcos-9-[-0-9]+-gcp-aarch64
         - rhcos-4[-0-9]+-gcp-aarch64
         EOF

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,7 +88,7 @@ jobs:
         # RHEL 8 doesn't handle file creation properly,
         # need more investigation
         - rhel-8
-        - rhcos-4[-0-9]+-gcp-x86-64
+        - rhcos-41[0-4]-[-0-9]+-gcp-x86-64
         # BPF trampolines are only implemented starting with RHEL 10
         - rhel-9-arm64
         - rhcos-9-[-0-9]+-gcp-aarch64

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         repository: stackrox/collector
         path: collector
-        ref: mauro/ansible/exclude-by-regex
+        ref: master
     - uses: actions/setup-python@v5
       with:
         python-version: "3.10"


### PR DESCRIPTION

## Description

The images we use from RHCOS may change from underneatch our feet, so we use regexes to exclude broader patterns that we know won't work with fact.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Verify all expected RHCOS VMs run the tests
- [x] Update collector ref to master before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated integration test image exclusion rules to reduce false failures caused by changes in RHCOS image naming.
  * Replaced specific excluded image identifiers with broader regex-style patterns to better match both x86_64 and aarch64 RHCOS variants, improving test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->