### PR TITLE
fix(mintmaker): always recreate StackRox konflux-tasks update PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,8 @@
         "matchPackageNames": [
           "/^quay.io/rhacs-eng/konflux-tasks/",
         ],
+        "recreateWhen": "always",
+        "rebaseWhen": "behind-base-branch",
       },
     ],
   },


### PR DESCRIPTION
## Description

Recently found some PRs that should've updated the custom konflux tasks from stackrox that were not being set to auto-merge, it has been suggested by the MintMaker team that adding the fields in this PR will help with the issue.

More context at: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1782727458789889

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Can't really test this without merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automation configuration to keep package updates more current by automatically recreating and rebasing them when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->