### PR TITLE
feat(output): add basic opentelemetry output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ possible include a PR number for easier tracking.
 
 ## Next
 
+* feat(output): add basic opentelemetry output (#971)
 * feat(grpc): add exponential backoff for reconnection attempts (#789)
 * feat: run integration tests on more platforms (#760)
 * ROX-34502: reload mTLS certificates on each gRPC connection attempt (#788)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +503,9 @@ dependencies = [
  "log",
  "native-tls",
  "openssl",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "prometheus-client",
  "prost",
  "prost-types",
@@ -585,12 +599,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -598,6 +622,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -624,8 +676,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -870,18 +925,124 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -893,6 +1054,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -981,6 +1148,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1139,6 +1312,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1466,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1479,6 +1731,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1948,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tempfile"
@@ -1691,6 +1994,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1843,6 +2156,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +2235,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2310,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2059,6 +2418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yaml-rust2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2432,29 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -2083,6 +2471,60 @@ name = "zerocopy-derive"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/fact/Cargo.toml
+++ b/fact/Cargo.toml
@@ -20,6 +20,9 @@ hyper-util = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 native-tls = { workspace = true }
+opentelemetry = { version = "0.32.0", optional = true }
+opentelemetry-otlp = { version = "0.32.0", optional = true }
+opentelemetry_sdk = { version = "0.32.1", features = [ "logs"], optional = true }
 openssl = { workspace = true }
 tonic = { workspace = true }
 tokio = { workspace = true }
@@ -51,3 +54,4 @@ path = "src/main.rs"
 
 [features]
 bpf-test = []
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -34,6 +34,7 @@ fn yaml_to_duration_secs(v: &Yaml) -> Option<Duration> {
 pub struct FactConfig {
     paths: Option<Vec<PathBuf>>,
     pub grpc: GrpcConfig,
+    pub otel: OTelConfig,
     pub endpoint: EndpointConfig,
     pub bpf: BpfConfig,
     skip_pre_flight: Option<bool>,
@@ -72,7 +73,7 @@ impl FactConfig {
             )?;
 
         // Once file configuration is handled, apply CLI arguments
-        static CLI_ARGS: LazyLock<FactConfig> = LazyLock::new(|| FactCli::parse().to_config());
+        static CLI_ARGS: LazyLock<FactConfig> = LazyLock::new(|| FactCli::parse().into_config());
         config.update(&CLI_ARGS);
 
         Ok(config)
@@ -84,6 +85,7 @@ impl FactConfig {
         }
 
         self.grpc.update(&from.grpc);
+        self.otel.update(&from.otel);
         self.endpoint.update(&from.endpoint);
         self.bpf.update(&from.bpf);
 
@@ -195,6 +197,10 @@ impl TryFrom<Vec<Yaml>> for FactConfig {
                 "grpc" if v.is_hash() => {
                     let grpc = v.as_hash().unwrap();
                     config.grpc = GrpcConfig::try_from(grpc)?;
+                }
+                "otel" if v.is_hash() => {
+                    let otel = v.as_hash().unwrap();
+                    config.otel = OTelConfig::try_from(otel)?;
                 }
                 "endpoint" if v.is_hash() => {
                     let endpoint = v.as_hash().unwrap();
@@ -493,6 +499,48 @@ impl TryFrom<&yaml::Hash> for GrpcConfig {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct OTelConfig {
+    endpoint: Option<String>,
+}
+
+impl OTelConfig {
+    fn update(&mut self, from: &OTelConfig) {
+        if let Some(endpoint) = from.endpoint.as_deref() {
+            self.endpoint = Some(endpoint.to_owned());
+        }
+    }
+
+    pub fn endpoint(&self) -> Option<&str> {
+        self.endpoint.as_deref()
+    }
+}
+
+impl TryFrom<&yaml::Hash> for OTelConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &yaml::Hash) -> Result<Self, Self::Error> {
+        let mut otel = OTelConfig::default();
+        for (k, v) in value.iter() {
+            let Some(k) = k.as_str() else {
+                bail!("key is not string: {k:?}");
+            };
+
+            match k {
+                "endpoint" => {
+                    let Some(endpoint) = v.as_str() else {
+                        bail!("otel.endpoint field has incorrect type: {v:?}")
+                    };
+                    otel.endpoint = Some(endpoint.to_owned());
+                }
+                name => bail!("Invalid field 'otel.{name}' with value: {v:?}"),
+            }
+        }
+
+        Ok(otel)
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct BpfConfig {
     ringbuf_size: Option<u32>,
     inodes_max: Option<u32>,
@@ -627,6 +675,10 @@ pub struct FactCli {
     #[arg(long, env = "FACT_GRPC_BACKOFF_RETRIES_MAX")]
     backoff_retries_max: Option<u64>,
 
+    /// OpenTelemetry endpoint to push logs into
+    #[arg(long, env = "FACT_OTEL_ENDPOINT")]
+    otel_endpoint: Option<String>,
+
     /// The port to bind for all exposed endpoints
     #[arg(long, short, env = "FACT_ENDPOINT_ADDRESS")]
     address: Option<SocketAddr>,
@@ -711,12 +763,12 @@ pub struct FactCli {
 }
 
 impl FactCli {
-    fn to_config(&self) -> FactConfig {
+    fn into_config(self) -> FactConfig {
         FactConfig {
-            paths: self.paths.clone(),
+            paths: self.paths,
             grpc: GrpcConfig {
-                url: self.url.clone(),
-                certs: self.certs.clone(),
+                url: self.url,
+                certs: self.certs,
                 backoff: BackoffConfig {
                     initial: self.backoff_initial,
                     max: self.backoff_max,
@@ -724,6 +776,9 @@ impl FactCli {
                     multiplier: self.backoff_multiplier,
                     retries_max: self.backoff_retries_max,
                 },
+            },
+            otel: OTelConfig {
+                endpoint: self.otel_endpoint,
             },
             endpoint: EndpointConfig {
                 address: self.address,

--- a/fact/src/config/reloader.rs
+++ b/fact/src/config/reloader.rs
@@ -9,12 +9,15 @@ use tokio::{
     time::interval,
 };
 
+use crate::config::OTelConfig;
+
 use super::{CONFIG_FILES, EndpointConfig, FactConfig, GrpcConfig};
 
 pub struct Reloader {
     config: FactConfig,
     endpoint: watch::Sender<EndpointConfig>,
     grpc: watch::Sender<GrpcConfig>,
+    otel: watch::Sender<OTelConfig>,
     paths: watch::Sender<Vec<PathBuf>>,
     files: HashMap<&'static str, i64>,
     scan_interval: watch::Sender<Duration>,
@@ -69,6 +72,12 @@ impl Reloader {
     /// changed.
     pub fn grpc(&self) -> watch::Receiver<GrpcConfig> {
         self.grpc.subscribe()
+    }
+
+    /// Subscribe to get notifications when otel configuration is
+    /// changed.
+    pub fn otel(&self) -> watch::Receiver<OTelConfig> {
+        self.otel.subscribe()
     }
 
     /// Subscribe to get notifications when paths configuration is
@@ -174,6 +183,16 @@ impl Reloader {
             }
         });
 
+        self.otel.send_if_modified(|old| {
+            if *old != new.otel {
+                debug!("Sending new OTel configuration...");
+                *old = new.otel.clone();
+                true
+            } else {
+                false
+            }
+        });
+
         self.paths.send_if_modified(|old| {
             let new = new.paths();
             if *old != new {
@@ -238,6 +257,7 @@ impl From<FactConfig> for Reloader {
             .collect();
         let (endpoint, _) = watch::channel(config.endpoint.clone());
         let (grpc, _) = watch::channel(config.grpc.clone());
+        let (otel, _) = watch::channel(config.otel.clone());
         let (paths, _) = watch::channel(config.paths().to_vec());
         let (scan_interval, _) = watch::channel(config.scan_interval());
         let (rate_limit, _) = watch::channel(config.rate_limit());
@@ -247,6 +267,7 @@ impl From<FactConfig> for Reloader {
             config,
             endpoint,
             grpc,
+            otel,
             paths,
             scan_interval,
             rate_limit,

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -51,6 +51,144 @@ fn parsing() {
         ),
         (
             r#"
+            grpc:
+              backoff:
+                initial: 2
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs(2)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                max: 30
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        max: Some(Duration::from_secs(30)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                jitter: false
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        jitter: Some(false),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                multiplier: 2
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        multiplier: Some(2.0),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                multiplier: 3.5
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        multiplier: Some(3.5),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                retries: 5
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        retries_max: Some(5),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            grpc:
+              backoff:
+                initial: 0.5
+                max: 120
+                jitter: false
+                multiplier: 2
+                retries: 5
+            "#,
+            FactConfig {
+                grpc: GrpcConfig {
+                    backoff: BackoffConfig {
+                        initial: Some(Duration::from_secs_f64(0.5)),
+                        max: Some(Duration::from_secs(120)),
+                        jitter: Some(false),
+                        multiplier: Some(2.0),
+                        retries_max: Some(5),
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            otel:
+              endpoint: http://localhost:4317
+            "#,
+            FactConfig {
+                otel: OTelConfig {
+                    endpoint: Some("http://localhost:4317".into()),
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
             endpoint:
               address: 0.0.0.0:8080
             "#,
@@ -257,134 +395,10 @@ fn parsing() {
         ),
         (
             r#"
-            grpc:
-              backoff:
-                initial: 2
-            "#,
-            FactConfig {
-                grpc: GrpcConfig {
-                    backoff: BackoffConfig {
-                        initial: Some(Duration::from_secs(2)),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ),
-        (
-            r#"
-            grpc:
-              backoff:
-                max: 30
-            "#,
-            FactConfig {
-                grpc: GrpcConfig {
-                    backoff: BackoffConfig {
-                        max: Some(Duration::from_secs(30)),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ),
-        (
-            r#"
-            grpc:
-              backoff:
-                jitter: false
-            "#,
-            FactConfig {
-                grpc: GrpcConfig {
-                    backoff: BackoffConfig {
-                        jitter: Some(false),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ),
-        (
-            r#"
-            grpc:
-              backoff:
-                multiplier: 2
-            "#,
-            FactConfig {
-                grpc: GrpcConfig {
-                    backoff: BackoffConfig {
-                        multiplier: Some(2.0),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ),
-        (
-            r#"
-            grpc:
-              backoff:
-                multiplier: 3.5
-            "#,
-            FactConfig {
-                grpc: GrpcConfig {
-                    backoff: BackoffConfig {
-                        multiplier: Some(3.5),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ),
-        (
-            r#"
-            grpc:
-              backoff:
-                retries: 5
-            "#,
-            FactConfig {
-                grpc: GrpcConfig {
-                    backoff: BackoffConfig {
-                        retries_max: Some(5),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ),
-        (
-            r#"
-            grpc:
-              backoff:
-                initial: 0.5
-                max: 120
-                jitter: false
-                multiplier: 2
-                retries: 5
-            "#,
-            FactConfig {
-                grpc: GrpcConfig {
-                    backoff: BackoffConfig {
-                        initial: Some(Duration::from_secs_f64(0.5)),
-                        max: Some(Duration::from_secs(120)),
-                        jitter: Some(false),
-                        multiplier: Some(2.0),
-                        retries_max: Some(5),
-                    },
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ),
-        (
-            r#"
             paths:
             - /etc
+            otel:
+              endpoint: 'http://localhost:4317'
             grpc:
               url: 'https://svc.sensor.stackrox:9090'
               certs: /etc/stackrox/certs
@@ -418,6 +432,9 @@ fn parsing() {
                         multiplier: Some(2.0),
                         retries_max: Some(5),
                     },
+                },
+                otel: OTelConfig {
+                    endpoint: Some("http://localhost:4317".into()),
                 },
                 endpoint: EndpointConfig {
                     address: Some(SocketAddr::from(([0, 0, 0, 0], 8080))),
@@ -595,6 +612,26 @@ paths:
                 unknown: 4
             "#,
             "Invalid field 'grpc.backoff.unknown' with value: Integer(4)",
+        ),
+        (
+            r#"
+            otel: 5
+            "#,
+            "Invalid field 'otel' with value: Integer(5)",
+        ),
+        (
+            r#"
+            otel:
+              something: true
+            "#,
+            "Invalid field 'otel.something' with value: Boolean(true)",
+        ),
+        (
+            r#"
+            otel:
+              endpoint: false
+            "#,
+            "otel.endpoint field has incorrect type: Boolean(false)",
         ),
         (
             "endpoint: true",
@@ -1150,6 +1187,37 @@ fn update() {
         ),
         (
             r#"
+            otel:
+              endpoint: 'http://localhost:4317'
+            "#,
+            FactConfig::default(),
+            FactConfig {
+                otel: OTelConfig {
+                    endpoint: Some(String::from("http://localhost:4317")),
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            otel:
+              endpoint: 'http://localhost:4317'
+            "#,
+            FactConfig {
+                otel: OTelConfig {
+                    endpoint: Some(String::from("http://localhost:1234")),
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                otel: OTelConfig {
+                    endpoint: Some(String::from("http://localhost:4317")),
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
             endpoint:
               expose_metrics: true
             "#,
@@ -1516,6 +1584,8 @@ fn update() {
                 jitter: false
                 multiplier: 3.0
                 retries: 5
+            otel:
+              endpoint: 'http://localhost:4317'
             endpoint:
               address: 127.0.0.1:8080
               expose_metrics: true
@@ -1540,6 +1610,9 @@ fn update() {
                         multiplier: Some(2.0),
                         retries_max: Some(20),
                     },
+                },
+                otel: OTelConfig {
+                    endpoint: Some(String::from("http://localhost:1234")),
                 },
                 endpoint: EndpointConfig {
                     address: Some(SocketAddr::from(([0, 0, 0, 0], 9000))),
@@ -1568,6 +1641,9 @@ fn update() {
                         multiplier: Some(3.0),
                         retries_max: Some(5),
                     },
+                },
+                otel: OTelConfig {
+                    endpoint: Some(String::from("http://localhost:4317")),
                 },
                 endpoint: EndpointConfig {
                     address: Some(SocketAddr::from(([127, 0, 0, 1], 8080))),
@@ -1619,6 +1695,7 @@ fn defaults() {
     assert!(config.grpc.backoff.jitter());
     assert_eq!(config.grpc.backoff.multiplier(), 1.5);
     assert_eq!(config.grpc.backoff.retries(), 10);
+    assert_eq!(config.otel.endpoint(), None);
 }
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -1678,7 +1755,7 @@ impl Display for EnvVar {
 
 fn with_env_var(env: EnvVar) -> Result<FactConfig, clap::Error> {
     let _guard = env.set();
-    FactCli::try_parse_from(["fact"]).map(|cli| cli.to_config())
+    FactCli::try_parse_from(["fact"]).map(|cli| cli.into_config())
 }
 
 #[test]
@@ -1868,6 +1945,18 @@ fn env_vars() {
         ),
         (
             EnvVar {
+                name: "FACT_OTEL_ENDPOINT",
+                value: "http://localhost:4317",
+            },
+            FactConfig {
+                otel: OTelConfig {
+                    endpoint: Some(String::from("http://localhost:4317")),
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
                 name: "FACT_ENDPOINT_ADDRESS",
                 value: "0.0.0.0:8080",
             },
@@ -2007,6 +2096,22 @@ fn env_vars_override_yaml() {
                         ..Default::default()
                     },
                     ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
+                name: "FACT_OTEL_ENDPOINT",
+                value: "http://localhost:4317",
+            },
+            r#"
+            otel:
+              endpoint: 'http://localhost:1234'
+            "#,
+            FactConfig {
+                otel: OTelConfig {
+                    endpoint: Some(String::from("http://localhost:4317")),
                 },
                 ..Default::default()
             },

--- a/fact/src/event/mod.rs
+++ b/fact/src/event/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "otel")]
+use std::collections::HashMap;
 #[cfg(all(test, feature = "bpf-test"))]
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
@@ -7,6 +9,8 @@ use std::{
 };
 
 use globset::GlobSet;
+#[cfg(feature = "otel")]
+use opentelemetry::logs::AnyValue;
 use serde::Serialize;
 
 use fact_ebpf::{
@@ -322,6 +326,11 @@ impl Event {
     pub fn is_monitored_by_parent(&self) -> bool {
         self.get_monitored() == monitored_t::MONITORED_BY_PARENT
     }
+
+    #[cfg(feature = "otel")]
+    pub(crate) fn event_type(&self) -> &'static str {
+        self.file.event_type()
+    }
 }
 
 impl TryFrom<&event_t> for Event {
@@ -360,6 +369,18 @@ impl From<Event> for fact_api::FileActivity {
             process: Some(process),
             hostname: value.hostname.to_string(),
         }
+    }
+}
+
+#[cfg(feature = "otel")]
+impl From<Event> for opentelemetry::logs::AnyValue {
+    fn from(value: Event) -> Self {
+        AnyValue::Map(Box::new(HashMap::from([
+            ("file".into(), value.file.into()),
+            ("timestamp".into(), AnyValue::Int(value.timestamp as i64)),
+            ("process".into(), value.process.into()),
+            ("hostname".into(), value.hostname.into()),
+        ])))
     }
 }
 
@@ -466,6 +487,23 @@ impl FileData {
 
         Ok(file)
     }
+
+    #[cfg(feature = "otel")]
+    fn event_type(&self) -> &'static str {
+        match self {
+            FileData::Open(_) => "open",
+            FileData::Creation(_) => "creation",
+            FileData::MkDir(_) => "mkdir",
+            FileData::RmDir(_) => "rmdir",
+            FileData::Unlink(_) => "unlink",
+            FileData::Chmod(_) => "permission",
+            FileData::Chown(_) => "ownership",
+            FileData::Rename(_) => "rename",
+            FileData::SetXattr(_) => "xattr_set",
+            FileData::RemoveXattr(_) => "xattr_remove",
+            FileData::AclSet(_) => "acl",
+        }
+    }
 }
 
 impl From<FileData> for fact_api::file_activity::File {
@@ -517,6 +555,31 @@ impl From<FileData> for fact_api::file_activity::File {
                 fact_api::file_activity::File::Acl(f_act)
             }
         }
+    }
+}
+
+#[cfg(feature = "otel")]
+impl From<FileData> for opentelemetry::logs::AnyValue {
+    fn from(value: FileData) -> Self {
+        let event_type = value.event_type();
+        let AnyValue::Map(mut map) = (match value {
+            FileData::Open(data)
+            | FileData::Creation(data)
+            | FileData::MkDir(data)
+            | FileData::RmDir(data)
+            | FileData::Unlink(data) => AnyValue::from(data),
+            FileData::Chmod(data) => AnyValue::from(data),
+            FileData::Chown(data) => AnyValue::from(data),
+            FileData::Rename(data) => AnyValue::from(data),
+            FileData::SetXattr(data) | FileData::RemoveXattr(data) => AnyValue::from(data),
+            FileData::AclSet(data) => AnyValue::from(data),
+        }) else {
+            unreachable!("event data did not serialize to map");
+        };
+
+        map.insert("event_type".into(), event_type.into());
+
+        AnyValue::Map(map)
     }
 }
 
@@ -586,6 +649,22 @@ impl From<BaseFileData> for fact_api::FileActivityBase {
     }
 }
 
+#[cfg(feature = "otel")]
+impl From<BaseFileData> for opentelemetry::logs::AnyValue {
+    fn from(value: BaseFileData) -> Self {
+        AnyValue::Map(Box::new(HashMap::from([
+            (
+                "filename".into(),
+                value.filename.to_string_lossy().to_string().into(),
+            ),
+            (
+                "host_path".into(),
+                value.host_file.to_string_lossy().to_string().into(),
+            ),
+        ])))
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ChmodFileData {
     inner: BaseFileData,
@@ -605,6 +684,21 @@ impl From<ChmodFileData> for fact_api::FilePermissionChange {
             activity: Some(activity),
             mode: new_mode as u32,
         }
+    }
+}
+
+#[cfg(feature = "otel")]
+impl From<ChmodFileData> for opentelemetry::logs::AnyValue {
+    fn from(value: ChmodFileData) -> Self {
+        let AnyValue::Map(mut map) = value.inner.into() else {
+            unreachable!("inner value did not serialize to map");
+        };
+        map.extend([
+            ("new_mode".into(), value.new_mode.into()),
+            ("old_mode".into(), value.old_mode.into()),
+        ]);
+
+        AnyValue::Map(map)
     }
 }
 
@@ -656,10 +750,49 @@ impl From<ChownFileData> for fact_api::FileOwnershipChange {
     }
 }
 
+#[cfg(feature = "otel")]
+impl From<ChownFileData> for opentelemetry::logs::AnyValue {
+    fn from(value: ChownFileData) -> Self {
+        let AnyValue::Map(mut map) = value.inner.into() else {
+            unreachable!("inner value did not serialize to map");
+        };
+        map.extend([
+            ("new_uid".into(), value.new_uid.into()),
+            ("old_uid".into(), value.old_uid.into()),
+            ("new_gid".into(), value.new_gid.into()),
+            ("old_gid".into(), value.old_gid.into()),
+        ]);
+
+        AnyValue::Map(map)
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct RenameFileData {
     new: BaseFileData,
     old: BaseFileData,
+}
+
+impl From<RenameFileData> for fact_api::FileRename {
+    fn from(RenameFileData { new, old }: RenameFileData) -> Self {
+        let new = fact_api::FileActivityBase::from(new);
+        let old = fact_api::FileActivityBase::from(old);
+        fact_api::FileRename {
+            old: Some(old),
+            new: Some(new),
+        }
+    }
+}
+
+#[cfg(feature = "otel")]
+impl From<RenameFileData> for opentelemetry::logs::AnyValue {
+    fn from(value: RenameFileData) -> Self {
+        let AnyValue::Map(mut map) = value.new.into() else {
+            unreachable!("new value did not serialize to map");
+        };
+        map.insert("old".into(), value.old.into());
+        AnyValue::Map(map)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -683,6 +816,21 @@ impl From<fact_ebpf::acl_tag_t> for AclTag {
             fact_ebpf::acl_tag_t::FACT_ACL_TAG_MASK => AclTag::Mask,
             fact_ebpf::acl_tag_t::FACT_ACL_TAG_OTHER => AclTag::Other,
             other => AclTag::Unknown(other.0 as i16),
+        }
+    }
+}
+
+#[cfg(feature = "otel")]
+impl From<AclTag> for opentelemetry::logs::AnyValue {
+    fn from(value: AclTag) -> Self {
+        match value {
+            AclTag::UserObj => "user_obj".into(),
+            AclTag::User => "user".into(),
+            AclTag::GroupObj => "group_obj".into(),
+            AclTag::Group => "group".into(),
+            AclTag::Mask => "mask".into(),
+            AclTag::Other => "other".into(),
+            AclTag::Unknown(v) => format!("unknown({v})").into(),
         }
     }
 }
@@ -713,10 +861,35 @@ impl AclEntry {
     }
 }
 
+#[cfg(feature = "otel")]
+impl From<AclEntry> for opentelemetry::logs::AnyValue {
+    fn from(value: AclEntry) -> Self {
+        let mut map = HashMap::from([
+            ("tag".into(), value.tag.into()),
+            ("perm".into(), value.perm.into()),
+        ]);
+        if let Some(id) = value.id {
+            map.insert("id".into(), id.into());
+        }
+
+        AnyValue::Map(Box::new(map))
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum AclType {
     Access,
     Default,
+}
+
+#[cfg(feature = "otel")]
+impl From<AclType> for opentelemetry::logs::AnyValue {
+    fn from(value: AclType) -> Self {
+        match value {
+            AclType::Access => "access".into(),
+            AclType::Default => "default".into(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -724,17 +897,6 @@ pub struct AclSetFileData {
     inner: BaseFileData,
     acl_type: AclType,
     entries: Vec<AclEntry>,
-}
-
-impl From<RenameFileData> for fact_api::FileRename {
-    fn from(RenameFileData { new, old }: RenameFileData) -> Self {
-        let new = fact_api::FileActivityBase::from(new);
-        let old = fact_api::FileActivityBase::from(old);
-        fact_api::FileRename {
-            old: Some(old),
-            new: Some(new),
-        }
-    }
 }
 
 impl From<AclTag> for i32 {
@@ -781,6 +943,24 @@ impl From<AclSetFileData> for fact_api::FileAclChange {
     }
 }
 
+#[cfg(feature = "otel")]
+impl From<AclSetFileData> for opentelemetry::logs::AnyValue {
+    fn from(value: AclSetFileData) -> Self {
+        let AnyValue::Map(mut map) = value.inner.into() else {
+            unreachable!("new value did not serialize to map");
+        };
+        map.insert("acl_type".into(), value.acl_type.into());
+        let entries = value
+            .entries
+            .into_iter()
+            .map(AnyValue::from)
+            .collect::<Vec<_>>();
+        map.insert("entries".into(), AnyValue::ListAny(Box::new(entries)));
+
+        AnyValue::Map(map)
+    }
+}
+
 #[cfg(test)]
 impl PartialEq for RenameFileData {
     fn eq(&self, other: &Self) -> bool {
@@ -801,6 +981,18 @@ impl From<XattrFileData> for fact_api::FileXattrChange {
             activity: Some(activity),
             xattr_name: value.xattr_name,
         }
+    }
+}
+
+#[cfg(feature = "otel")]
+impl From<XattrFileData> for opentelemetry::logs::AnyValue {
+    fn from(value: XattrFileData) -> Self {
+        let AnyValue::Map(mut map) = value.inner.into() else {
+            unreachable!("inner value did not serialize to map");
+        };
+        map.insert("xattr_name".into(), value.xattr_name.into());
+
+        AnyValue::Map(map)
     }
 }
 

--- a/fact/src/event/process.rs
+++ b/fact/src/event/process.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "otel")]
+use std::collections::HashMap;
 use std::{ffi::CStr, path::PathBuf};
 
 use fact_ebpf::{lineage_t, process_t};
+#[cfg(feature = "otel")]
+use opentelemetry::logs::AnyValue;
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -35,6 +39,19 @@ impl From<Lineage> for fact_api::process_signal::LineageInfo {
             parent_uid: uid,
             parent_exec_file_path: exe_path.to_string_lossy().to_string(),
         }
+    }
+}
+
+#[cfg(feature = "otel")]
+impl From<Lineage> for opentelemetry::logs::AnyValue {
+    fn from(value: Lineage) -> Self {
+        AnyValue::Map(Box::new(HashMap::from([
+            ("uid".into(), value.uid.into()),
+            (
+                "exec_path".into(),
+                value.exe_path.to_string_lossy().to_string().into(),
+            ),
+        ])))
     }
 }
 
@@ -217,6 +234,45 @@ impl From<Process> for fact_api::ProcessSignal {
             username: username.to_owned(),
             in_root_mount_ns,
         }
+    }
+}
+
+#[cfg(feature = "otel")]
+impl From<Process> for opentelemetry::logs::AnyValue {
+    fn from(value: Process) -> Self {
+        let args = value
+            .args
+            .into_iter()
+            .map(AnyValue::from)
+            .collect::<Vec<_>>();
+
+        let lineage = value
+            .lineage
+            .into_iter()
+            .map(AnyValue::from)
+            .collect::<Vec<_>>();
+
+        let mut map = HashMap::from([
+            ("comm".into(), value.comm.into()),
+            ("args".into(), AnyValue::ListAny(Box::new(args))),
+            (
+                "exe_path".into(),
+                value.exe_path.to_string_lossy().to_string().into(),
+            ),
+            ("pid".into(), value.pid.into()),
+            ("uid".into(), value.uid.into()),
+            ("gid".into(), value.gid.into()),
+            ("login_uid".into(), value.login_uid.into()),
+            ("username".into(), value.username.into()),
+            ("in_root_mount_ns".into(), value.in_root_mount_ns.into()),
+            ("lineage".into(), AnyValue::ListAny(Box::new(lineage))),
+        ]);
+
+        if let Some(container_id) = value.container_id {
+            map.insert("container_id".into(), container_id.into());
+        }
+
+        AnyValue::Map(Box::new(map))
     }
 }
 

--- a/fact/src/lib.rs
+++ b/fact/src/lib.rs
@@ -118,6 +118,7 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
         running.subscribe(),
         exporter.metrics.output.clone(),
         reloader.grpc(),
+        reloader.otel(),
         reloader.config().json(),
     );
     let mut host_scanner_handle = host_scanner.start();

--- a/fact/src/metrics/mod.rs
+++ b/fact/src/metrics/mod.rs
@@ -101,6 +101,7 @@ impl EventCounter {
 pub struct OutputMetrics {
     pub stdout: EventCounter,
     pub grpc: EventCounter,
+    pub otel: EventCounter,
 }
 
 impl OutputMetrics {
@@ -116,16 +117,23 @@ impl OutputMetrics {
             "Events processed by the grpc output component",
             &labels,
         );
+        let otel_counter = EventCounter::new(
+            "output_otel_events",
+            "Events processed by the otel output component",
+            &labels,
+        );
 
         OutputMetrics {
             stdout: stdout_counter,
             grpc: grpc_counter,
+            otel: otel_counter,
         }
     }
 
     fn register(&self, reg: &mut Registry) {
         self.stdout.register(reg);
         self.grpc.register(reg);
+        self.otel.register(reg);
     }
 }
 

--- a/fact/src/output/grpc.rs
+++ b/fact/src/output/grpc.rs
@@ -10,7 +10,7 @@ use openssl::{ec::EcKey, pkey::PKey};
 use tokio::{
     fs,
     sync::{mpsc, oneshot, watch},
-    task::JoinHandle,
+    task::JoinSet,
     time::sleep,
 };
 use tokio_stream::{
@@ -125,8 +125,8 @@ impl Client {
         }
     }
 
-    pub fn start(mut self) -> JoinHandle<anyhow::Result<()>> {
-        tokio::spawn(async move {
+    pub fn start(mut self, set: &mut JoinSet<anyhow::Result<()>>) {
+        set.spawn(async move {
             loop {
                 let res = if self.is_enabled() {
                     self.run().await
@@ -144,7 +144,7 @@ impl Client {
                 }
             }
             Ok(())
-        })
+        });
     }
 
     async fn get_connector(&self) -> anyhow::Result<Option<HttpsConnector<HttpConnector>>> {

--- a/fact/src/output/mod.rs
+++ b/fact/src/output/mod.rs
@@ -1,15 +1,20 @@
-use std::{borrow::BorrowMut, sync::Arc};
+use std::sync::Arc;
 
-use anyhow::bail;
 use log::{debug, warn};
 use tokio::{
     sync::{broadcast, mpsc, watch},
-    task::JoinHandle,
+    task::{JoinHandle, JoinSet},
 };
 
-use crate::{config::GrpcConfig, event::Event, metrics::OutputMetrics};
+use crate::{
+    config::{GrpcConfig, OTelConfig},
+    event::Event,
+    metrics::OutputMetrics,
+};
 
 mod grpc;
+#[cfg(feature = "otel")]
+mod otel;
 mod stdout;
 
 type EventReceiver = broadcast::Receiver<Arc<Event>>;
@@ -22,27 +27,47 @@ pub fn start(
     mut rx: mpsc::Receiver<Event>,
     running: watch::Receiver<bool>,
     metrics: OutputMetrics,
-    config: watch::Receiver<GrpcConfig>,
+    grpc_config: watch::Receiver<GrpcConfig>,
+    #[allow(unused)] otel_config: watch::Receiver<OTelConfig>,
     stdout_enabled: bool,
 ) -> JoinHandle<anyhow::Result<()>> {
-    let (broad_tx, broad_rx) = broadcast::channel(100);
+    let (broad_tx, _) = broadcast::channel(100);
     let (subs_req, mut subs_rx) = mpsc::channel(10);
     let mut run = running.clone();
+    let mut handles = JoinSet::new();
 
     let grpc_client = grpc::Client::new(
         subs_req.clone(),
         running.clone(),
         metrics.grpc.clone(),
-        config.clone(),
+        grpc_config,
     );
+    #[allow(unused_mut)]
+    let mut non_stdout_enabled = grpc_client.is_enabled();
+    grpc_client.start(&mut handles);
+
+    #[cfg(feature = "otel")]
+    {
+        let otel_client = otel::Client::new(
+            subs_req.clone(),
+            running.clone(),
+            metrics.otel.clone(),
+            otel_config,
+        );
+        non_stdout_enabled = non_stdout_enabled || otel_client.is_enabled();
+        otel_client.start(&mut handles);
+    }
 
     // JSON client will only start if explicitly enabled or no other
     // output is active at startup
-    if !grpc_client.is_enabled() || stdout_enabled {
-        stdout::Client::new(broad_rx, running.clone(), metrics.stdout.clone()).start();
+    if stdout_enabled || !non_stdout_enabled {
+        stdout::Client::new(
+            broad_tx.subscribe(),
+            running.clone(),
+            metrics.stdout.clone(),
+        )
+        .start();
     }
-
-    let mut grpc_handle = grpc_client.start();
 
     tokio::spawn(async move {
         debug!("Starting output component...");
@@ -50,6 +75,8 @@ pub fn start(
             tokio::select! {
                 event = rx.recv() => {
                     let Some(event) = event else {
+                        // Channel has been closed and no more messages
+                        // are present.
                         break Ok(());
                     };
 
@@ -64,11 +91,14 @@ pub fn start(
                         break Err(anyhow::anyhow!("Failed to subscribe worker: {e:?}"));
                     }
                 }
-                res = grpc_handle.borrow_mut() => {
+                res = handles.join_next() => {
+                    let Some(res) = res else {
+                        unreachable!("output handles should always have a task");
+                    };
                     match res {
                         Ok(Ok(_)) => break Ok(()),
-                        Ok(Err(e)) => bail!("gRPC worker errored out: {e:?}"),
-                        Err(e) => bail!("gRPC task errored out: {e:?}"),
+                        Ok(Err(e)) => break Err(e),
+                        Err(e) => break Err(e.into()),
                     }
                 }
                 _ = run.changed() => if !*run.borrow() { break Ok(()); }

--- a/fact/src/output/otel.rs
+++ b/fact/src/output/otel.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+
+use anyhow::bail;
+use log::{debug, info, warn};
+use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity};
+use opentelemetry_otlp::{LogExporter, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use tokio::{
+    sync::{broadcast::error::RecvError, mpsc, oneshot, watch},
+    task::JoinSet,
+};
+
+use crate::{config::OTelConfig, metrics::EventCounter, output::EventReceiver};
+
+pub(super) struct Client {
+    subscriber: mpsc::Sender<oneshot::Sender<EventReceiver>>,
+    running: watch::Receiver<bool>,
+    config: watch::Receiver<OTelConfig>,
+    metrics: EventCounter,
+}
+
+impl Client {
+    pub(super) fn new(
+        subscriber: mpsc::Sender<oneshot::Sender<EventReceiver>>,
+        running: watch::Receiver<bool>,
+        metrics: EventCounter,
+        config: watch::Receiver<OTelConfig>,
+    ) -> Self {
+        Client {
+            subscriber,
+            running,
+            config,
+            metrics,
+        }
+    }
+
+    pub(super) fn start(mut self, set: &mut JoinSet<anyhow::Result<()>>) {
+        set.spawn(async move {
+            loop {
+                let res = if self.is_enabled() {
+                    self.run().await
+                } else {
+                    self.idle().await
+                };
+
+                match res {
+                    Ok(true) => info!("Reloading oTel configuration..."),
+                    Ok(false) => {
+                        info!("Stopping oTel output...");
+                        break;
+                    }
+                    Err(e) => bail!("oTel error: {e:?}"),
+                }
+            }
+            Ok(())
+        });
+    }
+
+    async fn run(&mut self) -> anyhow::Result<bool> {
+        let Some(endpoint) = self.config.borrow().endpoint().map(|e| e.to_string()) else {
+            bail!("Attempted to unwrap empty endpoint");
+        };
+        debug!("oTel: forwarding events to {endpoint}");
+        let exporter_otlp = LogExporter::builder()
+            .with_http()
+            .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
+            .with_endpoint(endpoint)
+            .build()?;
+
+        let logger_provider = SdkLoggerProvider::builder()
+            .with_batch_exporter(exporter_otlp)
+            .with_resource(Resource::builder().with_service_name("fact").build())
+            .build();
+        let logger = logger_provider.logger("fact");
+
+        let (tx, rx) = oneshot::channel();
+        self.subscriber.send(tx).await?;
+        let mut rx = rx.await?;
+
+        let res = loop {
+            tokio::select! {
+                event = rx.recv() => {
+                    match event {
+                        Ok(event) => {
+                            self.metrics.added();
+                            let event= Arc::unwrap_or_clone(event);
+                            let mut record = logger.create_log_record();
+                            record.set_severity_number(Severity::Info);
+                            record.set_body(
+                                format!("{} on {} ({})",
+                                    event.event_type(),
+                                    event.get_filename().display(),
+                                    event.get_host_path().display()).into());
+                            if let AnyValue::Map(map) = event.into() {
+                                for (k, v) in *map {
+                                    record.add_attribute(k, v);
+                                }
+                            }
+                            logger.emit(record);
+                        }
+                        Err(RecvError::Closed) => break Err(anyhow::anyhow!("oTel: event stream closed")),
+                        Err(RecvError::Lagged(n)) => {
+                            warn!("oTel stream lagged, dropped {n} events");
+                            self.metrics.dropped_n(n);
+                        }
+                    }
+                }
+                _ = self.config.changed() => break Ok(true),
+                _ = self.running.changed() => break Ok(*self.running.borrow()),
+            }
+        };
+
+        logger_provider.shutdown()?;
+        res
+    }
+
+    pub(super) fn is_enabled(&self) -> bool {
+        self.config.borrow().endpoint().is_some()
+    }
+
+    async fn idle(&mut self) -> anyhow::Result<bool> {
+        tokio::select! {
+            _ = self.config.changed() => Ok(true),
+            _ = self.running.changed() => Ok(*self.running.borrow()),
+        }
+    }
+}


### PR DESCRIPTION

## Description

This output allows exporting file activity events as opentelemetry logs via otlp to be collected by compatible systems.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [x] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested pushing events to Loki and visualizing events in Grafana with the provided documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OpenTelemetry logs output via OTLP/HTTP with configurable `otel.endpoint` (YAML, environment variable, and CLI).
  * OpenTelemetry output now supports live configuration reload.
  * Enriched OpenTelemetry event payloads with additional metadata, including process/lineage and ACL details.
  * Added Prometheus counters for OpenTelemetry “added” and “dropped” events.
* **Bug Fixes**
  * Improved `otel` configuration parsing and validation, including stricter type checking, unknown-key rejection, clearer error messages, and correct environment-variable overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->