### PR TITLE
feat(ci): build otel images and run integration tests with them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,113 +128,16 @@ jobs:
         pip install ruff
         make format-check
 
-  vars:
-    runs-on: ubuntu-24.04
-    outputs:
-      tag: ${{ steps.vars.outputs.tag }}
-      stackrox-io-image: ${{ steps.vars.outputs.stackrox-io-image }}
-      rhacs-eng-image: ${{ steps.vars.outputs.rhacs-eng-image }}
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-        fetch-depth: 0
+  container-build:
+    uses: ./.github/workflows/container-build.yml
+    secrets: inherit
 
-    - id: vars
-      run: |
-        cat << EOF >> "$GITHUB_OUTPUT"
-        tag=$(make tag)
-        stackrox-io-image=$(make image-name)
-        rhacs-eng-image=$(FACT_REGISTRY="quay.io/rhacs-eng/fact" make image-name)
-        EOF
-
-  container:
-    needs:
-      - vars
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - amd64
-          - arm64
-    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
-    env:
-      FACT_TAG: ${{ needs.vars.outputs.tag }}-${{ matrix.arch }}
-      FACT_VERSION: ${{ needs.vars.outputs.tag }}
-      STACKROX_IO_IMAGE: ${{ needs.vars.outputs.stackrox-io-image }}-${{ matrix.arch }}
-      RHACS_ENG_IMAGE: ${{ needs.vars.outputs.rhacs-eng-image }}-${{ matrix.arch }}
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: Build image
-      run: DOCKER=podman make image
-
-    - name: Login to quay.io/stackrox-io
-      uses: docker/login-action@v3
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-        password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-    - run: podman push "${STACKROX_IO_IMAGE}"
-
-    - name: Login to quay.io/rhacs-eng
-      uses: docker/login-action@v3
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-        password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
-    - name: Tag and push to rhacs-eng
-      run: |
-        podman tag "${STACKROX_IO_IMAGE}" "${RHACS_ENG_IMAGE}"
-        podman push "${RHACS_ENG_IMAGE}"
-
-  manifest-stackrox-io:
-    runs-on: ubuntu-24.04
-    needs:
-      - container
-      - vars
-    env:
-      ARCHS: amd64 arm64
-    steps:
-      - uses: redhat-actions/podman-login@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-      - name: Create multiarch manifest
-        run: |
-          podman manifest create ${{ needs.vars.outputs.stackrox-io-image }} \
-            ${{ needs.vars.outputs.stackrox-io-image }}-amd64 \
-            ${{ needs.vars.outputs.stackrox-io-image }}-arm64
-          podman manifest inspect ${{ needs.vars.outputs.stackrox-io-image }}
-          podman manifest push ${{ needs.vars.outputs.stackrox-io-image }}
-
-  manifest-rhacs-eng:
-    runs-on: ubuntu-24.04
-    needs:
-      - container
-      - vars
-    env:
-      ARCHS: amd64 arm64
-    steps:
-      - uses: redhat-actions/podman-login@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
-      - name: Create multiarch manifest
-        run: |
-          podman manifest create ${{ needs.vars.outputs.rhacs-eng-image }} \
-            ${{ needs.vars.outputs.rhacs-eng-image }}-amd64 \
-            ${{ needs.vars.outputs.rhacs-eng-image }}-arm64
-          podman manifest inspect ${{ needs.vars.outputs.rhacs-eng-image }}
-          podman manifest push ${{ needs.vars.outputs.rhacs-eng-image }}
+  container-build-otel:
+    uses: ./.github/workflows/container-build.yml
+    secrets: inherit
+    with:
+      tag-suffix: '-otel'
+      make-target: 'image-otel'
 
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
@@ -242,22 +145,29 @@ jobs:
 
   integration-tests:
     needs:
-      - vars
-      - manifest-stackrox-io
-      - manifest-rhacs-eng
+    - container-build
     uses: ./.github/workflows/integration-tests.yml
     with:
-      tag: ${{ needs.vars.outputs.tag }}
+      tag: ${{ needs.container-build.outputs.tag }}
+      vms: '["fedora-coreos", "fcarm", "rhel", "rhel-arm64", "rhcos", "rhcos-arm64"]'
+    secrets: inherit
+
+  integration-tests-otel:
+    needs:
+    - container-build-otel
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      tag: ${{ needs.container-build-otel.outputs.tag }}
+      job-tag: otel
+      vms: '["fedora-coreos"]'
+      output-type: otlp
     secrets: inherit
 
   performance-tests:
     if: github.event_name == 'schedule'
     needs:
-      - vars
-      - manifest-stackrox-io
-      - manifest-rhacs-eng
-      - integration-tests
+    - container-build
     uses: ./.github/workflows/performance-tests.yml
     with:
-      tag: ${{ needs.vars.outputs.tag }}
+      tag: ${{ needs.container-build.outputs.tag }}
     secrets: inherit

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -26,13 +26,16 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
+        persist-credentials: false
 
     - id: vars
+      env:
+        TAG_SUFFIX: ${{ inputs.tag-suffix }}
       run: |
         cat << EOF >> "$GITHUB_OUTPUT"
-        tag=$(make tag)${{ inputs.tag-suffix }}
-        stackrox-io-image=$(make image-name)${{ inputs.tag-suffix }}
-        rhacs-eng-image=$(FACT_REGISTRY="quay.io/rhacs-eng/fact" make image-name)${{ inputs.tag-suffix }}
+        tag=$(make tag)${TAG_SUFFIX}
+        stackrox-io-image=$(make image-name)${TAG_SUFFIX}
+        rhacs-eng-image=$(FACT_REGISTRY="quay.io/rhacs-eng/fact" make image-name)${TAG_SUFFIX}
         EOF
 
   container:
@@ -54,6 +57,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Build image
       env:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,123 @@
+name: Build container
+on:
+  workflow_call:
+    inputs:
+      tag-suffix:
+        required: false
+        default: ''
+        type: string
+      make-target:
+        required: false
+        default: 'image'
+        type: string
+    outputs:
+      tag:
+        value: ${{ jobs.vars.outputs.tag }}
+
+jobs:
+  vars:
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.vars.outputs.tag }}
+      stackrox-io-image: ${{ steps.vars.outputs.stackrox-io-image }}
+      rhacs-eng-image: ${{ steps.vars.outputs.rhacs-eng-image }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - id: vars
+      run: |
+        cat << EOF >> "$GITHUB_OUTPUT"
+        tag=$(make tag)${{ inputs.tag-suffix }}
+        stackrox-io-image=$(make image-name)${{ inputs.tag-suffix }}
+        rhacs-eng-image=$(FACT_REGISTRY="quay.io/rhacs-eng/fact" make image-name)${{ inputs.tag-suffix }}
+        EOF
+
+  container:
+    needs:
+    - vars
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
+    env:
+      FACT_TAG: ${{ needs.vars.outputs.tag }}-${{ matrix.arch }}
+      FACT_VERSION: ${{ needs.vars.outputs.tag }}
+      STACKROX_IO_IMAGE: ${{ needs.vars.outputs.stackrox-io-image }}-${{ matrix.arch }}
+      RHACS_ENG_IMAGE: ${{ needs.vars.outputs.rhacs-eng-image }}-${{ matrix.arch }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Build image
+      env:
+        MAKE_TARGET: ${{ inputs.make-target }}
+      run: DOCKER=podman make "${MAKE_TARGET}"
+
+    - name: Login to quay.io/stackrox-io
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+        password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+    - run: podman push "${STACKROX_IO_IMAGE}"
+
+    - name: Login to quay.io/rhacs-eng
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+        password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+    - name: Tag and push to rhacs-eng
+      run: |
+        podman tag "${STACKROX_IO_IMAGE}" "${RHACS_ENG_IMAGE}"
+        podman push "${RHACS_ENG_IMAGE}"
+
+  manifest-stackrox-io:
+    runs-on: ubuntu-24.04
+    needs:
+      - container
+      - vars
+    steps:
+      - uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+      - name: Create multiarch manifest
+        run: |
+          podman manifest create ${{ needs.vars.outputs.stackrox-io-image }} \
+            ${{ needs.vars.outputs.stackrox-io-image }}-amd64 \
+            ${{ needs.vars.outputs.stackrox-io-image }}-arm64
+          podman manifest inspect ${{ needs.vars.outputs.stackrox-io-image }}
+          podman manifest push ${{ needs.vars.outputs.stackrox-io-image }}
+
+  manifest-rhacs-eng:
+    runs-on: ubuntu-24.04
+    needs:
+      - container
+      - vars
+    steps:
+      - uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+      - name: Create multiarch manifest
+        run: |
+          podman manifest create ${{ needs.vars.outputs.rhacs-eng-image }} \
+            ${{ needs.vars.outputs.rhacs-eng-image }}-amd64 \
+            ${{ needs.vars.outputs.rhacs-eng-image }}-arm64
+          podman manifest inspect ${{ needs.vars.outputs.rhacs-eng-image }}
+          podman manifest push ${{ needs.vars.outputs.rhacs-eng-image }}
+

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,7 +16,16 @@ on:
       job-tag:
         description: Additional tag to prevent collision on GCP VM naming
         type: string
-        default: ''
+        default: 'main'
+      vms:
+        description: JSON encoded list of vms to run tests on
+        type: string
+        required: true
+      output-type:
+        description: The output type to be used in the tests
+        type: string
+        required: false
+        default: grpc
 
 jobs:
   integration-tests:
@@ -24,13 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vm:
-          - fedora-coreos
-          - fcarm
-          - rhel
-          - rhel-arm64
-          - rhcos
-          - rhcos-arm64
+        vm: ${{ fromJson(inputs.vms) }}
 
     steps:
     - uses: actions/checkout@v4
@@ -73,6 +76,7 @@ jobs:
         FACT_VERSION: ${{ inputs.version }}
         FACT_REGISTRY: ${{ inputs.registry }}
         FACT_TAG: ${{ inputs.tag }}
+        OUTPUT_TYPE: ${{ inputs.output-type }}
       run: |
         FACT_IMAGE_NAME="$(make -sC "${GITHUB_WORKSPACE}/fact" image-name)"
         cat << EOF > vars.yml
@@ -81,6 +85,7 @@ jobs:
         fact:
           image: ${FACT_IMAGE_NAME}
           version: ${FACT_VERSION}
+        output_type: ${OUTPUT_TYPE}
         quay:
           username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -147,7 +152,7 @@ jobs:
       continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.vm }}-test-logs
+        name: ${{ matrix.vm }}-${{ inputs.job-tag }}-test-logs
         path: |
           /tmp/fact/tests/logs
           /tmp/fact/tests/*-results.xml

--- a/.github/workflows/konflux-tests.yml
+++ b/.github/workflows/konflux-tests.yml
@@ -50,4 +50,5 @@ jobs:
       registry: quay.io/rhacs-eng/release-fact
       tag: ${{ needs.init.outputs.fact-tag }}
       job-tag: konf
+      vms: '["fedora-coreos", "fcarm", "rhel", "rhel-arm64", "rhcos", "rhcos-arm64"]'
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,12 @@ image:
 		-f Containerfile \
 		--build-arg FACT_VERSION=$(FACT_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--build-arg CARGO_ARGS="$(CARGO_ARGS)" \
 		-t $(FACT_IMAGE_NAME) \
 		$(CURDIR)
 
-image-otel:
-	$(DOCKER) build \
-		-f Containerfile \
-		--build-arg FACT_VERSION=$(FACT_VERSION) \
-		--build-arg RUST_VERSION=$(RUST_VERSION) \
-		--build-arg CARGO_ARGS="--features otel" \
-		-t $(FACT_IMAGE_NAME)-otel \
-		$(CURDIR)
+image-otel: CARGO_ARGS = --features otel
+image-otel: image
 
 licenses:THIRD_PARTY_LICENSES.html
 

--- a/ansible/run-tests.yml
+++ b/ansible/run-tests.yml
@@ -1,8 +1,6 @@
 ---
 - name: Run integration tests
   hosts: "platform_*:&job_id_{{ job_id }}"
-  environment:
-    FACT_IMAGE_NAME: "{{ fact.image | default(None) }}"
 
   tasks:
     - name: Clone the repo
@@ -44,6 +42,8 @@
         become: true
         environment:
           DOCKER_HOST: "{{ runtime_host }}"
+          FACT_IMAGE_NAME: "{{ fact.image | default(None) }}"
+          OUTPUT_TYPE: "{{ output_type | default('grpc') }}"
         ansible.builtin.shell:
           cmd: |
             set -euo pipefail
@@ -65,7 +65,7 @@
                 ../third_party/stackrox/proto/internalapi/sensor/sfa_iservice.proto
 
             # Run the tests
-            pytest --image="${FACT_IMAGE_NAME}" --junit-xml=results.xml
+            pytest --image="${FACT_IMAGE_NAME}" --junit-xml=results.xml --output="${OUTPUT_TYPE}"
 
       always:
       - name: Make logs directories


### PR DESCRIPTION

## Description

This enables building images with the opentelemetry output enabled, making it easier to run integration tests with it.

Since the grpc output already tests all kernels we support, these tests are only run on fedora-coreos.


## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integration tests now support configurable virtual machines and output formats, including OTLP for OpenTelemetry.
- **Improvements**
  - CI container builds and downstream tests now use reusable workflows with consistent, parameterized image tags across amd64/arm64 and multi-arch manifests.
  - Test execution now passes the selected output format through to the test runner (defaulting to gRPC) and produces less collision-prone log artifact names.
  - OpenTelemetry-enabled test runs are wired to use OTLP output and corresponding image tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->