### PR TITLE
fix(tests): container exit code 137

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from shutil import rmtree
 from tempfile import NamedTemporaryFile, mkdtemp
@@ -107,6 +108,18 @@ def dump_logs(container: docker.models.containers.Container, file: str):
     logs = container.logs().decode('utf-8')
     with open(file, 'w') as f:
         f.write(logs)
+
+
+def dump_container_inspect(
+    container: docker.models.containers.Container, file: str
+):
+    assert container.id is not None
+    client = docker.APIClient(
+        base_url=os.environ.get('DOCKER_HOST', 'unix:///var/run/docker.sock')
+    )
+    container_inspect = client.inspect_container(container.id)
+    with open(file, 'w') as f:
+        json.dump(container_inspect, f, indent=2)
 
 
 @pytest.fixture
@@ -253,6 +266,7 @@ def fact(
     container.stop(timeout=2)
     exit_status = container.wait(timeout=2)
     dump_logs(container, container_log)
+    dump_container_inspect(container, os.path.join(logs_dir, 'container.json'))
     container.remove()
     assert exit_status['StatusCode'] == 0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,13 +111,12 @@ def dump_logs(container: docker.models.containers.Container, file: str):
 
 
 def dump_container_inspect(
-    container: docker.models.containers.Container, file: str
+    client: docker.DockerClient,
+    container: docker.models.containers.Container,
+    file: str,
 ):
     assert container.id is not None
-    client = docker.APIClient(
-        base_url=os.environ.get('DOCKER_HOST', 'unix:///var/run/docker.sock')
-    )
-    container_inspect = client.inspect_container(container.id)
+    container_inspect = client.api.inspect_container(container.id)
     with open(file, 'w') as f:
         json.dump(container_inspect, f, indent=2)
 
@@ -265,9 +264,13 @@ def fact(
 
     container.stop(timeout=5)
     exit_status = container.wait(timeout=2)
-    dump_logs(container, container_log)
-    dump_container_inspect(container, os.path.join(logs_dir, 'container.json'))
-    container.remove()
+    try:
+        dump_logs(container, container_log)
+        dump_container_inspect(
+            docker_client, container, os.path.join(logs_dir, 'container.json')
+        )
+    finally:
+        container.remove()
     assert exit_status['StatusCode'] == 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,7 +263,7 @@ def fact(
             with open(metric_log, 'w') as f:
                 f.write(resp.text)
 
-    container.stop(timeout=2)
+    container.stop(timeout=5)
     exit_status = container.wait(timeout=2)
     dump_logs(container, container_log)
     dump_container_inspect(container, os.path.join(logs_dir, 'container.json'))


### PR DESCRIPTION
## Description

Recently there have been a high degree of integration tests failing with an assertion error on the fact container, it being 137 rather than 0. This error code is the one used by docker/podman to notify when a container has been forcefully terminated, which in turn seems to point to the fact container not exiting on time.

After inspecting the code, it seems all tasks properly finish as expected, so the cause for this error seems to lay on the time constraint for fact to exit cleanly (currently set to 2 seconds) being to low. Bumping this timeout to 5 seconds seems to have fixed the issue with no noticeable increase on CI times.

This PR also makes it so we dump the output of `docker/podman inspect` directly on a file for each test, which might help in the future to debug problems that may arise in the tests.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test container cleanup reliability.
  * Added Docker container inspection data to test artifacts for easier troubleshooting.
  * Increased the container shutdown timeout and ensured containers are removed even when diagnostics fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->