### PR TITLE
feat(config): configurable loaded BPF programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ possible include a PR number for easier tracking.
 
 ## Next
 
+* feat(config): configurable loaded BPF programs (#1086)
 * feat(output): add basic opentelemetry output (#971)
 * feat(grpc): add exponential backoff for reconnection attempts (#789)
 * feat: run integration tests on more platforms (#760)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "serde_json",
  "shlex 2.0.1",
  "tempfile",
+ "thiserror",
  "tokio",
  "tokio-native-tls",
  "tokio-stream",

--- a/fact/Cargo.toml
+++ b/fact/Cargo.toml
@@ -35,6 +35,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shlex = { workspace = true }
+thiserror = { version = "2.0.18" }
 uuid = { workspace = true }
 yaml-rust2 = { workspace = true }
 

--- a/fact/src/bpf/checks.rs
+++ b/fact/src/bpf/checks.rs
@@ -4,7 +4,7 @@ use log::debug;
 
 pub(super) struct Checks {
     pub(super) path_hooks_support_bpf_d_path: bool,
-    pub(super) supports_inode_set_acl: bool,
+    supports_inode_set_acl: bool,
 }
 
 impl Checks {
@@ -39,5 +39,9 @@ impl Checks {
             return false;
         };
         prog.load(hook, btf).is_ok()
+    }
+
+    pub(super) fn is_unsupported_hook(&self, hook: &str) -> bool {
+        hook == "inode_set_acl" && !self.supports_inode_set_acl
     }
 }

--- a/fact/src/bpf/mod.rs
+++ b/fact/src/bpf/mod.rs
@@ -50,16 +50,9 @@ impl Bpf {
 
         // Include the BPF object as raw bytes at compile-time and load it
         // at runtime.
-        let obj = aya::EbpfLoader::new()
-            .override_global("host_mount_ns", &host_info::get_host_mount_ns(), true)
-            .override_global(
-                "path_hooks_support_bpf_d_path",
-                &(checks.path_hooks_support_bpf_d_path as u8),
-                true,
-            )
-            .map_max_entries(RINGBUFFER_NAME, bpf_config.ringbuf_size() * 1024)
-            .map_max_entries("inode_map", bpf_config.inodes_max())
-            .load(fact_ebpf::EBPF_OBJ)?;
+        let obj = Bpf::load_ebpf(&checks, bpf_config)?;
+
+        Bpf::validate_config(&obj, bpf_config);
 
         let (tx, rx) = mpsc::channel(100);
         let paths = Vec::new();
@@ -73,7 +66,7 @@ impl Bpf {
             links: Vec::new(),
         };
 
-        bpf.load_progs(&btf)?;
+        bpf.load_progs(&btf, bpf_config)?;
         bpf.load_paths()?;
 
         Ok((bpf, rx))
@@ -94,6 +87,22 @@ impl Bpf {
             );
         }
         Ok(())
+    }
+
+    fn load_ebpf(checks: &Checks, bpf_config: &BpfConfig) -> anyhow::Result<Ebpf> {
+        // Include the BPF object as raw bytes at compile-time and load it
+        // at runtime.
+        aya::EbpfLoader::new()
+            .override_global("host_mount_ns", &host_info::get_host_mount_ns(), true)
+            .override_global(
+                "path_hooks_support_bpf_d_path",
+                &(checks.path_hooks_support_bpf_d_path as u8),
+                true,
+            )
+            .map_max_entries(RINGBUFFER_NAME, bpf_config.ringbuf_size() * 1024)
+            .map_max_entries("inode_map", bpf_config.inodes_max())
+            .load(fact_ebpf::EBPF_OBJ)
+            .context("failed to load eBPF object")
     }
 
     pub fn take_inode_map(
@@ -172,7 +181,7 @@ impl Bpf {
         Ok(())
     }
 
-    fn load_progs(&mut self, btf: &Btf) -> anyhow::Result<()> {
+    fn load_progs(&mut self, btf: &Btf, bpf_config: &BpfConfig) -> anyhow::Result<()> {
         for (name, prog) in self.obj.programs_mut() {
             // The format used for our hook names is `trace_<hook>`, so
             // we can just strip trace_ to get the hook name we need for
@@ -181,8 +190,13 @@ impl Bpf {
                 bail!("Invalid hook name: {name}");
             };
 
+            if !bpf_config.program_is_enabled(hook) {
+                info!("Skipping {hook} loading");
+                continue;
+            }
+
             // Skip hooks that the kernel doesn't support
-            if hook == "inode_set_acl" && !self.checks.supports_inode_set_acl {
+            if self.checks.is_unsupported_hook(hook) {
                 info!("Skipping {hook}: not supported on this kernel");
                 continue;
             }
@@ -195,31 +209,57 @@ impl Bpf {
         Ok(())
     }
 
+    /// Attaches the supplied BPF program if it is loaded into the kernel.
+    fn attach_prog(prog: &mut Program) -> Result<LsmLink, BpfAttachError> {
+        match prog {
+            Program::Lsm(prog) if prog.fd().is_ok() => {
+                let link_id = prog.attach()?;
+                Ok(prog.take_link(link_id)?)
+            }
+            Program::Lsm(_) => Err(BpfAttachError::NotLoaded),
+            u => unimplemented!("{u:?}"),
+        }
+    }
+
     /// Attaches all loaded BPF programs. Programs that were not loaded
     /// (e.g. optional hooks on unsupported kernels) are skipped.
+    ///
     /// If any attach fails, programs that were already attached during
-    /// this call remain attached (they are not rolled back); callers
-    /// should treat an `Err` here as fatal.
+    /// this call are dropped.
     fn attach_progs(&mut self) -> anyhow::Result<()> {
-        self.links.clear();
-        for (_, prog) in self.obj.programs_mut() {
-            match prog {
-                Program::Lsm(prog) => {
-                    if prog.fd().is_err() {
-                        continue;
-                    }
-                    let link_id = prog.attach()?;
-                    self.links.push(prog.take_link(link_id)?);
-                }
-                u => unimplemented!("{u:?}"),
-            }
-        }
+        self.links = self
+            .obj
+            .programs_mut()
+            .filter_map(|(_, prog)| match Bpf::attach_prog(prog) {
+                Ok(link) => Some(Ok(link)),
+                Err(BpfAttachError::NotLoaded) => None,
+                Err(e) => Some(Err(e)),
+            })
+            .collect::<Result<Vec<_>, BpfAttachError>>()?;
+
         Ok(())
     }
 
     /// Detaches all BPF programs by dropping owned links.
     fn detach_progs(&mut self) {
         self.links.clear();
+    }
+
+    /// Verify the current configuration for errors.
+    ///
+    /// Checks for hooks that are not implemented.
+    fn validate_config(obj: &Ebpf, bpf_config: &BpfConfig) -> bool {
+        let mut is_valid = true;
+
+        for name in bpf_config.programs.keys() {
+            let hook = "trace_".to_string() + name;
+            if obj.program(&hook).is_none() {
+                warn!("{name} is not a known program");
+                is_valid = false;
+            }
+        }
+
+        is_valid
     }
 
     // Gather events from the ring buffer and print them out.
@@ -287,15 +327,23 @@ impl Bpf {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+enum BpfAttachError {
+    #[error("attempted to attach unloaded program")]
+    NotLoaded,
+    #[error("program error: {0:?}")]
+    ProgramError(#[from] aya::programs::ProgramError),
+}
+
 #[cfg(all(test, feature = "bpf-test"))]
 mod bpf_tests {
-    use std::{env, os::unix::fs::PermissionsExt, path::PathBuf, time::Duration};
+    use std::{collections, env, os::unix::fs::PermissionsExt, path::PathBuf, time::Duration};
 
     use tempfile::NamedTempFile;
     use tokio::{sync::watch, time::timeout};
 
     use crate::{
-        config::{FactConfig, reloader::Reloader},
+        config::{BpfProgConfig, FactConfig, reloader::Reloader},
         event::{EventTestData, process::Process},
         host_info,
         metrics::exporter::Exporter,
@@ -416,5 +464,70 @@ mod bpf_tests {
         }
 
         run_tx.send(false).unwrap();
+    }
+
+    #[test]
+    fn test_validate_config() {
+        let tests = [
+            (collections::HashMap::new(), true),
+            (
+                collections::HashMap::from([("file_open".into(), BpfProgConfig::default())]),
+                true,
+            ),
+            (
+                collections::HashMap::from([(
+                    "file_open".into(),
+                    BpfProgConfig {
+                        enabled: Some(true),
+                    },
+                )]),
+                true,
+            ),
+            (
+                collections::HashMap::from([(
+                    "file_open".into(),
+                    BpfProgConfig {
+                        enabled: Some(false),
+                    },
+                )]),
+                true,
+            ),
+            (
+                collections::HashMap::from([
+                    (
+                        "file_open".into(),
+                        BpfProgConfig {
+                            enabled: Some(false),
+                        },
+                    ),
+                    (
+                        "path_rename".into(),
+                        BpfProgConfig {
+                            enabled: Some(true),
+                        },
+                    ),
+                    ("path_unlink".into(), BpfProgConfig::default()),
+                ]),
+                true,
+            ),
+            (
+                collections::HashMap::from([("gibberish".into(), BpfProgConfig::default())]),
+                false,
+            ),
+        ];
+
+        let btf = Btf::from_sys_fs().expect("Failed to read BTF symbols");
+        let checks = Checks::new(&btf).expect("Failed to create `checks`");
+        let obj =
+            Bpf::load_ebpf(&checks, &BpfConfig::default()).expect("Failed to load eBPF object");
+
+        for (programs, expected) in tests {
+            let mut bpf_config = BpfConfig::default();
+            bpf_config.programs = programs.clone();
+
+            let res = Bpf::validate_config(&obj, &bpf_config);
+
+            assert_eq!(res, expected, "input: {programs:#?}");
+        }
     }
 }

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fs::read_to_string,
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -544,6 +545,7 @@ impl TryFrom<&yaml::Hash> for OTelConfig {
 pub struct BpfConfig {
     ringbuf_size: Option<u32>,
     inodes_max: Option<u32>,
+    pub programs: HashMap<String, BpfProgConfig>,
 }
 
 impl BpfConfig {
@@ -555,6 +557,10 @@ impl BpfConfig {
         if let Some(inodes_max) = from.inodes_max {
             self.inodes_max = Some(inodes_max);
         }
+
+        for (k, v) in &from.programs {
+            self.programs.entry(k.clone()).or_default().update(v);
+        }
     }
 
     pub fn ringbuf_size(&self) -> u32 {
@@ -564,44 +570,112 @@ impl BpfConfig {
     pub fn inodes_max(&self) -> u32 {
         self.inodes_max.unwrap_or(65536)
     }
+
+    pub fn program_is_enabled(&self, name: &str) -> bool {
+        self.programs.get(name).map(|c| c.enabled()).unwrap_or(true)
+    }
 }
 
 impl TryFrom<&yaml::Hash> for BpfConfig {
     type Error = anyhow::Error;
 
     fn try_from(value: &yaml::Hash) -> Result<Self, Self::Error> {
-        value
-            .iter()
-            .try_fold(BpfConfig::default(), |mut bpf, (k, v)| {
-                let Some(k) = k.as_str() else {
-                    bail!("key is not string: {k:?}");
-                };
+        let mut bpf = BpfConfig::default();
+        for (k, v) in value {
+            let Some(k) = k.as_str() else {
+                bail!("key is not string: {k:?}");
+            };
 
-                match k {
-                    "ringbuf_size" => {
-                        let Some(rb_size) = v.as_i64() else {
-                            bail!("ringbuf_size field has incorrect type: {v:?}");
-                        };
-                        if rb_size < 64 || rb_size > (u32::MAX / 1024) as i64 {
-                            bail!("ringbuf_size out of range: {rb_size}");
-                        }
-                        let rb_size = rb_size as u32;
-                        if rb_size.count_ones() != 1 {
-                            bail!("ringbuf_size is not a power of 2: {rb_size}");
-                        }
-                        bpf.ringbuf_size = Some(rb_size);
+            match k {
+                "ringbuf_size" => {
+                    let Some(rb_size) = v.as_i64() else {
+                        bail!("ringbuf_size field has incorrect type: {v:?}");
+                    };
+                    if rb_size < 64 || rb_size > (u32::MAX / 1024) as i64 {
+                        bail!("ringbuf_size out of range: {rb_size}");
                     }
-                    "inodes_max" => {
-                        let Some(inode_max) = v.as_i64() else {
-                            bail!("inodes_max field has incorrect type: {v:?}");
-                        };
-                        bpf.inodes_max = Some(inode_max as u32);
+                    let rb_size = rb_size as u32;
+                    if rb_size.count_ones() != 1 {
+                        bail!("ringbuf_size is not a power of 2: {rb_size}");
                     }
-                    name => bail!("Invalid field 'bpf.{name}' with value: {v:?}"),
+                    bpf.ringbuf_size = Some(rb_size);
                 }
+                "inodes_max" => {
+                    let Some(inode_max) = v.as_i64() else {
+                        bail!("inodes_max field has incorrect type: {v:?}");
+                    };
+                    bpf.inodes_max = Some(inode_max as u32);
+                }
+                "programs" => {
+                    let Some(programs) = v.as_hash() else {
+                        bail!("bpf.programs field has incorrect type: {v:?}");
+                    };
+                    bpf.programs = programs
+                        .iter()
+                        .map(|(name, config)| {
+                            let Some(name) = name.as_str() else {
+                                bail!("bpf program name is not string: {name:?}");
+                            };
+                            let Some(config) = config.as_hash() else {
+                                bail!("bpf.programs.{name} has wrong type: {config:?}");
+                            };
+                            let config = match BpfProgConfig::try_from(config) {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    bail!("bpf.programs.{name} parsing failed: {e:?}");
+                                }
+                            };
 
-                Ok(bpf)
-            })
+                            Ok((name.into(), config))
+                        })
+                        .collect::<Result<HashMap<_, _>, _>>()?;
+                }
+                name => bail!("Invalid field 'bpf.{name}' with value: {v:?}"),
+            }
+        }
+        Ok(bpf)
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct BpfProgConfig {
+    pub enabled: Option<bool>,
+}
+
+impl BpfProgConfig {
+    fn update(&mut self, from: &BpfProgConfig) {
+        if let Some(enabled) = from.enabled {
+            self.enabled = Some(enabled);
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
+}
+
+impl TryFrom<&yaml::Hash> for BpfProgConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &yaml::Hash) -> Result<Self, Self::Error> {
+        let mut bpf_prog_config = BpfProgConfig::default();
+        for (k, v) in value.iter() {
+            let Some(k) = k.as_str() else {
+                bail!("key is not string: {k:?}");
+            };
+
+            match k {
+                "enabled" => {
+                    let Some(enabled) = v.as_bool() else {
+                        bail!("enabled field has wrong type: {v:?}");
+                    };
+                    bpf_prog_config.enabled = Some(enabled);
+                }
+                name => bail!("Invalid field '{name}' with value: {v:?}"),
+            }
+        }
+
+        Ok(bpf_prog_config)
     }
 }
 
@@ -788,6 +862,7 @@ impl FactCli {
             bpf: BpfConfig {
                 ringbuf_size: self.ringbuf_size,
                 inodes_max: self.inodes_max,
+                programs: HashMap::new(),
             },
             skip_pre_flight: resolve_bool_arg(self.skip_pre_flight, self.no_skip_pre_flight),
             json: resolve_bool_arg(self.json, self.no_json),

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -352,6 +352,64 @@ fn parsing() {
             },
         ),
         (
+            r#"
+            bpf:
+                programs:
+                    file_open:
+                        enabled: false
+            "#,
+            FactConfig {
+                bpf: BpfConfig {
+                    programs: HashMap::from([(
+                        "file_open".into(),
+                        BpfProgConfig {
+                            enabled: Some(false),
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            bpf:
+                programs:
+                    file_open:
+                        enabled: false
+                    path_unlink:
+                        enabled: true
+                    giberish:
+                        enabled: false
+            "#,
+            FactConfig {
+                bpf: BpfConfig {
+                    programs: HashMap::from([
+                        (
+                            "file_open".into(),
+                            BpfProgConfig {
+                                enabled: Some(false),
+                            },
+                        ),
+                        (
+                            "path_unlink".into(),
+                            BpfProgConfig {
+                                enabled: Some(true),
+                            },
+                        ),
+                        (
+                            "giberish".into(),
+                            BpfProgConfig {
+                                enabled: Some(false),
+                            },
+                        ),
+                    ]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
             "hotreload: true",
             FactConfig {
                 hotreload: Some(true),
@@ -417,6 +475,13 @@ fn parsing() {
             bpf:
                 ringbuf_size: 8192
                 inodes_max: 64
+                programs:
+                    file_open:
+                        enabled: false
+                    path_unlink:
+                        enabled: true
+                    giberish:
+                        enabled: false
             hotreload: false
             scan_interval: 60
             "#,
@@ -446,6 +511,26 @@ fn parsing() {
                 bpf: BpfConfig {
                     ringbuf_size: Some(8192),
                     inodes_max: Some(64),
+                    programs: HashMap::from([
+                        (
+                            "file_open".into(),
+                            BpfProgConfig {
+                                enabled: Some(false),
+                            },
+                        ),
+                        (
+                            "path_unlink".into(),
+                            BpfProgConfig {
+                                enabled: Some(true),
+                            },
+                        ),
+                        (
+                            "giberish".into(),
+                            BpfProgConfig {
+                                enabled: Some(false),
+                            },
+                        ),
+                    ]),
                 },
                 hotreload: Some(false),
                 scan_interval: Some(Duration::from_secs(60)),
@@ -763,6 +848,48 @@ paths:
               inodes_max: true
             "#,
             "inodes_max field has incorrect type: Boolean(true)",
+        ),
+        (
+            r#"
+            bpf:
+              programs: file_open
+            "#,
+            "bpf.programs field has incorrect type: String(\"file_open\")",
+        ),
+        (
+            r#"
+            bpf:
+              programs:
+                true:
+                    enabled: true
+            "#,
+            "bpf program name is not string: Boolean(true)",
+        ),
+        (
+            r#"
+            bpf:
+              programs:
+                file_open: something
+            "#,
+            "bpf.programs.file_open has wrong type: String(\"something\")",
+        ),
+        (
+            r#"
+            bpf:
+              programs:
+                file_open:
+                  something: true
+            "#,
+            "bpf.programs.file_open parsing failed: Invalid field 'something' with value: Boolean(true)",
+        ),
+        (
+            r#"
+            bpf:
+              programs:
+                file_open:
+                  enabled: 5
+            "#,
+            "bpf.programs.file_open parsing failed: enabled field has wrong type: Integer(5)",
         ),
         (
             "hotreload: 4",
@@ -1493,6 +1620,59 @@ fn update() {
             },
         ),
         (
+            r#"
+            bpf:
+              programs:
+                file_open:
+                  enabled: true
+            "#,
+            FactConfig::default(),
+            FactConfig {
+                bpf: BpfConfig {
+                    programs: HashMap::from([(
+                        "file_open".into(),
+                        BpfProgConfig {
+                            enabled: Some(true),
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            bpf:
+              programs:
+                file_open:
+                  enabled: true
+            "#,
+            FactConfig {
+                bpf: BpfConfig {
+                    programs: HashMap::from([(
+                        "file_open".into(),
+                        BpfProgConfig {
+                            enabled: Some(false),
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                bpf: BpfConfig {
+                    programs: HashMap::from([(
+                        "file_open".into(),
+                        BpfProgConfig {
+                            enabled: Some(true),
+                        },
+                    )]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
             "hotreload: false",
             FactConfig::default(),
             FactConfig {
@@ -1595,6 +1775,9 @@ fn update() {
             bpf:
               ringbuf_size: 16384
               inodes_max: 8192
+              programs:
+                file_open:
+                  enabled: false
             hotreload: false
             scan_interval: 60
             "#,
@@ -1624,6 +1807,12 @@ fn update() {
                 bpf: BpfConfig {
                     ringbuf_size: Some(64),
                     inodes_max: Some(4096),
+                    programs: HashMap::from([(
+                        "path_unlink".into(),
+                        BpfProgConfig {
+                            enabled: Some(false),
+                        },
+                    )]),
                 },
                 hotreload: Some(true),
                 scan_interval: Some(Duration::from_secs(30)),
@@ -1655,6 +1844,20 @@ fn update() {
                 bpf: BpfConfig {
                     ringbuf_size: Some(16384),
                     inodes_max: Some(8192),
+                    programs: HashMap::from([
+                        (
+                            "path_unlink".into(),
+                            BpfProgConfig {
+                                enabled: Some(false),
+                            },
+                        ),
+                        (
+                            "file_open".into(),
+                            BpfProgConfig {
+                                enabled: Some(false),
+                            },
+                        ),
+                    ]),
                 },
                 hotreload: Some(false),
                 scan_interval: Some(Duration::from_secs(60)),
@@ -1696,6 +1899,55 @@ fn defaults() {
     assert_eq!(config.grpc.backoff.multiplier(), 1.5);
     assert_eq!(config.grpc.backoff.retries(), 10);
     assert_eq!(config.otel.endpoint(), None);
+}
+
+#[test]
+fn bpf_prog_defaults() {
+    let config = BpfProgConfig::default();
+    assert!(config.enabled());
+}
+
+#[test]
+fn bpf_prog_enabled() {
+    const PROGRAM: &str = "file_open";
+    let tests = [
+        (
+            BpfConfig {
+                programs: HashMap::new(),
+                ..Default::default()
+            },
+            true,
+        ),
+        (
+            BpfConfig {
+                programs: HashMap::from([(
+                    PROGRAM.into(),
+                    BpfProgConfig {
+                        enabled: Some(true),
+                    },
+                )]),
+                ..Default::default()
+            },
+            true,
+        ),
+        (
+            BpfConfig {
+                programs: HashMap::from([(
+                    PROGRAM.into(),
+                    BpfProgConfig {
+                        enabled: Some(false),
+                    },
+                )]),
+                ..Default::default()
+            },
+            false,
+        ),
+    ];
+
+    for (bpf_config, expected) in tests {
+        let is_enabled = bpf_config.program_is_enabled(PROGRAM);
+        assert_eq!(is_enabled, expected)
+    }
 }
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());


### PR DESCRIPTION
## Description

This patch makes it possible to decide at runtime which BPF programs should be loaded.

To make the code as flexible as possible the configuration side stores the programs in a map, then the bpf side validates the configuration to notify if an unknown BPF program is found.

Default behavior is still loading and attaching all BPF programs.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Test excluded programs are not loaded with bpftool

<details>
  <summary>output of `bpftool prog list` with `file_open` and `inode_setxattr` disabled</summary>

```
41: lsm  name restrict_filesystems  tag 31efb7c56239148b  gpl
	loaded_at 2026-07-07T10:26:12+0200  uid 0
	xlated 520B  jited 294B  memlock 4096B  map_ids 22
	btf_id 67
	pids systemd(1)
7413: cgroup_device  tag 9b92522e365f8863  gpl
	loaded_at 2026-07-08T18:07:17+0200  uid 0
	xlated 616B  jited 344B  memlock 4096B  map_ids 8503
	pids virtqemud(2212115)
24824: cgroup_device  name sd_devices  tag c1591dae5f5bcd9f  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 464B  jited 298B  memlock 4096B
	pids systemd(1)
24825: cgroup_device  name sd_devices  tag 98b7b6f166b26c8a  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 184B  jited 111B  memlock 4096B
	pids systemd(1)
24826: cgroup_skb  name sd_fw_egress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24827: cgroup_skb  name sd_fw_ingress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24828: cgroup_device  name sd_devices  tag 858f17d96476585f  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 792B  jited 490B  memlock 4096B
	pids systemd(1)
24829: cgroup_skb  name sd_fw_egress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24830: cgroup_skb  name sd_fw_ingress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24831: cgroup_device  name sd_devices  tag feaab199760324c9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 504B  jited 319B  memlock 4096B
	pids systemd(1)
24832: cgroup_skb  name sd_fw_egress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24833: cgroup_skb  name sd_fw_ingress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24834: cgroup_device  name sd_devices  tag c1591dae5f5bcd9f  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 464B  jited 298B  memlock 4096B
	pids systemd(1)
24835: cgroup_device  name sd_devices  tag a97c143260cd9940  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 416B  jited 268B  memlock 4096B
	pids systemd(1)
24836: cgroup_skb  name sd_fw_egress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24837: cgroup_skb  name sd_fw_ingress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24838: cgroup_skb  name sd_fw_egress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24839: cgroup_skb  name sd_fw_ingress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24840: cgroup_device  name sd_devices  tag c1591dae5f5bcd9f  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 464B  jited 298B  memlock 4096B
	pids systemd(1)
24841: cgroup_device  name sd_devices  tag 2faeafd5e3cce185  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 560B  jited 361B  memlock 4096B
	pids systemd(1)
24842: cgroup_device  name sd_devices  tag c1591dae5f5bcd9f  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 464B  jited 298B  memlock 4096B
	pids systemd(1)
24843: cgroup_skb  name sd_fw_egress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24844: cgroup_skb  name sd_fw_ingress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24845: cgroup_device  name sd_devices  tag a97c143260cd9940  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 416B  jited 268B  memlock 4096B
	pids systemd(1)
24846: cgroup_device  name sd_devices  tag a97c143260cd9940  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 416B  jited 268B  memlock 4096B
	pids systemd(1)
24847: cgroup_skb  name sd_fw_egress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24848: cgroup_skb  name sd_fw_ingress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24849: cgroup_device  name sd_devices  tag a97c143260cd9940  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 416B  jited 268B  memlock 4096B
	pids systemd(1)
24850: cgroup_device  name sd_devices  tag a97c143260cd9940  gpl
	loaded_at 2026-07-13T17:22:45+0200  uid 0
	xlated 416B  jited 268B  memlock 4096B
	pids systemd(1)
24930: cgroup_skb  name sd_fw_egress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:50:51+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24931: cgroup_skb  name sd_fw_ingress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-13T17:50:51+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24970: cgroup_skb  name sd_fw_egress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-14T10:08:10+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24971: cgroup_skb  name sd_fw_ingress  tag 772db7720b2728e9  gpl
	loaded_at 2026-07-14T10:08:10+0200  uid 0
	xlated 64B  jited 64B  memlock 4096B
	pids systemd(1)
24973: socket_filter  tag 86d0579461d4b1e3
	loaded_at 2026-07-14T10:08:16+0200  uid 0
	xlated 848B  jited 461B  memlock 4096B  map_ids 30677
24974: socket_filter  tag 6d48e6fab26dfb6c
	loaded_at 2026-07-14T10:08:24+0200  uid 0
	xlated 848B  jited 461B  memlock 4096B  map_ids 30678
25094: lsm  name trace_inode_set_acl  tag 23c65a791e6c3807  gpl
	loaded_at 2026-07-14T10:44:19+0200  uid 0
	xlated 6968B  jited 4457B  memlock 8192B  map_ids 30799,30804,30798,30801,30797,30796
	btf_id 13476
	pids fact(2870990)
25095: lsm  name trace_path_chmod  tag 816a9f14bc8da202  gpl
	loaded_at 2026-07-14T10:44:19+0200  uid 0
	xlated 4240B  jited 2817B  memlock 8192B  map_ids 30799,30797,30802,30801,30804,30798,30803,30796
	btf_id 13476
	pids fact(2870990)
25096: lsm  name trace_path_rmdir  tag 2d7129a34779b8bb  gpl
	loaded_at 2026-07-14T10:44:19+0200  uid 0
	xlated 4200B  jited 2754B  memlock 8192B  map_ids 30799,30797,30802,30801,30804,30798,30796
	btf_id 13476
	pids fact(2870990)
25097: lsm  name trace_path_chown  tag d0d1e170f16bcd54  gpl
	loaded_at 2026-07-14T10:44:19+0200  uid 0
	xlated 4384B  jited 2899B  memlock 8192B  map_ids 30799,30797,30802,30801,30804,30798,30803,30796
	btf_id 13476
	pids fact(2870990)
25098: lsm  name trace_inode_removexattr  tag f9ef1a72a1b9fe73  gpl
	loaded_at 2026-07-14T10:44:19+0200  uid 0
	xlated 6248B  jited 4003B  memlock 8192B  map_ids 30799,30804,30798,30801,30797,30796
	btf_id 13476
	pids fact(2870990)
25099: lsm  name trace_path_unlink  tag 5efbfd1d2a032d8c  gpl
	loaded_at 2026-07-14T10:44:19+0200  uid 0
	xlated 4512B  jited 2922B  memlock 8192B  map_ids 30799,30797,30802,30801,30804,30798,30803,30796
	btf_id 13476
	pids fact(2870990)
25100: lsm  name trace_path_rename  tag 08ff150e408f18a2  gpl
	loaded_at 2026-07-14T10:44:19+0200  uid 0
	xlated 7312B  jited 4598B  memlock 12288B  map_ids 30799,30797,30802,30801,30804,30798,30803,30796
	btf_id 13476
	pids fact(2870990)
25101: lsm  name trace_d_instantiate  tag 8d296658e710a937  gpl
	loaded_at 2026-07-14T10:44:19+0200  uid 0
	xlated 5592B  jited 3673B  memlock 8192B  map_ids 30799,30800,30804,30798,30801,30797,30796
	btf_id 13476
	pids fact(2870990)
25102: lsm  name trace_path_mkdir  tag eb16e5690eecf38f  gpl
	loaded_at 2026-07-14T10:44:19+0200  uid 0
	xlated 2408B  jited 1370B  memlock 4096B  map_ids 30799,30797,30802,30801,30804,30800,30803
	btf_id 13476
	pids fact(2870990)
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `bpf.programs` configuration to enable/disable specific BPF programs via `enabled`.
  * Configured programs are now validated against what’s available in the loaded eBPF object.

* **Bug Fixes**
  * Disabled programs are skipped during load/attachment, with improved warnings.
  * Enhanced error context for eBPF loading and attachment failures.

* **Tests**
  * Expanded YAML parsing, config update, and validation coverage for `bpf.programs`.

* **Documentation**
  * Updated the changelog for the new configurable BPF program feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->