### PR TITLE
fix(host_scanner): reduce syscalls during scans

### DIFF
--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -181,6 +181,7 @@ impl HostScanner {
             self.scan_inner(&path)?;
         }
         let duration = start.elapsed();
+        self.metrics.scan_duration.observe(duration.as_secs_f64());
         info!(
             "Host scan done, took {duration:?}. Inodes tracked: {}",
             self.inode_map.borrow().len()

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -244,8 +244,24 @@ impl HostScanner {
 
     /// Similar to update_entry except we are are directly using the inode instead of the path.
     fn update_entry_with_inode(&self, inode: inode_key_t, path: PathBuf) -> anyhow::Result<()> {
+        let mut inode_map = self.inode_map.borrow_mut();
+        match inode_map.get_mut(&inode) {
+            Some(p) => {
+                // inode is already tracked.
+                if path != *p {
+                    *p = path;
+                    self.metrics.scan_inc(ScanLabels::FileUpdated);
+                }
+                return Ok(());
+            }
+            None => {
+                self.metrics.scan_inc(ScanLabels::FileUpdated);
+                inode_map.insert(inode, path.clone());
+            }
+        };
+
         match self.kernel_inode_map.borrow_mut().insert(inode, 0, 0) {
-            Ok(_) => {}
+            Ok(_) => Ok(()),
             Err(MapError::SyscallError(SyscallError { io_error, .. }))
                 if io_error.kind() == io::ErrorKind::ArgumentListTooLong =>
             {
@@ -257,20 +273,8 @@ You can increase this limit with:
 * The --inodes-max argument."#,
                 )
             }
-            e => {
-                return e.with_context(|| {
-                    format!("Failed to insert kernel entry for {}", path.display())
-                });
-            }
+            e => e.with_context(|| format!("Failed to insert kernel entry for {}", path.display())),
         }
-
-        let mut inode_map = self.inode_map.borrow_mut();
-        let entry = inode_map.entry(inode).or_default();
-        *entry = path;
-
-        self.metrics.scan_inc(ScanLabels::FileUpdated);
-
-        Ok(())
     }
 
     fn get_host_path(&self, inode: Option<&inode_key_t>) -> Option<PathBuf> {

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -41,6 +41,7 @@ use serde::{Serialize, ser::SerializeMap};
 use tokio::{
     sync::{Notify, mpsc, oneshot, watch},
     task::JoinSet,
+    time::Instant,
 };
 
 use crate::{
@@ -154,7 +155,8 @@ impl HostScanner {
     }
 
     fn scan(&self) -> anyhow::Result<()> {
-        debug!("Host scan started");
+        info!("Host scan started");
+        let start = Instant::now();
         self.metrics.scan_inc(ScanLabels::Scans);
         let config = self.paths.borrow();
 
@@ -178,7 +180,11 @@ impl HostScanner {
             let path = host_info::prepend_host_mount(pattern);
             self.scan_inner(&path)?;
         }
-        debug!("Host scan done");
+        let duration = start.elapsed();
+        info!(
+            "Host scan done, took {duration:?}. Inodes tracked: {}",
+            self.inode_map.borrow().len()
+        );
 
         Ok(())
     }

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -21,6 +21,7 @@
 use std::{
     cell::RefCell,
     collections::HashMap,
+    fs::Metadata,
     io,
     ops::{Deref, DerefMut},
     os::linux::fs::MetadataExt,
@@ -198,14 +199,28 @@ impl HostScanner {
         };
 
         for entry in glob::glob(glob_str)? {
-            let path = entry?;
-            if path.is_file() {
+            let path = match entry {
+                Ok(p) => p,
+                Err(e) => {
+                    debug!("Glob expansion failed: {e:?}");
+                    continue;
+                }
+            };
+            let metadata = match path.metadata() {
+                Ok(p) => p,
+                Err(e) => {
+                    debug!("Failed to get metadata for {}: {e:?}", path.display());
+                    continue;
+                }
+            };
+
+            if metadata.is_file() {
                 self.metrics.scan_inc(ScanLabels::FileScanned);
-                self.update_entry(path.as_path())
+                self.update_entry(path.as_path(), &metadata)
                     .with_context(|| format!("Failed to update entry for {}", path.display()))?;
-            } else if path.is_dir() {
+            } else if metadata.is_dir() {
                 self.metrics.scan_inc(ScanLabels::DirectoryScanned);
-                self.update_entry(path.as_path())
+                self.update_entry(path.as_path(), &metadata)
                     .with_context(|| format!("Failed to update entry for {}", path.display()))?;
             } else {
                 self.metrics.scan_inc(ScanLabels::FsItemIgnored);
@@ -214,14 +229,7 @@ impl HostScanner {
         Ok(())
     }
 
-    fn update_entry(&self, path: &Path) -> anyhow::Result<()> {
-        if !path.exists() {
-            // If path does not exist, we don't have anything to update
-            self.metrics.scan_inc(ScanLabels::FileRemoved);
-            return Ok(());
-        }
-
-        let metadata = path.metadata()?;
+    fn update_entry(&self, path: &Path, metadata: &Metadata) -> anyhow::Result<()> {
         let inode = inode_key_t {
             inode: metadata.st_ino(),
             dev: metadata.st_dev(),

--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -203,6 +203,7 @@ impl HostScanner {
                 Ok(p) => p,
                 Err(e) => {
                     debug!("Glob expansion failed: {e:?}");
+                    self.metrics.scan_inc(ScanLabels::GlobFailed);
                     continue;
                 }
             };
@@ -210,6 +211,7 @@ impl HostScanner {
                 Ok(p) => p,
                 Err(e) => {
                     debug!("Failed to get metadata for {}: {e:?}", path.display());
+                    self.metrics.scan_inc(ScanLabels::FsMetadataFailed);
                     continue;
                 }
             };

--- a/fact/src/metrics/host_scanner.rs
+++ b/fact/src/metrics/host_scanner.rs
@@ -1,6 +1,6 @@
 use prometheus_client::{
     encoding::{EncodeLabelSet, EncodeLabelValue},
-    metrics::{counter::Counter, family::Family},
+    metrics::{counter::Counter, family::Family, histogram::Histogram},
     registry::Registry,
 };
 
@@ -29,6 +29,7 @@ pub struct ScanEvents {
 pub struct HostScannerMetrics {
     pub events: EventCounter,
     pub scan: Family<ScanEvents, Counter<u64>>,
+    pub scan_duration: Histogram,
 }
 
 impl HostScannerMetrics {
@@ -59,8 +60,15 @@ impl HostScannerMetrics {
         ] {
             let _ = scan.get_or_create(&ScanEvents { label });
         }
+        let scan_duration = Histogram::new([
+            0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0,
+        ]);
 
-        HostScannerMetrics { events, scan }
+        HostScannerMetrics {
+            events,
+            scan,
+            scan_duration,
+        }
     }
 
     pub(super) fn register(&self, reg: &mut Registry) {
@@ -69,6 +77,12 @@ impl HostScannerMetrics {
             "host_scanner_scan",
             "Counter of events by scans from the host scanner component",
             self.scan.clone(),
+        );
+
+        reg.register(
+            "host_scanner_scan_duration",
+            "Histogram of scan durations from the host scanner component",
+            self.scan_duration.clone(),
         );
     }
 

--- a/fact/src/metrics/host_scanner.rs
+++ b/fact/src/metrics/host_scanner.rs
@@ -17,6 +17,8 @@ pub enum ScanLabels {
     FileRemoved,
     FileUpdated,
     FsItemIgnored,
+    FsMetadataFailed,
+    GlobFailed,
 }
 
 #[derive(Clone, Hash, Eq, Debug, PartialEq, EncodeLabelSet)]
@@ -57,6 +59,8 @@ impl HostScannerMetrics {
             ScanLabels::FileRemoved,
             ScanLabels::FileUpdated,
             ScanLabels::FsItemIgnored,
+            ScanLabels::FsMetadataFailed,
+            ScanLabels::GlobFailed,
         ] {
             let _ = scan.get_or_create(&ScanEvents { label });
         }


### PR DESCRIPTION
## Description

This PR makes some efforts to try and reduce the amount of syscalls that `HostScanner` does when scanning through the filesystem. This is achieved essentially with two changes:
- Reduce the number of `stat` calls.
- Reduce the number of BPF map update for inode tracking.

The first one is done by replacing individual calls to `PathBuf::is_file`, `PathBuf::is_dir` and `PathBuf::metadata`, all of which call `stat` under the hood, with a single `PathBuf::metadata` call and using it where needed.

The second one is done by first checking if the userspace inode map has the found inode and if it is already there, we simply skip inserting it kernel side, since it should've been put there in a previous scan.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

### Reduced number of syscalls

Running fact with the following command: `FACT_LOGLEVEL=info RUST_BACKTRACE=1 cargo srun --bin fact --all-features -- -p '/etc/**/*:/etc/' --inodes-max=2097152 --expose-metrics --scan-interval 30`, then using `perf stat -e 'syscalls:sys_enter_statx,syscalls:sys_enter_bpf' -p "$(pgrep fact)" -- sleep 30` capturing a single scan. No events generated during the run, no modifications to the `/etc` directory, 25966 inodes tracked for all the scans.

Before changes:
```
 Performance counter stats for process id '1050929':

           114,514      syscalls:sys_enter_statx
            28,447      syscalls:sys_enter_bpf

      30.002484040 seconds time elapsed
```

After all changes:
```
 Performance counter stats for process id '1067511':

            56,597      syscalls:sys_enter_statx
                 0      syscalls:sys_enter_bpf

      30.002870566 seconds time elapsed
```

### Average scan time

Run `fact` with the following command in each commit in this PR: `FACT_LOGLEVEL=info RUST_BACKTRACE=1 cargo srun --bin fact --all-features -- -p '/etc/**/*:/etc/' --inodes-max=2097152 --expose-metrics --scan-interval 1`. No events generated during the run, no modifications to the `/etc` directory, 25966 inodes tracked for all the scans.

<details>
<summary>Average scan time adding scan duration to log and metric: 162.48ms</summary>

```
# HELP stackrox_fact_host_scanner_scan_duration Histogram of scan durations from the host scanner component.
# TYPE stackrox_fact_host_scanner_scan_duration histogram
stackrox_fact_host_scanner_scan_duration_sum 19.660724177999989
stackrox_fact_host_scanner_scan_duration_count 121
stackrox_fact_host_scanner_scan_duration_bucket{le="0.01"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.05"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.1"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.25"} 121
stackrox_fact_host_scanner_scan_duration_bucket{le="0.5"} 121
stackrox_fact_host_scanner_scan_duration_bucket{le="1.0"} 121
stackrox_fact_host_scanner_scan_duration_bucket{le="5.0"} 121
stackrox_fact_host_scanner_scan_duration_bucket{le="10.0"} 121
stackrox_fact_host_scanner_scan_duration_bucket{le="30.0"} 121
stackrox_fact_host_scanner_scan_duration_bucket{le="60.0"} 121
stackrox_fact_host_scanner_scan_duration_bucket{le="120.0"} 121
stackrox_fact_host_scanner_scan_duration_bucket{le="+Inf"} 121
```

</details>

<details>
<summary>Average scan time using a single metadata call: 136.44ms</summary>

```
# HELP stackrox_fact_host_scanner_scan_duration Histogram of scan durations from the host scanner component.
# TYPE stackrox_fact_host_scanner_scan_duration histogram
stackrox_fact_host_scanner_scan_duration_sum 14.190043638000005
stackrox_fact_host_scanner_scan_duration_count 104
stackrox_fact_host_scanner_scan_duration_bucket{le="0.01"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.05"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.1"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.25"} 104
stackrox_fact_host_scanner_scan_duration_bucket{le="0.5"} 104
stackrox_fact_host_scanner_scan_duration_bucket{le="1.0"} 104
stackrox_fact_host_scanner_scan_duration_bucket{le="5.0"} 104
stackrox_fact_host_scanner_scan_duration_bucket{le="10.0"} 104
stackrox_fact_host_scanner_scan_duration_bucket{le="30.0"} 104
stackrox_fact_host_scanner_scan_duration_bucket{le="60.0"} 104
stackrox_fact_host_scanner_scan_duration_bucket{le="120.0"} 104
stackrox_fact_host_scanner_scan_duration_bucket{le="+Inf"} 104
```

</details>

<details>
<summary>Average scan time skipping re-insertion of inodes in BPF map: 114.19ms</summary>

```
# HELP stackrox_fact_host_scanner_scan_duration Histogram of scan durations from the host scanner component.
# TYPE stackrox_fact_host_scanner_scan_duration histogram
stackrox_fact_host_scanner_scan_duration_sum 13.245613742999997
stackrox_fact_host_scanner_scan_duration_count 116
stackrox_fact_host_scanner_scan_duration_bucket{le="0.01"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.05"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.1"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.25"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="0.5"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="1.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="5.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="10.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="30.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="60.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="120.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="+Inf"} 116
```

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

* Host scans now report completion times and tracked inode counts.
* Scanning continues processing valid entries when filesystem metadata or path-matching errors occur.
* File updates are processed more efficiently when paths remain unchanged.

## Monitoring

* Added scan-duration metrics for improved operational visibility.
* Added metrics for filesystem metadata failures and directory traversal failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->