### PR TITLE
chore(host_scanner): improve cleanup algorithm in scans

### DIFF
--- a/fact/src/host_scanner.rs
+++ b/fact/src/host_scanner.rs
@@ -32,7 +32,7 @@ use std::{
 
 use anyhow::{Context, bail};
 use aya::{
-    maps::{MapData, MapError},
+    maps::{HashMap as AyaHashMap, MapData, MapError},
     sys::SyscallError,
 };
 use fact_ebpf::{inode_key_t, inode_value_t, monitored_t};
@@ -52,7 +52,7 @@ use crate::{
     metrics::host_scanner::{HostScannerMetrics, ScanLabels},
 };
 
-struct InodeMap(HashMap<inode_key_t, PathBuf>);
+struct InodeMap(HashMap<inode_key_t, (PathBuf, u8)>);
 
 impl InodeMap {
     fn new() -> Self {
@@ -61,7 +61,7 @@ impl InodeMap {
 }
 
 impl Deref for InodeMap {
-    type Target = HashMap<inode_key_t, PathBuf>;
+    type Target = HashMap<inode_key_t, (PathBuf, u8)>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -85,15 +85,17 @@ impl Serialize for InodeMap {
             // a string key. This enables us to send this type over HTTP
             // as part of the "/inodes" introspection endpoint, while
             // keeping the existing inode_key_t Serialize implementation.
-            map.serialize_entry(&format!("{}:{}", k.dev, k.inode), v)?;
+            map.serialize_entry(&format!("{}:{}", k.dev, k.inode), &v.0)?;
         }
         map.end()
     }
 }
 
 pub struct HostScanner {
-    kernel_inode_map: RefCell<aya::maps::HashMap<MapData, inode_key_t, inode_value_t>>,
+    kernel_inode_map: RefCell<AyaHashMap<MapData, inode_key_t, inode_value_t>>,
     inode_map: RefCell<InodeMap>,
+
+    scan_count: RefCell<u8>,
 
     paths: watch::Receiver<Vec<PathBuf>>,
     scan_interval: watch::Receiver<Duration>,
@@ -124,6 +126,7 @@ impl HostScanner {
         let host_scanner = HostScanner {
             kernel_inode_map,
             inode_map,
+            scan_count: RefCell::new(0),
             paths,
             scan_interval,
             rx,
@@ -155,32 +158,45 @@ impl HostScanner {
         Ok(builder.build()?)
     }
 
+    fn new_scan(&self) -> u8 {
+        let mut scan_count = self.scan_count.borrow_mut();
+        *scan_count += 1;
+        *scan_count
+    }
+
     fn scan(&self) -> anyhow::Result<()> {
         info!("Host scan started");
         let start = Instant::now();
         self.metrics.scan_inc(ScanLabels::Scans);
-        let config = self.paths.borrow();
+
+        let scan_count = self.new_scan();
+
+        for pattern in self.paths.borrow().iter() {
+            let path = host_info::prepend_host_mount(pattern);
+            self.scan_inner(&path, scan_count)?;
+        }
 
         // Cleanup any items that are either:
         // * Not configured to be monitored anymore.
         // * Are configured to be monitored but no longer are found in
         //   the file system.
-        self.inode_map.borrow_mut().retain(|inode, path| {
-            if config.iter().any(|prefix| path.starts_with(prefix))
-                && host_info::prepend_host_mount(path).exists()
-            {
-                true
-            } else {
-                let _ = self.kernel_inode_map.borrow_mut().remove(inode);
-                self.metrics.scan_inc(ScanLabels::InodeRemoved);
-                false
-            }
-        });
-
-        for pattern in self.paths.borrow().iter() {
-            let path = host_info::prepend_host_mount(pattern);
-            self.scan_inner(&path)?;
+        //
+        // The scan happens inline with processing of events, so at this
+        // point all elements in the map that we saw during the scan
+        // should have the corresponding scan count set to the same
+        // value as the one we have now. Everything that has a different
+        // value can be assumed to have been removed or no longer
+        // monitored.
+        for (inode, _) in self
+            .inode_map
+            .borrow_mut()
+            .extract_if(|_, (_, c)| *c != scan_count)
+        {
+            // TODO: Turn this into a bulk operation. https://github.com/stackrox/fact/issues/1133
+            let _ = self.kernel_inode_map.borrow_mut().remove(&inode);
+            self.metrics.scan_inc(ScanLabels::InodeRemoved);
         }
+
         let duration = start.elapsed();
         self.metrics.scan_duration.observe(duration.as_secs_f64());
         info!(
@@ -191,7 +207,7 @@ impl HostScanner {
         Ok(())
     }
 
-    fn scan_inner(&self, path: &Path) -> anyhow::Result<()> {
+    fn scan_inner(&self, path: &Path, scan_count: u8) -> anyhow::Result<()> {
         self.metrics.scan_inc(ScanLabels::ElementsScanned);
 
         let Some(glob_str) = path.to_str() else {
@@ -218,11 +234,11 @@ impl HostScanner {
 
             if metadata.is_file() {
                 self.metrics.scan_inc(ScanLabels::FileScanned);
-                self.update_entry(path.as_path(), &metadata)
+                self.update_entry(path.as_path(), &metadata, scan_count)
                     .with_context(|| format!("Failed to update entry for {}", path.display()))?;
             } else if metadata.is_dir() {
                 self.metrics.scan_inc(ScanLabels::DirectoryScanned);
-                self.update_entry(path.as_path(), &metadata)
+                self.update_entry(path.as_path(), &metadata, scan_count)
                     .with_context(|| format!("Failed to update entry for {}", path.display()))?;
             } else {
                 self.metrics.scan_inc(ScanLabels::FsItemIgnored);
@@ -231,34 +247,40 @@ impl HostScanner {
         Ok(())
     }
 
-    fn update_entry(&self, path: &Path, metadata: &Metadata) -> anyhow::Result<()> {
+    fn update_entry(&self, path: &Path, metadata: &Metadata, scan_count: u8) -> anyhow::Result<()> {
         let inode = inode_key_t {
             inode: metadata.st_ino(),
             dev: metadata.st_dev(),
         };
 
         let host_path = host_info::remove_host_mount(path);
-        self.update_entry_with_inode(inode, host_path)?;
+        self.update_entry_with_inode(inode, host_path, scan_count)?;
 
         debug!("Added entry for {}: {inode:?}", path.display());
         Ok(())
     }
 
     /// Similar to update_entry except we are are directly using the inode instead of the path.
-    fn update_entry_with_inode(&self, inode: inode_key_t, path: PathBuf) -> anyhow::Result<()> {
+    fn update_entry_with_inode(
+        &self,
+        inode: inode_key_t,
+        path: PathBuf,
+        scan_count: u8,
+    ) -> anyhow::Result<()> {
         let mut inode_map = self.inode_map.borrow_mut();
         match inode_map.get_mut(&inode) {
-            Some(p) => {
+            Some((p, c)) => {
                 // inode is already tracked.
                 if path != *p {
                     *p = path;
                     self.metrics.scan_inc(ScanLabels::FileUpdated);
                 }
+                *c = scan_count;
                 return Ok(());
             }
             None => {
                 self.metrics.scan_inc(ScanLabels::FileUpdated);
-                inode_map.insert(inode, path.clone());
+                inode_map.insert(inode, (path.clone(), scan_count));
             }
         };
 
@@ -282,7 +304,7 @@ You can increase this limit with:
     fn get_host_path(&self, inode: Option<&inode_key_t>) -> Option<PathBuf> {
         // The path here needs to be cloned because we won't keep the
         // inode_map borrow long enough.
-        self.inode_map.borrow().get(inode?).cloned()
+        self.inode_map.borrow().get(inode?).cloned().map(|(p, _)| p)
     }
 
     /// Handle file creation events by adding new inodes to the map.
@@ -301,7 +323,7 @@ You can increase this limit with:
             && let Some(parent_host_path) = self.get_host_path(Some(parent_inode))
         {
             let host_path = parent_host_path.join(filename);
-            self.update_entry_with_inode(*inode, host_path)
+            self.update_entry_with_inode(*inode, host_path, *self.scan_count.borrow())
                 .with_context(|| {
                     format!(
                         "Failed to add creation event entry for {}",
@@ -352,7 +374,7 @@ You can increase this limit with:
                     warn!("Rename event did not have old host path for inode tracked item");
                     return;
                 };
-                self.inode_map.borrow_mut().retain(|inode, path| {
+                self.inode_map.borrow_mut().retain(|inode, (path, _)| {
                     if !path.starts_with(old_host_path) {
                         return true;
                     }
@@ -381,7 +403,7 @@ You can increase this limit with:
                 // path that didn't hold anything, we need to figure out the
                 // host path and check if we should track it.
                 let mut inode_map = self.inode_map.borrow_mut();
-                let Some(new_host_parent) = inode_map.get(event.get_parent_inode()) else {
+                let Some((new_host_parent, _)) = inode_map.get(event.get_parent_inode()) else {
                     warn!("Failed to get parent host path");
                     return;
                 };
@@ -397,7 +419,7 @@ You can increase this limit with:
                 if self.paths_globset.is_match(&new_host_path) {
                     // New path needs to be tracked.
                     // Move all entries for the old host path to the new one
-                    for path in inode_map.values_mut() {
+                    for (path, _) in inode_map.values_mut() {
                         if let Ok(suffix) = path.strip_prefix(old_host_path) {
                             if suffix == Path::new("") {
                                 *path = new_host_path.clone();
@@ -411,7 +433,7 @@ You can increase this limit with:
                     event.set_host_path(new_host_path);
                 } else {
                     // New path is not tracked, remove old entries
-                    inode_map.retain(|inode, path| {
+                    inode_map.retain(|inode, (path, _)| {
                         if !path.starts_with(old_host_path) {
                             return true;
                         }
@@ -433,7 +455,7 @@ You can increase this limit with:
 
                 // Attempt to update the host path with the old inode
                 if let Some(old_inode) = event.get_old_inode()
-                    && let Some(path) = self.inode_map.borrow().get(old_inode)
+                    && let Some((path, _)) = self.inode_map.borrow().get(old_inode)
                 {
                     event.set_host_path(path.clone());
                 }


### PR DESCRIPTION
## Description

In order to remove items from the inode maps for files that may have been deleted and may have missed events, or paths that are no longer monitored due to a configuration change, we used to:
* Iterate over the userspace map.
* Check if the path matches the configured globs.
* Check if the path still exists in the filesystem (via statx).
* If either of the previous checks failed, we remove the inode from the maps

After this cleanup is done, we proceed to glob the configured paths and check all of them on disk, adding any missing inodes and updating any changed paths. The most common situation for these scans is that most inodes should hit (unless the configuration is changed or massive changes to the fs were missed), which means we are essentially doing two statx calls per element in the inode (once during the cleanup iteration and another during the glob expansion).

This change does a few things:
* Add a marker to each tracked inode (a counter that increments every scan iteration).
* Do the glob expansion first, marking each found inode with the current scan number.
* Once we are done exploring the glob expansion, iterate over the map and remove any entries that have an out of date scan marker (i.e: they were not found as part of the glob expansion).

This saves us some `statx` calls during scans, making them faster.

Of note, this change works because scanning pauses processing of events until the scan is done, otherwise it could be subject to race conditions.

This is a small follow-up to #1221.

## Checklist
- [ ] Patch has a change log entry **OR** does not need one.
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

### Reduced number of syscalls

Running fact with the following command: `FACT_LOGLEVEL=info RUST_BACKTRACE=1 cargo srun --bin fact --all-features -- -p '/etc/**/*:/etc/' --inodes-max=2097152 --expose-metrics --scan-interval 30`, then using `perf stat -e 'syscalls:sys_enter_statx,syscalls:sys_enter_bpf' -p "$(pgrep fact)" -- sleep 30` capturing a single scan. No events generated during the run, no modifications to the /etc directory, 25966 inodes tracked for all the scans.

Before changes:

```
 Performance counter stats for process id '1067511':

            56,597      syscalls:sys_enter_statx
                 0      syscalls:sys_enter_bpf

      30.002870566 seconds time elapsed
```

After changes:

```
 Performance counter stats for process id '1954123':

            30,631      syscalls:sys_enter_statx
                 0      syscalls:sys_enter_bpf

      30.004685963 seconds time elapsed
```

### Average scan time

<details>
<summary>Average scan time before changes: 114.19ms</summary>

```
# HELP stackrox_fact_host_scanner_scan_duration Histogram of scan durations from the host scanner component.
# TYPE stackrox_fact_host_scanner_scan_duration histogram
stackrox_fact_host_scanner_scan_duration_sum 13.245613742999997
stackrox_fact_host_scanner_scan_duration_count 116
stackrox_fact_host_scanner_scan_duration_bucket{le="0.01"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.05"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.1"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.25"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="0.5"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="1.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="5.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="10.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="30.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="60.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="120.0"} 116
stackrox_fact_host_scanner_scan_duration_bucket{le="+Inf"} 116
```

</details>

<details>
<summary>Average scan time after changes: 79.35ms</summary>

```
# HELP stackrox_fact_host_scanner_scan_duration Histogram of scan durations from the host scanner component.
# TYPE stackrox_fact_host_scanner_scan_duration histogram
stackrox_fact_host_scanner_scan_duration_sum 8.8867888
stackrox_fact_host_scanner_scan_duration_count 112
stackrox_fact_host_scanner_scan_duration_bucket{le="0.01"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.05"} 0
stackrox_fact_host_scanner_scan_duration_bucket{le="0.1"} 109
stackrox_fact_host_scanner_scan_duration_bucket{le="0.25"} 112
stackrox_fact_host_scanner_scan_duration_bucket{le="0.5"} 112
stackrox_fact_host_scanner_scan_duration_bucket{le="1.0"} 112
stackrox_fact_host_scanner_scan_duration_bucket{le="5.0"} 112
stackrox_fact_host_scanner_scan_duration_bucket{le="10.0"} 112
stackrox_fact_host_scanner_scan_duration_bucket{le="30.0"} 112
stackrox_fact_host_scanner_scan_duration_bucket{le="60.0"} 112
stackrox_fact_host_scanner_scan_duration_bucket{le="120.0"} 112
stackrox_fact_host_scanner_scan_duration_bucket{le="+Inf"} 112
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host filesystem scanning to remove entries that are no longer present.
  * Improved tracking of newly discovered and event-created files during scans.
  * Updated rename handling and host-path lookups for more accurate results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->