### PR TITLE
chore(config): remove config field from Reloader

### DIFF
--- a/fact/src/bpf/mod.rs
+++ b/fact/src/bpf/mod.rs
@@ -368,12 +368,13 @@ mod bpf_tests {
         let paths = vec![PathBuf::from(format!("{}/**/*", monitored_path.display()))];
         let mut config = FactConfig::default();
         config.set_paths(paths);
+        let bpf_config = config.bpf.clone();
         let reloader = Reloader::from(config);
         let metrics = Metrics::new();
         let (run_tx, run_rx) = watch::channel(true);
         let (bpf, mut rx) = Bpf::new(
             reloader.paths(),
-            &reloader.config().bpf,
+            &bpf_config,
             run_rx,
             metrics.bpf_worker.clone(),
         )

--- a/fact/src/config/reloader.rs
+++ b/fact/src/config/reloader.rs
@@ -13,7 +13,8 @@ use crate::config::OTelConfig;
 use super::{CONFIG_FILES, EndpointConfig, FactConfig, GrpcConfig};
 
 pub struct Reloader {
-    config: FactConfig,
+    enabled: bool,
+
     endpoint: watch::Sender<EndpointConfig>,
     grpc: watch::Sender<GrpcConfig>,
     otel: watch::Sender<OTelConfig>,
@@ -34,7 +35,7 @@ impl Reloader {
     /// If hotreload is disabled on startup the task will not be
     /// spawned.
     pub fn start(mut self, mut running: watch::Receiver<bool>) {
-        if !self.config.hotreload() {
+        if !self.enabled {
             info!("Configuration hotreload is disabled, changes will require a restart.");
             return;
         }
@@ -54,10 +55,6 @@ impl Reloader {
                 }
             }
         });
-    }
-
-    pub fn config(&self) -> &FactConfig {
-        &self.config
     }
 
     /// Subscribe to get notifications when endpoint configuration is
@@ -161,36 +158,6 @@ impl Reloader {
         };
         info!("Updated configuration: {new:#?}");
 
-        self.endpoint.send_if_modified(|old| {
-            if *old != new.endpoint {
-                debug!("Sending new endpoint configuration...");
-                *old = new.endpoint.clone();
-                true
-            } else {
-                false
-            }
-        });
-
-        self.grpc.send_if_modified(|old| {
-            if *old != new.grpc {
-                debug!("Sending new gRPC configuration...");
-                *old = new.grpc.clone();
-                true
-            } else {
-                false
-            }
-        });
-
-        self.otel.send_if_modified(|old| {
-            if *old != new.otel {
-                debug!("Sending new OTel configuration...");
-                *old = new.otel.clone();
-                true
-            } else {
-                false
-            }
-        });
-
         self.paths.send_if_modified(|old| {
             let new = new.paths();
             if *old != new {
@@ -224,11 +191,46 @@ impl Reloader {
             }
         });
 
-        if self.config.hotreload() != new.hotreload() {
+        if self.enabled != new.hotreload() {
             warn!("Changes to the hotreload field only take effect on startup");
         }
 
-        self.config = new;
+        let FactConfig {
+            endpoint,
+            grpc,
+            otel,
+            ..
+        } = new;
+
+        self.endpoint.send_if_modified(|old| {
+            if *old != endpoint {
+                debug!("Sending new endpoint configuration...");
+                *old = endpoint;
+                true
+            } else {
+                false
+            }
+        });
+
+        self.grpc.send_if_modified(|old| {
+            if *old != grpc {
+                debug!("Sending new gRPC configuration...");
+                *old = grpc;
+                true
+            } else {
+                false
+            }
+        });
+
+        self.otel.send_if_modified(|old| {
+            if *old != otel {
+                debug!("Sending new OTel configuration...");
+                *old = otel;
+                true
+            } else {
+                false
+            }
+        });
     }
 }
 
@@ -253,16 +255,26 @@ impl From<FactConfig> for Reloader {
                 }
             })
             .collect();
-        let (endpoint, _) = watch::channel(config.endpoint.clone());
-        let (grpc, _) = watch::channel(config.grpc.clone());
-        let (otel, _) = watch::channel(config.otel.clone());
+
+        let enabled = config.hotreload();
         let (paths, _) = watch::channel(config.paths().to_vec());
         let (scan_interval, _) = watch::channel(config.scan_interval());
         let (rate_limit, _) = watch::channel(config.rate_limit());
+
+        let FactConfig {
+            endpoint,
+            grpc,
+            otel,
+            ..
+        } = config;
+
+        let (endpoint, _) = watch::channel(endpoint);
+        let (grpc, _) = watch::channel(grpc);
+        let (otel, _) = watch::channel(otel);
         let trigger = Arc::new(Notify::new());
 
         Reloader {
-            config,
+            enabled,
             endpoint,
             grpc,
             otel,

--- a/fact/src/config/reloader/mod.rs
+++ b/fact/src/config/reloader/mod.rs
@@ -25,6 +25,9 @@ pub struct Reloader {
     trigger: Arc<Notify>,
 }
 
+#[cfg(test)]
+mod tests;
+
 impl Reloader {
     /// Consume the reloader into a task
     ///
@@ -142,22 +145,8 @@ impl Reloader {
         res
     }
 
-    /// Recreate the configuration and notify of changes to any
-    /// subscribers.
-    fn reload(&mut self) {
-        if !self.update_cache() {
-            return;
-        }
-
-        let new = match FactConfig::build() {
-            Ok(config) => config,
-            Err(e) => {
-                warn!("Configuration reloading failed: {e}");
-                return;
-            }
-        };
-        info!("Updated configuration: {new:#?}");
-
+    /// Propagate configuration changes to all subscribers that need it
+    fn send_updates(&self, new: FactConfig) {
         self.paths.send_if_modified(|old| {
             let new = new.paths();
             if *old != new {
@@ -231,6 +220,25 @@ impl Reloader {
                 false
             }
         });
+    }
+
+    /// Recreate the configuration and notify of changes to any
+    /// subscribers.
+    fn reload(&mut self) {
+        if !self.update_cache() {
+            return;
+        }
+
+        let new = match FactConfig::build() {
+            Ok(config) => config,
+            Err(e) => {
+                warn!("Configuration reloading failed: {e}");
+                return;
+            }
+        };
+        info!("Updated configuration: {new:#?}");
+
+        self.send_updates(new);
     }
 }
 

--- a/fact/src/config/reloader/tests.rs
+++ b/fact/src/config/reloader/tests.rs
@@ -1,0 +1,1417 @@
+use std::{
+    fmt::Debug,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+
+use crate::config::BackoffConfig;
+
+use super::*;
+
+/// Assert the value in the watch::Receiver matches the expected one or
+/// it hasn't been updated.
+///
+/// This is not part of the generate_test macro in order to help the
+/// macro in doing type inference properly when the expected value is
+/// None.
+fn assert_reload<T>(result: watch::Receiver<T>, expected: Option<T>)
+where
+    T: Debug + PartialEq,
+{
+    match expected {
+        Some(expected) => {
+            assert!(result.has_changed().unwrap());
+            assert_eq!(*result.borrow(), expected);
+        }
+        None => {
+            assert!(!result.has_changed().unwrap());
+        }
+    }
+}
+
+macro_rules! generate_test {
+    ($testname:ident, $channel:ident, $old:expr, $new:expr, $expected:expr) => {
+        #[test]
+        fn $testname() {
+            let reloader = Reloader::from($old);
+            let channel = reloader.$channel();
+            reloader.send_updates($new);
+
+            assert_reload(channel, $expected);
+        }
+    };
+}
+
+macro_rules! generate_paths_test {
+    ($testname:ident, $old:expr, $new:expr, $expected:expr) => {
+        generate_test!($testname, paths, $old, $new, $expected);
+    };
+}
+
+generate_paths_test! {
+    test_reloader_paths_default,
+    FactConfig::default(),
+    FactConfig::default(),
+    None
+}
+generate_paths_test! {
+    test_reloader_paths_from_default_to_empty,
+    FactConfig::default(),
+    FactConfig {
+        paths: Some(vec![]),
+        ..Default::default()
+    },
+    None
+}
+generate_paths_test! {
+    test_reloader_paths_config_change,
+    FactConfig {
+        paths: Some(vec!["/home".into()]),
+        ..Default::default()
+    },
+    FactConfig {
+        paths: Some(vec!["/etc".into()]),
+        ..Default::default()
+    },
+    Some(vec![PathBuf::from("/etc")])
+}
+generate_paths_test! {
+    test_reloader_paths_no_config_change,
+    FactConfig {
+        paths: Some(vec!["/home".into()]),
+        ..Default::default()
+    },
+    FactConfig {
+        paths: Some(vec!["/home".into()]),
+        scan_interval: Some(Duration::from_secs(10)),
+        ..Default::default()
+    },
+    None
+}
+
+macro_rules! generate_scan_interval_test {
+    ($testname:ident, $old:expr, $new:expr, $expected:expr) => {
+        generate_test!($testname, scan_interval, $old, $new, $expected);
+    };
+}
+
+generate_scan_interval_test! {
+    test_reloader_scan_interval_default,
+    FactConfig::default(),
+    FactConfig::default(),
+    None
+}
+generate_scan_interval_test! {
+    test_reloader_scan_interval_from_default,
+    FactConfig::default(),
+    FactConfig {
+        scan_interval: Some(Duration::from_secs(10)),
+        ..Default::default()
+    },
+    Some(Duration::from_secs(10))
+}
+generate_scan_interval_test! {
+    test_reloader_scan_interval_to_default,
+    FactConfig {
+        scan_interval: Some(Duration::from_secs(10)),
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(Duration::from_secs(30))
+}
+generate_scan_interval_test! {
+    test_reloader_scan_interval_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        scan_interval: Some(Duration::from_secs(30)),
+        ..Default::default()
+    },
+    None
+}
+generate_scan_interval_test! {
+    test_reloader_scan_interval_to_default_from_explicit_default,
+    FactConfig {
+        scan_interval: Some(Duration::from_secs(30)),
+        ..Default::default()
+    },
+    FactConfig::default(),
+    None
+}
+generate_scan_interval_test! {
+    test_reloader_scan_interval_changed,
+    FactConfig {
+        scan_interval: Some(Duration::from_secs(30)),
+        ..Default::default()
+    },
+    FactConfig {
+        scan_interval: Some(Duration::from_secs(60)),
+        ..Default::default()
+    },
+    Some(Duration::from_secs(60))
+}
+generate_scan_interval_test! {
+    test_reloader_scan_interval_no_change,
+    FactConfig {
+        scan_interval: Some(Duration::from_secs(60)),
+        ..Default::default()
+    },
+    FactConfig {
+        scan_interval: Some(Duration::from_secs(60)),
+        paths: Some(vec!["/etc".into()]),
+        ..Default::default()
+    },
+    None
+}
+
+macro_rules! generate_rate_limit_test {
+    ($testname:ident, $old:expr, $new:expr, $expected:expr) => {
+        generate_test!($testname, rate_limit, $old, $new, $expected);
+    };
+}
+
+generate_rate_limit_test! {
+    test_reloader_rate_limit_default,
+    FactConfig::default(),
+    FactConfig::default(),
+    None
+}
+generate_rate_limit_test! {
+    test_reloader_rate_limit_from_default,
+    FactConfig::default(),
+    FactConfig {
+        rate_limit: Some(5000),
+        ..Default::default()
+    },
+    Some(5000)
+}
+generate_rate_limit_test! {
+    test_reloader_rate_limit_to_default,
+    FactConfig {
+        rate_limit: Some(5000),
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(0)
+}
+generate_rate_limit_test! {
+    test_reloader_rate_limit_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        rate_limit: Some(0),
+        ..Default::default()
+    },
+    None
+}
+generate_rate_limit_test! {
+    test_reloader_rate_limit_to_default_from_explicit_default,
+    FactConfig {
+        rate_limit: Some(0),
+        ..Default::default()
+    },
+    FactConfig::default(),
+    None
+}
+generate_rate_limit_test! {
+    test_reloader_rate_limit_changed,
+    FactConfig {
+        rate_limit: Some(1000),
+        ..Default::default()
+    },
+    FactConfig {
+        rate_limit: Some(5000),
+        ..Default::default()
+    },
+    Some(5000)
+}
+generate_rate_limit_test! {
+    test_reloader_rate_limit_no_change,
+    FactConfig {
+        rate_limit: Some(1000),
+        ..Default::default()
+    },
+    FactConfig {
+        rate_limit: Some(1000),
+        paths: Some(vec!["/etc".into()]),
+        ..Default::default()
+    },
+    None
+}
+
+macro_rules! generate_endpoint_test {
+    ($testname:ident, $old:expr, $new:expr, $expected:expr) => {
+        generate_test!($testname, endpoint, $old, $new, $expected);
+    };
+}
+
+generate_endpoint_test! {
+    test_reloader_endpoint_default,
+    FactConfig::default(),
+    FactConfig::default(),
+    None
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_no_change,
+    FactConfig {
+        endpoint: EndpointConfig {
+            address: Some(ENDPOINT_ADDRESS_DEFAULT),
+            expose_metrics: Some(true),
+            health_check: Some(true),
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        endpoint: EndpointConfig {
+            address: Some(ENDPOINT_ADDRESS_DEFAULT),
+            expose_metrics: Some(true),
+            health_check: Some(true),
+        },
+        paths: Some(vec!["/etc".into()]),
+        ..Default::default()
+    },
+    None
+}
+
+const ENDPOINT_ADDRESS_DEFAULT: SocketAddr =
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 9000);
+const ENDPOINT_ADDRESS_LOCAL: SocketAddr =
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+
+generate_endpoint_test! {
+    test_reloader_endpoint_address_from_default,
+    FactConfig::default(),
+    FactConfig {
+        endpoint: EndpointConfig {
+            address: Some(ENDPOINT_ADDRESS_LOCAL),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(EndpointConfig {
+        address: Some(ENDPOINT_ADDRESS_LOCAL),
+        ..Default::default()
+    })
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_address_to_default,
+    FactConfig {
+        endpoint: EndpointConfig {
+            address: Some(ENDPOINT_ADDRESS_LOCAL),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(EndpointConfig::default())
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_address_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        endpoint: EndpointConfig {
+            address: Some(ENDPOINT_ADDRESS_DEFAULT),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(EndpointConfig {
+        address: Some(ENDPOINT_ADDRESS_DEFAULT),
+        ..Default::default()
+    })
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_address_to_default_from_explicit_default,
+    FactConfig {
+        endpoint: EndpointConfig {
+            address: Some(ENDPOINT_ADDRESS_DEFAULT),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(EndpointConfig::default())
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_address_changed,
+    FactConfig {
+        endpoint: EndpointConfig {
+            address: Some(ENDPOINT_ADDRESS_DEFAULT),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        endpoint: EndpointConfig {
+            address: Some(SocketAddr::from(([0,0,0,0], 8000))),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(EndpointConfig {
+        address: Some(SocketAddr::from(([0,0,0,0], 8000))),
+        ..Default::default()
+    })
+}
+
+generate_endpoint_test! {
+    test_reloader_endpoint_expose_metrics_from_default,
+    FactConfig::default(),
+    FactConfig {
+        endpoint: EndpointConfig {
+            expose_metrics: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(EndpointConfig {
+        expose_metrics: Some(true),
+        ..Default::default()
+    })
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_expose_metrics_to_default,
+    FactConfig {
+        endpoint: EndpointConfig {
+            expose_metrics: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(EndpointConfig::default())
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_expose_metrics_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        endpoint: EndpointConfig {
+            expose_metrics: Some(false),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(EndpointConfig {
+        expose_metrics: Some(false),
+        ..Default::default()
+    })
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_expose_metrics_to_default_from_explicit_default,
+    FactConfig {
+        endpoint: EndpointConfig {
+            expose_metrics: Some(false),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(EndpointConfig::default())
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_expose_metrics_changed,
+    FactConfig {
+        endpoint: EndpointConfig {
+            expose_metrics: Some(false),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        endpoint: EndpointConfig {
+            expose_metrics: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(EndpointConfig {
+        expose_metrics: Some(true),
+        ..Default::default()
+    })
+}
+
+generate_endpoint_test! {
+    test_reloader_endpoint_health_check_from_default,
+    FactConfig::default(),
+    FactConfig {
+        endpoint: EndpointConfig {
+            health_check: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(EndpointConfig {
+        health_check: Some(true),
+        ..Default::default()
+    })
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_health_check_to_default,
+    FactConfig {
+        endpoint: EndpointConfig {
+            health_check: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(EndpointConfig::default())
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_health_check_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        endpoint: EndpointConfig {
+            health_check: Some(false),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(EndpointConfig {
+        health_check: Some(false),
+        ..Default::default()
+    })
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_health_check_to_default_from_explicit_default,
+    FactConfig {
+        endpoint: EndpointConfig {
+            health_check: Some(false),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(EndpointConfig::default())
+}
+generate_endpoint_test! {
+    test_reloader_endpoint_health_check_changed,
+    FactConfig {
+        endpoint: EndpointConfig {
+            health_check: Some(false),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        endpoint: EndpointConfig {
+            health_check: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(EndpointConfig {
+        health_check: Some(true),
+        ..Default::default()
+    })
+}
+
+macro_rules! generate_grpc_test {
+    ($testname:ident, $old:expr, $new:expr, $expected:expr) => {
+        generate_test!($testname, grpc, $old, $new, $expected);
+    };
+}
+
+generate_grpc_test! {
+    test_reloader_grpc_default,
+    FactConfig::default(),
+    FactConfig::default(),
+    None
+}
+
+generate_grpc_test! {
+    test_reloader_grpc_no_change,
+    FactConfig {
+        grpc: GrpcConfig {
+            url: Some(GRPC_URL_NEW.into()),
+            certs: Some(GRPC_CERTS_NEW.into()),
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_NEW),
+                max: Some(GRPC_BACKOFF_MAX_NEW),
+                jitter: Some(false),
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_NEW),
+                retries_max: Some(GRPC_BACKOFF_RETRIES_NEW),
+            }
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            url: Some(GRPC_URL_NEW.into()),
+            certs: Some(GRPC_CERTS_NEW.into()),
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_NEW),
+                max: Some(GRPC_BACKOFF_MAX_NEW),
+                jitter: Some(false),
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_NEW),
+                retries_max: Some(GRPC_BACKOFF_RETRIES_NEW),
+            }
+        },
+        paths: Some(vec!["/etc".into()]),
+        ..Default::default()
+    },
+    None
+}
+
+const GRPC_URL_OLD: &str = "https://old.example.com";
+const GRPC_URL_NEW: &str = "https://new.example.com";
+
+generate_grpc_test! {
+    test_reloader_grpc_url_from_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            url: Some(GRPC_URL_NEW.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        url: Some(GRPC_URL_NEW.into()),
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_url_to_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            url: Some(GRPC_URL_NEW.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_url_changed,
+    FactConfig {
+        grpc: GrpcConfig {
+            url: Some(GRPC_URL_OLD.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            url: Some(GRPC_URL_NEW.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        url: Some(GRPC_URL_NEW.into()),
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_url_no_change,
+    FactConfig {
+        grpc: GrpcConfig {
+            url: Some(GRPC_URL_OLD.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            url: Some(GRPC_URL_OLD.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    None
+}
+
+const GRPC_CERTS_OLD: &str = "/etc/stackrox/old-certs";
+const GRPC_CERTS_NEW: &str = "/etc/stackrox/new-certs";
+
+generate_grpc_test! {
+    test_reloader_grpc_certs_from_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            certs: Some(GRPC_CERTS_NEW.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        certs: Some(GRPC_CERTS_NEW.into()),
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_certs_to_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            certs: Some(GRPC_CERTS_NEW.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_certs_changed,
+    FactConfig {
+        grpc: GrpcConfig {
+            certs: Some(GRPC_CERTS_OLD.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            certs: Some(GRPC_CERTS_NEW.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        certs: Some(GRPC_CERTS_NEW.into()),
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_certs_no_change,
+    FactConfig {
+        grpc: GrpcConfig {
+            certs: Some(GRPC_CERTS_OLD.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            certs: Some(GRPC_CERTS_OLD.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    None
+}
+
+const GRPC_BACKOFF_INITIAL_DEFAULT: Duration = Duration::from_secs(1);
+const GRPC_BACKOFF_INITIAL_OLD: Duration = Duration::from_secs(5);
+const GRPC_BACKOFF_INITIAL_NEW: Duration = Duration::from_secs(10);
+
+generate_grpc_test! {
+    test_reloader_grpc_backoff_initial_from_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            initial: Some(GRPC_BACKOFF_INITIAL_NEW),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_initial_to_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_initial_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_DEFAULT),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            initial: Some(GRPC_BACKOFF_INITIAL_DEFAULT),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_initial_to_default_from_explicit_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_DEFAULT),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_initial_changed,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_OLD),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            initial: Some(GRPC_BACKOFF_INITIAL_NEW),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_initial_no_change,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                initial: Some(GRPC_BACKOFF_INITIAL_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    None
+}
+
+const GRPC_BACKOFF_MAX_DEFAULT: Duration = Duration::from_secs(60);
+const GRPC_BACKOFF_MAX_OLD: Duration = Duration::from_secs(5);
+const GRPC_BACKOFF_MAX_NEW: Duration = Duration::from_secs(10);
+
+generate_grpc_test! {
+    test_reloader_grpc_backoff_max_from_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                max: Some(GRPC_BACKOFF_MAX_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            max: Some(GRPC_BACKOFF_MAX_NEW),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_max_to_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                max: Some(GRPC_BACKOFF_MAX_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_max_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                max: Some(GRPC_BACKOFF_MAX_DEFAULT),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            max: Some(GRPC_BACKOFF_MAX_DEFAULT),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_max_to_default_from_explicit_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                max: Some(GRPC_BACKOFF_MAX_DEFAULT),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_max_changed,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                max: Some(GRPC_BACKOFF_MAX_OLD),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                max: Some(GRPC_BACKOFF_MAX_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            max: Some(GRPC_BACKOFF_MAX_NEW),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_max_no_change,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                max: Some(GRPC_BACKOFF_MAX_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                max: Some(GRPC_BACKOFF_MAX_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    None
+}
+
+generate_grpc_test! {
+    test_reloader_grpc_backoff_jitter_from_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                jitter: Some(false),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            jitter: Some(false),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_jitter_to_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                jitter: Some(false),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_jitter_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                jitter: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            jitter: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_jitter_to_default_from_explicit_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                jitter: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_jitter_changed,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                jitter: Some(false),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                jitter: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            jitter: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_jitter_no_change,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                jitter: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                jitter: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    None
+}
+
+const GRPC_BACKOFF_MULTIPLIER_DEFAULT: f64 = 1.5;
+const GRPC_BACKOFF_MULTIPLIER_OLD: f64 = 5.0;
+const GRPC_BACKOFF_MULTIPLIER_NEW: f64 = 3.5;
+
+generate_grpc_test! {
+    test_reloader_grpc_backoff_multiplier_from_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            multiplier: Some(GRPC_BACKOFF_MULTIPLIER_NEW),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_multiplier_to_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_multiplier_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_DEFAULT),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            multiplier: Some(GRPC_BACKOFF_MULTIPLIER_DEFAULT),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_multiplier_to_default_from_explicit_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_DEFAULT),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_multiplier_changed,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_OLD),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            multiplier: Some(GRPC_BACKOFF_MULTIPLIER_NEW),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_multiplier_no_change,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                multiplier: Some(GRPC_BACKOFF_MULTIPLIER_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    None
+}
+
+const GRPC_BACKOFF_RETRIES_DEFAULT: u64 = 10;
+const GRPC_BACKOFF_RETRIES_OLD: u64 = 20;
+const GRPC_BACKOFF_RETRIES_NEW: u64 = 5;
+
+generate_grpc_test! {
+    test_reloader_grpc_backoff_retries_from_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                retries_max: Some(GRPC_BACKOFF_RETRIES_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            retries_max: Some(GRPC_BACKOFF_RETRIES_NEW),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_retries_to_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                retries_max: Some(GRPC_BACKOFF_RETRIES_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_retries_from_default_to_explicit_default,
+    FactConfig::default(),
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                retries_max: Some(GRPC_BACKOFF_RETRIES_DEFAULT),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            retries_max: Some(GRPC_BACKOFF_RETRIES_DEFAULT),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_retries_to_default_from_explicit_default,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                retries_max: Some(GRPC_BACKOFF_RETRIES_DEFAULT),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(GrpcConfig::default())
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_retries_changed,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                retries_max: Some(GRPC_BACKOFF_RETRIES_OLD),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                retries_max: Some(GRPC_BACKOFF_RETRIES_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    Some(GrpcConfig {
+        backoff: BackoffConfig {
+            retries_max: Some(GRPC_BACKOFF_RETRIES_NEW),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+generate_grpc_test! {
+    test_reloader_grpc_backoff_retries_no_change,
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                retries_max: Some(GRPC_BACKOFF_RETRIES_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        grpc: GrpcConfig {
+            backoff: BackoffConfig {
+                retries_max: Some(GRPC_BACKOFF_RETRIES_NEW),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    },
+    None
+}
+
+macro_rules! generate_otel_test {
+    ($testname:ident, $old:expr, $new:expr, $expected:expr) => {
+        generate_test!($testname, otel, $old, $new, $expected);
+    };
+}
+
+const OTEL_ENDPOINT_OLD: &str = "http://old:4317";
+const OTEL_ENDPOINT_NEW: &str = "http://new:4317";
+
+generate_otel_test! {
+    test_reloader_otel_default,
+    FactConfig::default(),
+    FactConfig::default(),
+    None
+}
+generate_otel_test! {
+    test_reloader_otel_endpoint_from_default,
+    FactConfig::default(),
+    FactConfig {
+        otel: OTelConfig {
+            endpoint: Some(OTEL_ENDPOINT_NEW.into()),
+        },
+        ..Default::default()
+    },
+    Some(OTelConfig {
+        endpoint: Some(OTEL_ENDPOINT_NEW.into()),
+    })
+}
+generate_otel_test! {
+    test_reloader_otel_endpoint_to_default,
+    FactConfig {
+        otel: OTelConfig {
+            endpoint: Some(OTEL_ENDPOINT_NEW.into()),
+        },
+        ..Default::default()
+    },
+    FactConfig::default(),
+    Some(OTelConfig::default())
+}
+generate_otel_test! {
+    test_reloader_otel_endpoint_changed,
+    FactConfig {
+        otel: OTelConfig {
+            endpoint: Some(OTEL_ENDPOINT_OLD.into()),
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        otel: OTelConfig {
+            endpoint: Some(OTEL_ENDPOINT_NEW.into()),
+        },
+        ..Default::default()
+    },
+    Some(OTelConfig {
+        endpoint: Some(OTEL_ENDPOINT_NEW.into()),
+    })
+}
+generate_otel_test! {
+    test_reloader_otel_endpoint_no_change,
+    FactConfig {
+        otel: OTelConfig {
+            endpoint: Some(OTEL_ENDPOINT_NEW.into()),
+        },
+        ..Default::default()
+    },
+    FactConfig {
+        otel: OTelConfig {
+            endpoint: Some(OTEL_ENDPOINT_NEW.into()),
+        },
+        paths: Some(vec!["/etc".into()]),
+        ..Default::default()
+    },
+    None
+}

--- a/fact/src/lib.rs
+++ b/fact/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, str::FromStr, time::Duration};
+use std::{io::Write, path::PathBuf, str::FromStr, time::Duration};
 
 use anyhow::{Context, Result};
 use bpf::Bpf;
@@ -30,6 +30,7 @@ use config::FactConfig;
 use pre_flight::pre_flight;
 
 use crate::{
+    config::BpfConfig,
     event::Event,
     metrics::{Metrics, kernel_metrics::KernelMetrics},
 };
@@ -89,23 +90,49 @@ async fn join_all_tasks(mut task_set: JoinSet<anyhow::Result<()>>) -> anyhow::Re
     Ok(())
 }
 
+struct SetupArgs<'a> {
+    skip_pre_flight: bool,
+    running: watch::Receiver<bool>,
+    task_set: &'a mut JoinSet<anyhow::Result<()>>,
+    reloader: &'a config::reloader::Reloader,
+    metrics: &'a Metrics,
+
+    // Replay mode
+    replay: Option<PathBuf>,
+
+    // BPF mode
+    bpf_config: BpfConfig,
+}
+
 pub async fn run(config: FactConfig) -> anyhow::Result<()> {
     // Log system information as early as possible so we have it
     // available in case of a crash
     log_system_information();
     let (running_pipeline_tx, running_pipeline_rx) = watch::channel(true);
     let (running_helpers, _) = watch::channel(true);
-    let reloader = config::reloader::Reloader::from(config);
-    let config_trigger = reloader.get_trigger();
-    let mut task_set = JoinSet::new();
-    let metrics_userspace = Metrics::new();
 
-    let (metrics_kernelspace, rx) = setup_input(
-        &mut task_set,
-        &reloader,
-        &metrics_userspace,
-        running_pipeline_rx,
-    )?;
+    let stdout_enabled = config.json();
+    let skip_pre_flight = config.skip_pre_flight();
+    let replay = config.replay().map(PathBuf::from);
+    let bpf_config = config.bpf.clone();
+
+    let metrics_userspace = Metrics::new();
+    let mut task_set = JoinSet::new();
+    let reloader = config::reloader::Reloader::from(config);
+
+    let setup_args = SetupArgs {
+        skip_pre_flight,
+        running: running_pipeline_rx.clone(),
+        task_set: &mut task_set,
+        reloader: &reloader,
+        metrics: &metrics_userspace,
+        replay,
+        bpf_config,
+    };
+
+    let config_trigger = reloader.get_trigger();
+
+    let (metrics_kernelspace, rx) = setup_input(setup_args)?;
     let (rate_limiter, rx) = RateLimiter::new(
         rx,
         reloader.rate_limit(),
@@ -118,7 +145,7 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
         metrics_userspace.output.clone(),
         reloader.grpc(),
         reloader.otel(),
-        reloader.config().json(),
+        stdout_enabled,
     );
 
     rate_limiter.start(&mut task_set);
@@ -157,53 +184,43 @@ pub async fn run(config: FactConfig) -> anyhow::Result<()> {
     res
 }
 
-fn setup_input(
-    task_set: &mut JoinSet<anyhow::Result<()>>,
-    reloader: &config::reloader::Reloader,
-    metrics: &Metrics,
-    running: watch::Receiver<bool>,
-) -> anyhow::Result<(Option<KernelMetrics>, mpsc::Receiver<Event>)> {
-    match reloader.config().replay() {
+fn setup_input(args: SetupArgs) -> anyhow::Result<(Option<KernelMetrics>, mpsc::Receiver<Event>)> {
+    match args.replay {
         Some(replay_file) => {
-            let rx = replay::start(task_set, replay_file, running)?;
+            let rx = replay::start(args.task_set, &replay_file, args.running)?;
             Ok((None, rx))
         }
         None => {
-            if !reloader.config().skip_pre_flight() {
+            if !args.skip_pre_flight {
                 debug!("Performing pre-flight checks");
                 pre_flight().context("Pre-flight checks failed")?;
             } else {
                 debug!("Skipping pre-flight checks");
             }
 
-            bpf_input(task_set, reloader, running, metrics)
+            bpf_input(args)
         }
     }
 }
 
-fn bpf_input(
-    task_set: &mut JoinSet<anyhow::Result<()>>,
-    reloader: &config::reloader::Reloader,
-    running: watch::Receiver<bool>,
-    metrics_userspace: &Metrics,
-) -> anyhow::Result<(Option<KernelMetrics>, mpsc::Receiver<Event>)> {
+fn bpf_input(args: SetupArgs) -> anyhow::Result<(Option<KernelMetrics>, mpsc::Receiver<Event>)> {
     let (mut bpf, rx) = Bpf::new(
-        reloader.paths(),
-        &reloader.config().bpf,
-        running.clone(),
-        metrics_userspace.bpf_worker.clone(),
+        args.reloader.paths(),
+        &args.bpf_config,
+        args.running.clone(),
+        args.metrics.bpf_worker.clone(),
     )?;
     let metrics_kernelspace = KernelMetrics::new(bpf.take_metrics()?);
 
     let (host_scanner, rx) = HostScanner::new(
         &mut bpf,
         rx,
-        reloader.paths(),
-        reloader.scan_interval(),
-        metrics_userspace.host_scanner.clone(),
+        args.reloader.paths(),
+        args.reloader.scan_interval(),
+        args.metrics.host_scanner.clone(),
     )?;
 
-    bpf.start(task_set);
-    host_scanner.start(task_set);
+    bpf.start(args.task_set);
+    host_scanner.start(args.task_set);
     Ok((Some(metrics_kernelspace), rx))
 }


### PR DESCRIPTION
## Description

This field is only really used at startup and then simply becomes a thing to be kept in memory with no additional value, the internal watch channels `Reloader` uses already has owned copies of everything in there.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Added unit tests to `config::reloader::Reloader`.

The tests themselves are pretty basic, they simply:
* Create a `FactConfig` object.
* Turn it into a `Reloader`.
* Feed a new `FactConfig` object to the `Reloader`.
* Check the correspoding `watch::Receiver` to see the expected update.

These tests show some inconsistencies on how updating from or to
explicit versions of default values behave, some fields send an update
and some don't. We might want to address this at some point.

A new approach is also used for the added tests, instead of using an
array for defining the cases and iterating over them, the main logic is
abstracted in a macro and invoked for each set of input/expected values.
This gives a few benefits:
* Each test case gets a dedicated test name, making it easier to find
  where an error occurs.
* If one test case fails, the rest still run (the array iteration
  approach stops at the first failure).
* All test cases are run in parallel, potentially speeding up the tests
  (though the current state of tests is fast enough for now).

The downside is the number of tests bloats quite a bit, but this should
not be too much of an issue.

This new approach is properly described here: https://unterwaditzer.net/2023/rust-test-parametrization.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration reload handling across paths, scan intervals, rate limits, endpoints, gRPC, and OpenTelemetry settings.
  * Configuration changes now propagate more reliably without unnecessary updates.
  * Hot-reload enablement remains consistent after configuration changes.

* **Refactor**
  * Streamlined internal pipeline setup while preserving existing runtime behavior.

* **Tests**
  * Added comprehensive coverage for configuration updates, defaults, changes, and no-op reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->