### PR TITLE
test: run all tests on a single fact instance

### DIFF
--- a/fact-ebpf/src/lib.rs
+++ b/fact-ebpf/src/lib.rs
@@ -64,6 +64,15 @@ impl From<path_prefix_t> for lpm_trie::Key<[c_char; LPM_SIZE_MAX as usize]> {
     }
 }
 
+impl From<lpm_trie::Key<[c_char; LPM_SIZE_MAX as usize]>> for path_prefix_t {
+    fn from(value: lpm_trie::Key<[c_char; LPM_SIZE_MAX as usize]>) -> Self {
+        path_prefix_t {
+            bit_len: value.prefix_len(),
+            path: value.data(),
+        }
+    }
+}
+
 impl PartialEq for path_prefix_t {
     fn eq(&self, other: &Self) -> bool {
         self.bit_len == other.bit_len && self.path == other.path

--- a/fact/src/bpf/mod.rs
+++ b/fact/src/bpf/mod.rs
@@ -30,8 +30,8 @@ pub struct Bpf {
 
     tx: mpsc::Sender<Event>,
 
-    paths: Vec<path_prefix_t>,
     paths_config: watch::Receiver<Vec<PathBuf>>,
+    paths_lpm_map: LpmTrie<MapData, [c_char; LPM_SIZE_MAX as usize], c_char>,
 
     paths_globset: GlobSet,
 
@@ -55,19 +55,19 @@ impl Bpf {
 
         // Include the BPF object as raw bytes at compile-time and load it
         // at runtime.
-        let obj = Bpf::load_ebpf(&checks, bpf_config)?;
+        let mut obj = Bpf::load_ebpf(&checks, bpf_config)?;
 
         Bpf::validate_config(&obj, bpf_config);
+        let paths_lpm_map = Bpf::take_path_prefix(&mut obj);
 
         let (tx, rx) = mpsc::channel(100);
-        let paths = Vec::new();
         let mut bpf = Bpf {
             obj,
             checks,
             tx,
-            paths,
             paths_config,
             paths_globset: GlobSet::empty(),
+            paths_lpm_map,
             links: Vec::new(),
             running,
             metrics,
@@ -129,6 +129,19 @@ impl Bpf {
         Ok(PerCpuArray::try_from(metrics)?)
     }
 
+    fn take_path_prefix(
+        obj: &mut Ebpf,
+    ) -> LpmTrie<MapData, [c_char; LPM_SIZE_MAX as usize], c_char> {
+        let Some(paths_lpm_prefix) = obj.take_map("path_prefix") else {
+            unreachable!("path_prefix map not found");
+        };
+
+        match paths_lpm_prefix.try_into() {
+            Ok(map) => map,
+            Err(_) => unreachable!("path_prefix map is not LpmTrie"),
+        }
+    }
+
     fn take_ringbuffer(&mut self) -> anyhow::Result<RingBuf<MapData>> {
         let ringbuf = match self.obj.take_map(RINGBUFFER_NAME) {
             Some(r) => r,
@@ -137,10 +150,34 @@ impl Bpf {
         Ok(RingBuf::try_from(ringbuf)?)
     }
 
+    fn cleanup_lpm_map(&mut self, new_paths: &[path_prefix_t]) -> anyhow::Result<()> {
+        let to_be_removed = self
+            .paths_lpm_map
+            .keys()
+            .filter_map(|p| match p {
+                Ok(p) => {
+                    let p = path_prefix_t::from(p);
+                    if !new_paths.contains(&p) {
+                        Some(Ok(p))
+                    } else {
+                        None
+                    }
+                }
+                Err(e) => Some(Err(e)),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for p in to_be_removed {
+            self.paths_lpm_map.remove(&p.into())?;
+        }
+
+        Ok(())
+    }
+
     fn load_paths(&mut self) -> anyhow::Result<()> {
         if self.paths_config.borrow().is_empty() {
             self.detach_progs();
-            self.paths.clear();
+            self.cleanup_lpm_map(&[])?;
             self.paths_globset = GlobSet::empty();
             return Ok(());
         }
@@ -149,41 +186,29 @@ impl Bpf {
             self.attach_progs()?;
         }
 
-        let Some(path_prefix) = self.obj.map_mut("path_prefix") else {
-            bail!("path_prefix map not found");
-        };
-        let mut path_prefix: LpmTrie<&mut MapData, [c_char; LPM_SIZE_MAX as usize], c_char> =
-            LpmTrie::try_from(path_prefix)?;
-
         // Add the new prefixes
-        let paths_config = self.paths_config.borrow();
-        let mut new_paths = Vec::with_capacity(paths_config.len());
-        let mut builder = GlobSetBuilder::new();
-        for p in paths_config.iter() {
-            let Some(glob_str) = p.to_str() else {
-                bail!("failed to convert path {} to string", p.display());
-            };
+        let new_paths = {
+            let paths_config = self.paths_config.borrow();
+            let mut new_paths = Vec::with_capacity(paths_config.len());
+            let mut builder = GlobSetBuilder::new();
+            for p in paths_config.iter() {
+                let Some(glob_str) = p.to_str() else {
+                    bail!("failed to convert path {} to string", p.display());
+                };
 
-            builder.add(
-                Glob::new(glob_str)
-                    .with_context(|| format!("invalid glob {}", glob_str))
-                    .unwrap(),
-            );
+                builder.add(
+                    Glob::new(glob_str).with_context(|| format!("invalid glob {}", glob_str))?,
+                );
 
-            let prefix = path_prefix_t::try_from(p)?;
-            path_prefix.insert(&prefix.into(), 0, 0)?;
-            new_paths.push(prefix);
-        }
-        self.paths_globset = builder.build()?;
-
-        // Remove old prefixes
-        for p in self.paths.iter().filter(|p| !new_paths.contains(p)) {
-            if let Err(e) = path_prefix.remove(&(*p).into()) {
-                warn!("Failed to remove path prefix: {e:#?}");
+                let prefix = path_prefix_t::try_from(p)?;
+                self.paths_lpm_map.insert(&prefix.into(), 0, 0)?;
+                new_paths.push(prefix);
             }
-        }
+            self.paths_globset = builder.build()?;
+            new_paths
+        };
 
-        self.paths = new_paths;
+        self.cleanup_lpm_map(&new_paths)?;
 
         Ok(())
     }

--- a/fact/src/config/reloader/mod.rs
+++ b/fact/src/config/reloader/mod.rs
@@ -116,7 +116,7 @@ impl Reloader {
             let path = PathBuf::from(file);
             if path.exists() {
                 let mtime = match path.metadata() {
-                    Ok(m) => m.mtime(),
+                    Ok(m) => m.mtime_nsec(),
                     Err(e) => {
                         warn!("Failed to stat {file}: {e}");
                         warn!("Configuration reloading may not work");

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,6 +200,7 @@ def fact_config_file():
         mode='w',
     )
     yaml.dump(config, f)
+    f.flush()
     yield f.name
     f.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,8 @@ pytest_plugins = ['test_editors.commons']
 ENDPOINT_ADDRESS = '127.0.0.1:9000'
 
 
-def base_config(server: EventServer) -> dict:
-    config: dict = {
+def base_config() -> dict:
+    return {
         'paths': [],
         'endpoint': {
             'address': ENDPOINT_ADDRESS,
@@ -33,11 +33,6 @@ def base_config(server: EventServer) -> dict:
         'json': True,
         'scan_interval': 0,
     }
-    if server.output_mode == 'otlp':
-        config['otel'] = {'endpoint': 'http://127.0.0.1:4318/v1/logs'}
-    else:
-        config['grpc'] = {'url': 'http://127.0.0.1:9999'}
-    return config
 
 
 @pytest.fixture
@@ -93,17 +88,12 @@ def _get_output_modes(config: pytest.Config) -> list[str]:
     output = config.getoption('--output')
     assert isinstance(output, str)
     if output == 'all':
-        pytest.exit(
-            '--output=all is not supported with session-scoped fact '
-            'container (port conflicts). Run separately with '
-            '--output=grpc and --output=otlp instead.',
-            returncode=1,
-        )
+        return ['grpc', 'otlp']
     return [output]
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc):
-    if 'server' in metafunc.fixturenames:
+    if 'server' in metafunc.definition._fixtureinfo.argnames:
         modes = _get_output_modes(metafunc.config)
         metafunc.parametrize('server', modes, indirect=True)
 
@@ -114,10 +104,12 @@ def server(request: pytest.FixtureRequest):
     Start and stop an event server.
 
     Parameterised via --output to create either a GrpcServer or an
-    OtlpServer. When --output=all, every test that uses this fixture
-    runs once per output mode.
+    OtlpServer.  When --output=all, every test that directly
+    requests this fixture runs once per output mode.  Tests that
+    only get it transitively (via autouse ``fact_config``) default
+    to grpc.
     """
-    mode = request.param
+    mode = getattr(request, 'param', 'grpc')
     if mode == 'otlp':
         s: EventServer = OtlpServer()
     else:
@@ -170,7 +162,7 @@ def dump_container_inspect(
 
 
 @pytest.fixture(scope='session')
-def fact_config_file(server: EventServer):
+def fact_config_file():
     """
     Session-scoped config file shared across all tests.
 
@@ -178,7 +170,7 @@ def fact_config_file(server: EventServer):
     by the per-test ``fact_config`` fixture before each test.
     """
     cwd = os.getcwd()
-    config = base_config(server)
+    config = base_config()
     f = NamedTemporaryFile(  # noqa: SIM115
         prefix='fact-config-',
         suffix='.yml',
@@ -194,7 +186,6 @@ def fact_config_file(server: EventServer):
 def fact(
     request: pytest.FixtureRequest,
     docker_client: docker.DockerClient,
-    server: EventServer,
     fact_config_file: str,
 ):
     """
@@ -306,7 +297,11 @@ def fact_config(
     fact does not fire on directory cleanup, and captures
     timestamp-sliced container logs for the test.
     """
-    config = base_config(server)
+    config = base_config()
+    if server.output_mode == 'otlp':
+        config['otel'] = {'endpoint': 'http://127.0.0.1:4318/v1/logs'}
+    else:
+        config['grpc'] = {'url': 'http://127.0.0.1:9999'}
     config['paths'] = [
         monitored_dir,
         f'{monitored_dir}/**/*',
@@ -345,8 +340,8 @@ def fact_config(
     except Exception:
         pass
 
-    baseline = base_config(server)
-    reload_fact(fact, baseline, fact_config_file)
+    config['paths'] = []
+    reload_fact(fact, config, fact_config_file)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ import pytest
 import requests
 import yaml
 
+from metrics import MetricsSnapshot
 from server import EventServer, GrpcServer, OtlpServer
 
 pytest_plugins = ['test_editors.commons']
@@ -317,6 +318,7 @@ def fact_config(
     reload_fact(fact, config, fact_config_file)
 
     test_start = datetime.now(tz=timezone.utc)
+    metrics_before = MetricsSnapshot.fetch(ENDPOINT_ADDRESS)
 
     yield config, fact_config_file
 
@@ -327,6 +329,14 @@ def fact_config(
         open(fact_config_file) as src,
     ):
         out.write(src.read())
+
+    try:
+        metrics_after = MetricsSnapshot.fetch(ENDPOINT_ADDRESS)
+        metrics_delta = metrics_before.delta(metrics_after)
+        with open(os.path.join(logs_dir, 'metrics'), 'w') as f:
+            f.write(metrics_delta.to_text())
+    except Exception:
+        pass
 
     try:
         log_bytes = fact.logs(since=test_start, until=test_end)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime, timezone
+import time
 from shutil import rmtree
 from tempfile import NamedTemporaryFile, mkdtemp
 from time import sleep
@@ -297,6 +297,8 @@ def fact_config(
     fact does not fire on directory cleanup, and captures
     timestamp-sliced container logs for the test.
     """
+    test_start = time.time()
+
     config = base_config()
     if server.output_mode == 'otlp':
         config['otel'] = {'endpoint': 'http://127.0.0.1:4318/v1/logs'}
@@ -312,12 +314,9 @@ def fact_config(
     server.drain()
     reload_fact(fact, config, fact_config_file)
 
-    test_start = datetime.now(tz=timezone.utc)
     metrics_before = MetricsSnapshot.fetch(ENDPOINT_ADDRESS)
 
     yield config, fact_config_file
-
-    test_end = datetime.now(tz=timezone.utc)
 
     with (
         open(os.path.join(logs_dir, 'fact.yml'), 'w') as out,
@@ -334,13 +333,14 @@ def fact_config(
         pass
 
     try:
+        test_end = time.time()
         log_bytes = fact.logs(since=test_start, until=test_end)
         with open(os.path.join(logs_dir, 'fact.log'), 'wb') as f:
             f.write(log_bytes)
     except Exception:
         pass
 
-    config['paths'] = []
+    config = base_config()
     reload_fact(fact, config, fact_config_file)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timezone
 from shutil import rmtree
 from tempfile import NamedTemporaryFile, mkdtemp
 from time import sleep
@@ -15,8 +16,27 @@ import yaml
 
 from server import EventServer, GrpcServer, OtlpServer
 
-# Declare files holding fixtures
 pytest_plugins = ['test_editors.commons']
+
+ENDPOINT_ADDRESS = '127.0.0.1:9000'
+
+
+def base_config(server: EventServer) -> dict:
+    config: dict = {
+        'paths': [],
+        'endpoint': {
+            'address': ENDPOINT_ADDRESS,
+            'expose_metrics': True,
+            'health_check': True,
+        },
+        'json': True,
+        'scan_interval': 0,
+    }
+    if server.output_mode == 'otlp':
+        config['otel'] = {'endpoint': 'http://127.0.0.1:4318/v1/logs'}
+    else:
+        config['grpc'] = {'url': 'http://127.0.0.1:9999'}
+    return config
 
 
 @pytest.fixture
@@ -33,7 +53,7 @@ def monitored_dir():
 @pytest.fixture
 def test_file(monitored_dir: str):
     """
-    Create a temporary file for tests
+    Create a temporary file for tests.
 
     This file needs to exist when fact starts up for the inode tracking
     algorithm to work.
@@ -72,7 +92,12 @@ def _get_output_modes(config: pytest.Config) -> list[str]:
     output = config.getoption('--output')
     assert isinstance(output, str)
     if output == 'all':
-        return ['grpc', 'otlp']
+        pytest.exit(
+            '--output=all is not supported with session-scoped fact '
+            'container (port conflicts). Run separately with '
+            '--output=grpc and --output=otlp instead.',
+            returncode=1,
+        )
     return [output]
 
 
@@ -82,7 +107,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
         metafunc.parametrize('server', modes, indirect=True)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def server(request: pytest.FixtureRequest):
     """
     Start and stop an event server.
@@ -143,50 +168,175 @@ def dump_container_inspect(
         json.dump(container_inspect, f, indent=2)
 
 
-@pytest.fixture
-def fact_config(
-    request: pytest.FixtureRequest,
-    monitored_dir: str,
-    logs_dir: str,
-    server: EventServer,
-):
+@pytest.fixture(scope='session')
+def fact_config_file(server: EventServer):
+    """
+    Session-scoped config file shared across all tests.
+
+    The file is created once with a baseline config and rewritten
+    by the per-test ``fact_config`` fixture before each test.
+    """
     cwd = os.getcwd()
-    config: dict = {
-        'paths': [
-            f'{monitored_dir}',
-            f'{monitored_dir}/**/*',
-            '/mounted/**/*',
-            '/container-dir/**/*',
-        ],
-        'endpoint': {
-            'address': '127.0.0.1:9000',
-            'expose_metrics': True,
-            'health_check': True,
-        },
-        'json': True,
-        'scan_interval': 0,
-    }
-
-    if server.output_mode == 'otlp':
-        config['otel'] = {'endpoint': 'http://127.0.0.1:4318/v1/logs'}
-    else:
-        config['grpc'] = {'url': 'http://127.0.0.1:9999'}
-
-    config_file = NamedTemporaryFile(  # noqa: SIM115
+    config = base_config(server)
+    f = NamedTemporaryFile(  # noqa: SIM115
         prefix='fact-config-',
         suffix='.yml',
         dir=cwd,
         mode='w',
     )
-    yaml.dump(config, config_file)
+    yaml.dump(config, f)
+    yield f.name
+    f.close()
 
-    yield config, config_file.name
+
+@pytest.fixture(scope='session', autouse=True)
+def fact(
+    request: pytest.FixtureRequest,
+    docker_client: docker.DockerClient,
+    server: EventServer,
+    fact_config_file: str,
+):
+    """
+    Session-scoped fact container shared across all tests.
+
+    The container is started once and kept alive for the entire test
+    session.  Between tests the ``fact_config`` fixture rewrites the
+    config file and sends SIGHUP so that fact picks up new paths.
+    """
+    image = request.config.getoption('--image')
+    assert isinstance(image, str)
+    container = docker_client.containers.run(
+        image,
+        detach=True,
+        environment={
+            'FACT_LOGLEVEL': 'debug',
+            'FACT_HOST_MOUNT': '/host',
+            'OTEL_BLRP_SCHEDULE_DELAY': '100',
+            'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '1',
+            'RUST_BACKTRACE': '1',
+        },
+        name='fact',
+        network_mode='host',
+        privileged=True,
+        volumes={
+            '/': {
+                'bind': '/host',
+                'mode': 'ro',
+            },
+            fact_config_file: {
+                'bind': '/etc/stackrox/fact.yml',
+                'mode': 'ro',
+            },
+        },
+    )
+
+    session_logs = os.path.join(os.getcwd(), 'logs')
+    container_log = os.path.join(session_logs, 'fact.log')
+
+    os.makedirs(session_logs, exist_ok=True)
+
+    for _ in range(10):
+        try:
+            resp = requests.get(f'http://{ENDPOINT_ADDRESS}/health_check')
+            if resp.status_code == 200:
+                break
+        except (requests.RequestException, requests.ConnectionError) as e:
+            print(e)
+        sleep(1)
+    else:
+        container.stop(timeout=1)
+        dump_logs(container, container_log)
+        container.remove()
+        pytest.fail('fact failed to start')
+
+    yield container
+
+    try:
+        resp = requests.get(f'http://{ENDPOINT_ADDRESS}/metrics')
+        if resp.status_code == 200:
+            with open(os.path.join(session_logs, 'metrics'), 'w') as f:
+                f.write(resp.text)
+    except requests.RequestException:
+        pass
+
+    container.stop(timeout=5)
+    exit_status = container.wait(timeout=2)
+    try:
+        dump_logs(container, container_log)
+        dump_container_inspect(
+            docker_client,
+            container,
+            os.path.join(session_logs, 'container.json'),
+        )
+    finally:
+        container.remove()
+    assert exit_status['StatusCode'] == 0
+
+
+def reload_fact(
+    container: docker.models.containers.Container,
+    config: dict,
+    config_file: str,
+    delay: float = 0.1,
+):
+    with open(config_file, 'w') as f:
+        yaml.dump(config, f)
+    container.kill('SIGHUP')
+    sleep(delay)
+
+
+@pytest.fixture(autouse=True)
+def fact_config(
+    fact: docker.models.containers.Container,
+    fact_config_file: str,
+    monitored_dir: str,
+    server: EventServer,
+    logs_dir: str,
+    test_file: str,
+):
+    """
+    Per-test config that hot-reloads fact via SIGHUP.
+
+    On setup: writes a config with the test's ``monitored_dir`` paths,
+    drains stale events from the server queue, and signals fact to
+    reload.
+
+    On teardown: restores the baseline config (empty paths) so that
+    fact does not fire on directory cleanup, and captures
+    timestamp-sliced container logs for the test.
+    """
+    config = base_config(server)
+    config['paths'] = [
+        monitored_dir,
+        f'{monitored_dir}/**/*',
+        '/mounted/**/*',
+        '/container-dir/**/*',
+    ]
+
+    server.drain()
+    reload_fact(fact, config, fact_config_file)
+
+    test_start = datetime.now(tz=timezone.utc)
+
+    yield config, fact_config_file
+
+    test_end = datetime.now(tz=timezone.utc)
+
     with (
-        open(os.path.join(logs_dir, 'fact.yml'), 'w') as f,
-        open(config_file.name) as r,
+        open(os.path.join(logs_dir, 'fact.yml'), 'w') as out,
+        open(fact_config_file) as src,
     ):
-        f.write(r.read())
-    config_file.close()
+        out.write(src.read())
+
+    try:
+        log_bytes = fact.logs(since=test_start, until=test_end)
+        with open(os.path.join(logs_dir, 'fact.log'), 'wb') as f:
+            f.write(log_bytes)
+    except Exception:
+        pass
+
+    baseline = base_config(server)
+    reload_fact(fact, baseline, fact_config_file)
 
 
 @pytest.fixture
@@ -221,86 +371,6 @@ def test_container(
 
     container.stop(timeout=1)
     container.remove()
-
-
-@pytest.fixture(autouse=True)
-def fact(
-    request: pytest.FixtureRequest,
-    docker_client: docker.DockerClient,
-    fact_config: tuple[dict, str],
-    server: EventServer,
-    logs_dir: str,
-    test_file: str,
-):
-    """
-    Run the fact docker container for integration tests.
-    """
-    config, config_file = fact_config
-    image = request.config.getoption('--image')
-    assert isinstance(image, str)
-    container = docker_client.containers.run(
-        image,
-        detach=True,
-        environment={
-            'FACT_LOGLEVEL': 'debug',
-            'FACT_HOST_MOUNT': '/host',
-            'OTEL_BLRP_SCHEDULE_DELAY': '100',
-            'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE': '1',
-            'RUST_BACKTRACE': '1',
-        },
-        name='fact',
-        network_mode='host',
-        privileged=True,
-        volumes={
-            '/': {
-                'bind': '/host',
-                'mode': 'ro',
-            },
-            config_file: {
-                'bind': '/etc/stackrox/fact.yml',
-                'mode': 'ro',
-            },
-        },
-    )
-
-    container_log = os.path.join(logs_dir, 'fact.log')
-    # Wait for container to be ready
-    for _ in range(10):
-        try:
-            resp = requests.get(
-                f'http://{config["endpoint"]["address"]}/health_check'
-            )
-            if resp.status_code == 200:
-                break
-        except (requests.RequestException, requests.ConnectionError) as e:
-            print(e)
-        sleep(1)
-    else:
-        container.stop(timeout=1)
-        dump_logs(container, container_log)
-        container.remove()
-        pytest.fail('fact failed to start')
-
-    yield container
-
-    # Capture prometheus metrics before stopping the container
-    if config['endpoint']['expose_metrics']:
-        metric_log = os.path.join(logs_dir, 'metrics')
-        resp = requests.get(f'http://{config["endpoint"]["address"]}/metrics')
-        if resp.status_code == 200:
-            with open(metric_log, 'w') as f:
-                f.write(resp.text)
-
-    container.stop(timeout=5)
-    exit_status = container.wait(timeout=2)
-    try:
-        dump_logs(container, container_log)
-        dump_container_inspect(
-            docker_client, container, os.path.join(logs_dir, 'container.json')
-        )
-    finally:
-        container.remove()
-    assert exit_status['StatusCode'] == 0
 
 
 def pytest_addoption(parser: pytest.Parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,8 @@ pytest_plugins = ['test_editors.commons']
 ENDPOINT_ADDRESS = '127.0.0.1:9000'
 
 
-def base_config() -> dict:
-    return {
+def base_config(output_mode: str = 'grpc') -> dict:
+    config = {
         'paths': [],
         'endpoint': {
             'address': ENDPOINT_ADDRESS,
@@ -33,6 +33,13 @@ def base_config() -> dict:
         'json': True,
         'scan_interval': 0,
     }
+
+    if output_mode == 'otlp':
+        config['otel'] = {'endpoint': 'http://127.0.0.1:4318/v1/logs'}
+    else:
+        config['grpc'] = {'url': 'http://127.0.0.1:9999'}
+
+    return config
 
 
 @pytest.fixture
@@ -99,24 +106,39 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
 
 
 @pytest.fixture(scope='session')
-def server(request: pytest.FixtureRequest):
-    """
-    Start and stop an event server.
+def _servers(request: pytest.FixtureRequest):
+    """Start all event servers needed for this session.
 
-    Parameterised via --output to create either a GrpcServer or an
+    Servers are started before the fact container so that fact can
+    connect on startup.  The parametrised ``server`` fixture looks
+    up the right instance from here.
+    """
+    modes = _get_output_modes(request.config)
+    servers: dict[str, EventServer] = {}
+    for mode in modes:
+        s: EventServer = OtlpServer() if mode == 'otlp' else GrpcServer()
+        s.serve()
+        servers[mode] = s
+    yield servers
+    for s in servers.values():
+        s.stop()
+
+
+@pytest.fixture(scope='session')
+def server(
+    request: pytest.FixtureRequest,
+    _servers: dict[str, EventServer],
+):
+    """Select the event server for the current test.
+
+    Parameterised via --output to pick either the GrpcServer or the
     OtlpServer.  When --output=all, every test that directly
     requests this fixture runs once per output mode.  Tests that
     only get it transitively (via autouse ``fact_config``) default
     to grpc.
     """
     mode = getattr(request, 'param', 'grpc')
-    if mode == 'otlp':
-        s: EventServer = OtlpServer()
-    else:
-        s = GrpcServer()
-    s.serve()
-    yield s
-    s.stop()
+    return _servers[mode]
 
 
 @pytest.fixture
@@ -187,6 +209,7 @@ def fact(
     request: pytest.FixtureRequest,
     docker_client: docker.DockerClient,
     fact_config_file: str,
+    _servers: dict[str, EventServer],
 ):
     """
     Session-scoped fact container shared across all tests.
@@ -299,11 +322,7 @@ def fact_config(
     """
     test_start = time.time()
 
-    config = base_config()
-    if server.output_mode == 'otlp':
-        config['otel'] = {'endpoint': 'http://127.0.0.1:4318/v1/logs'}
-    else:
-        config['grpc'] = {'url': 'http://127.0.0.1:9999'}
+    config = base_config(server.output_mode)
     config['paths'] = [
         monitored_dir,
         f'{monitored_dir}/**/*',
@@ -340,7 +359,7 @@ def fact_config(
     except Exception:
         pass
 
-    config = base_config()
+    config = base_config(server.output_mode)
     reload_fact(fact, config, fact_config_file)
 
 

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import requests
+from prometheus_client import CollectorRegistry
+from prometheus_client.metrics_core import Metric
+from prometheus_client.openmetrics.exposition import generate_latest
+from prometheus_client.openmetrics.parser import (
+    text_string_to_metric_families,
+)
+from prometheus_client.samples import Sample
+
+
+class MetricsSnapshot:
+    """Parsed snapshot of Prometheus metrics from fact's /metrics endpoint.
+
+    Stores the full list of ``Metric`` family objects returned by the
+    prometheus-client parser so that snapshots can be diffed and
+    serialised back to valid OpenMetrics text exposition format.
+    """
+
+    def __init__(self, families: list[Metric]):
+        self._families = families
+        self._index: dict[str, dict[str, float]] = {}
+        for fam in families:
+            by_label: dict[str, float] = {}
+            for s in fam.samples:
+                key = _label_key(s.labels)
+                by_label[key] = s.value
+            self._index[fam.name] = by_label
+
+    @classmethod
+    def from_text(cls, text: str) -> MetricsSnapshot:
+        families = list(text_string_to_metric_families(text))
+        return cls(families)
+
+    @classmethod
+    def fetch(cls, endpoint: str) -> MetricsSnapshot:
+        resp = requests.get(f'http://{endpoint}/metrics')
+        resp.raise_for_status()
+        return cls.from_text(resp.text)
+
+    def get(
+        self,
+        metric_name: str,
+        labels: dict[str, str] | None = None,
+    ) -> str | None:
+        """Look up a single metric value.
+
+        ``metric_name`` is matched as a substring against family
+        names (mirrors the old ``get_metric_value`` behaviour).
+        ``labels`` must match exactly when provided.
+
+        Returns the value as a string, or ``None``.
+        """
+        labels = labels or {}
+        key = _label_key(labels)
+        for name, by_label in self._index.items():
+            if metric_name not in name:
+                continue
+            if key in by_label:
+                return str(int(by_label[key]))
+        return None
+
+    def delta(self, after: MetricsSnapshot) -> MetricsSnapshot:
+        """Return a new snapshot containing metrics."""
+        delta_families: list[Metric] = []
+        for fam in after._families:
+            before_labels = self._index.get(fam.name, {})
+            delta_samples: list[Sample] = []
+            for s in fam.samples:
+                key = _label_key(s.labels)
+                before_val = before_labels.get(key, 0.0)
+                d = s.value - before_val
+                delta_samples.append(Sample(s.name, s.labels, d, s.timestamp))
+            if delta_samples:
+                m = Metric(fam.name, fam.documentation, fam.type)
+                m.samples = delta_samples
+                delta_families.append(m)
+        return MetricsSnapshot(delta_families)
+
+    def to_text(self) -> str:
+        """Serialise to OpenMetrics text exposition format."""
+        registry = CollectorRegistry()
+        registry.register(_FamilyCollector(self._families))
+        return generate_latest(registry).decode('utf-8')
+
+
+class _FamilyCollector:
+    """Minimal Collector that replays pre-built Metric objects."""
+
+    def __init__(self, families: list[Metric]):
+        self._families = families
+
+    def collect(self) -> list[Metric]:
+        return self._families
+
+    def describe(self) -> list[Metric]:
+        return self._families
+
+
+def _label_key(labels: dict[str, str]) -> str:
+    return ','.join(f'{k}={v}' for k, v in sorted(labels.items()))
+
+
+def get_metric_value(
+    fact_config: tuple[dict, str],
+    metric_name: str,
+    labels: dict[str, str] | None = None,
+) -> str | None:
+    """Query Prometheus metrics endpoint to get the value of a metric.
+
+    Args:
+        fact_config: The fact configuration tuple
+            (config dict, config file path).
+        metric_name: Name of the metric to query
+            (e.g., "host_scanner_scan").
+        labels: Optional dict of label filters
+            (e.g., {"label": "InodeRemoved"}).
+
+    Returns:
+        The metric value as a string if found, None otherwise.
+    """
+    config, _ = fact_config
+    snapshot = MetricsSnapshot.fetch(config['endpoint']['address'])
+    return snapshot.get(metric_name, labels)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,7 @@ docker==7.1.0
 grpcio==1.76.0
 grpcio-tools==1.76.0
 opentelemetry-proto==1.41.1
+prometheus-client==0.26.0
 pytest==8.4.1
 requests==2.32.4
 pyyaml==6.0.3

--- a/tests/server.py
+++ b/tests/server.py
@@ -105,6 +105,10 @@ class EventServer(ABC):
         """Check if the internal queue of events is empty."""
         return len(self.queue) == 0
 
+    def drain(self):
+        """Remove all pending events from the queue."""
+        self.queue.clear()
+
     def is_running(self) -> bool:
         """Check if the server is currently running."""
         return self.running.is_set()

--- a/tests/test_path_rmdir.py
+++ b/tests/test_path_rmdir.py
@@ -7,8 +7,8 @@ import sys
 import pytest
 
 from event import Event, EventType, Process
+from metrics import get_metric_value
 from server import EventServer
-from utils import get_metric_value
 
 
 def get_inode_removed_count(fact_config: tuple[dict, str]):

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -6,10 +6,11 @@ from time import sleep
 
 import docker.models.containers
 import pytest
-import requests
 import yaml
 
+from conftest import ENDPOINT_ADDRESS
 from event import Event, EventType, Process
+from metrics import MetricsSnapshot
 from server import EventServer
 
 
@@ -33,19 +34,20 @@ def rate_limited_config(
     return config, config_file
 
 
-@pytest.mark.skip(reason='Metrics are cumulative with session-scoped container')
 def test_rate_limit_drops_events(
     rate_limited_config: tuple[dict, str],
     monitored_dir: str,
     server: EventServer,
 ):
     """
-    Test that the rate limiter drops events when the rate limit is exceeded.
+    Test that the rate limiter drops events when the rate limit
+    is exceeded.
     """
-    config, _ = rate_limited_config
     num_files = 100
-    start_time = time.time()
 
+    before = MetricsSnapshot.fetch(ENDPOINT_ADDRESS)
+
+    start_time = time.time()
     for i in range(num_files):
         fut = os.path.join(monitored_dir, f'file_{i}.txt')
         with open(fut, 'w') as f:
@@ -68,48 +70,41 @@ def test_rate_limit_drops_events(
         f'but received all {received_count}'
     )
 
-    metrics_response = requests.get(
-        f'http://{config["endpoint"]["address"]}/metrics',
-    )
-    assert metrics_response.status_code == 200
+    after = MetricsSnapshot.fetch(ENDPOINT_ADDRESS)
+    delta = before.delta(after)
 
-    metrics_text = metrics_response.text
-    assert 'rate_limiter_events' in metrics_text, (
-        'rate_limiter_events metric not found'
+    delta_dropped = delta.get('rate_limiter_events', {'label': 'Dropped'})
+    assert delta_dropped is not None, (
+        'rate_limiter_events{label="Dropped"} metric not found'
     )
-
-    dropped_count = 0
-    for line in metrics_text.split('\n'):
-        if 'rate_limiter_events' in line and 'label="Dropped"' in line:
-            parts = line.split()
-            if len(parts) >= 2:
-                dropped_count = int(parts[1])
-                break
+    dropped_count = int(delta_dropped)
 
     assert dropped_count > 0, (
         'Expected rate limiter to report dropped events in metrics'
     )
 
     total_accounted = received_count + dropped_count
-
     assert total_accounted == num_files, (
-        'Expected rate limiter to see all events'
+        f'Expected received ({received_count}) + dropped '
+        f'({dropped_count}) to equal {num_files}, '
+        f'got {total_accounted}'
     )
 
 
-@pytest.mark.skip(reason='Metrics are cumulative with session-scoped container')
 def test_rate_limit_unlimited(
     monitored_dir: str,
     server: EventServer,
     fact_config: tuple[dict, str],
 ):
     """
-    Test that the default config (rate_limit=0) allows all events through.
+    Test that the default config (rate_limit=0) allows all events
+    through.
     """
-    config, _ = fact_config
     num_files = 20
     events = []
     process = Process.from_proc()
+
+    before = MetricsSnapshot.fetch(ENDPOINT_ADDRESS)
 
     for i in range(num_files):
         fut = os.path.join(monitored_dir, f'file_{i}.txt')
@@ -127,20 +122,11 @@ def test_rate_limit_unlimited(
 
     server.wait_events(events)
 
-    metrics_response = requests.get(
-        f'http://{config["endpoint"]["address"]}/metrics',
-    )
-    assert metrics_response.status_code == 200
+    after = MetricsSnapshot.fetch(ENDPOINT_ADDRESS)
+    delta = before.delta(after)
 
-    metrics_text = metrics_response.text
-
-    dropped_count = 0
-    for line in metrics_text.split('\n'):
-        if 'rate_limiter_events' in line and 'label="Dropped"' in line:
-            parts = line.split()
-            if len(parts) >= 2:
-                dropped_count = int(parts[1])
-                break
+    delta_dropped = delta.get('rate_limiter_events', {'label': 'Dropped'})
+    dropped_count = int(delta_dropped) if delta_dropped else 0
 
     assert dropped_count == 0, (
         'Expected no dropped events with unlimited '

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -33,6 +33,7 @@ def rate_limited_config(
     return config, config_file
 
 
+@pytest.mark.skip(reason='Metrics are cumulative with session-scoped container')
 def test_rate_limit_drops_events(
     rate_limited_config: tuple[dict, str],
     monitored_dir: str,
@@ -96,6 +97,7 @@ def test_rate_limit_drops_events(
     )
 
 
+@pytest.mark.skip(reason='Metrics are cumulative with session-scoped container')
 def test_rate_limit_unlimited(
     monitored_dir: str,
     server: EventServer,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import os
 import re
 
-import requests
-
 
 def join_path_with_filename(directory: str, filename: str | bytes):
     """
@@ -100,42 +98,3 @@ def btf_has_symbol(symbol: str) -> bool:
         return False
     except OSError:
         return False
-
-
-def get_metric_value(
-    fact_config: tuple[dict, str],
-    metric_name: str,
-    labels: dict[str, str] | None = None,
-):
-    """
-    Query Prometheus metrics endpoint to get the value of a metric.
-
-    Args:
-        fact_config: The fact configuration tuple
-            (config dict, config file path).
-        metric_name: Name of the metric to query
-            (e.g., "host_scanner_scan").
-        labels: Optional dict of label filters
-            (e.g., {"label": "InodeRemoved"}).
-
-    Returns:
-        The metric value as a string if found, None otherwise.
-    """
-    config, _ = fact_config
-    response = requests.get(f'http://{config["endpoint"]["address"]}/metrics')
-    assert response.status_code == 200
-
-    labels = labels or {}
-
-    for line in response.text.split('\n'):
-        if metric_name not in line:
-            continue
-
-        # Check if all label filters match
-        if all(f'{k}="{v}"' in line for k, v in labels.items()):
-            # Format: metric_name{label="value"} 42
-            parts = line.split()
-            if len(parts) >= 2:
-                return parts[-1]
-
-    return None


### PR DESCRIPTION
## Description

Change how tests are run from having a fact container being spin up and down for each test to spinning one container and running the full set of tests on that instead. This gives a substantial improvement to the time it takes to run the full set of tests, since the tests themselves are usually pretty fast and most of the time was being used in creating and removing the fact container.

The handling of logs is done in a way that we should still be able to see relevant information for each individual test, but if that happens to fail we also have a session wide log with the entire output of the fact container. For metrics, a new `MetricsSnapshot` type is added so we can still get a per-test metrics dump which is useful to understand when a test fails because we missed some event.

Assisted-by: claude-opus-4-6 <noreply@opencode.ai>

## Checklist
- [ ] Patch has a change log entry **OR** does not need one.
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration change detection by recognizing file updates with nanosecond precision, helping ensure rapid edits trigger reloads reliably.

- **Tests**
  - Enhanced integration testing for configuration hot reloads and event handling.
  - Added Prometheus metrics snapshot and delta validation.
  - Improved test isolation, container lifecycle management, and server event cleanup.
  - Added coverage for rate-limit metrics using before-and-after measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->