### PR TITLE
chore: make d_instantiate_ctx size configurable

### DIFF
--- a/fact-ebpf/src/bpf/maps.h
+++ b/fact-ebpf/src/bpf/maps.h
@@ -96,7 +96,7 @@ struct {
   __uint(type, BPF_MAP_TYPE_LRU_HASH);
   __type(key, __u64);
   __type(value, struct d_instantiate_ctx_t);
-  __uint(max_entries, 16384);
+  __uint(max_entries, 512);
 } d_instantiate_ctx SEC(".maps");
 
 __always_inline static struct d_instantiate_ctx_t* get_d_instantiate_ctx() {

--- a/fact/src/bpf/mod.rs
+++ b/fact/src/bpf/mod.rs
@@ -108,6 +108,7 @@ impl Bpf {
             )
             .map_max_entries(RINGBUFFER_NAME, bpf_config.ringbuf_size() * 1024)
             .map_max_entries("inode_map", bpf_config.inodes_max())
+            .map_max_entries("d_instantiate_ctx", bpf_config.d_instantiate_ctx_size())
             .load(fact_ebpf::EBPF_OBJ)
             .context("failed to load eBPF object")
     }

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -569,6 +569,7 @@ impl TryFrom<&yaml::Hash> for OTelConfig {
 pub struct BpfConfig {
     ringbuf_size: Option<u32>,
     inodes_max: Option<u32>,
+    d_instantiate_ctx_size: Option<u32>,
     pub programs: HashMap<String, BpfProgConfig>,
 }
 
@@ -582,6 +583,10 @@ impl BpfConfig {
             self.inodes_max = Some(inodes_max);
         }
 
+        if let Some(d_inst_size) = from.d_instantiate_ctx_size {
+            self.d_instantiate_ctx_size = Some(d_inst_size);
+        }
+
         for (k, v) in &from.programs {
             self.programs.entry(k.clone()).or_default().update(v);
         }
@@ -593,6 +598,10 @@ impl BpfConfig {
 
     pub fn inodes_max(&self) -> u32 {
         self.inodes_max.unwrap_or(65536)
+    }
+
+    pub fn d_instantiate_ctx_size(&self) -> u32 {
+        self.d_instantiate_ctx_size.unwrap_or(512)
     }
 
     pub fn program_is_enabled(&self, name: &str) -> bool {
@@ -630,6 +639,15 @@ impl TryFrom<&yaml::Hash> for BpfConfig {
                     };
                     bpf.inodes_max = Some(inode_max as u32);
                 }
+                "d_instantiate_ctx_size" => match v.as_i64() {
+                    Some(size) if size > 0 && size < u32::MAX as i64 => {
+                        bpf.d_instantiate_ctx_size = Some(size as u32);
+                    }
+                    Some(size) => {
+                        bail!("bpf.d_instantiate_ctx_size field has invalid value: {size}")
+                    }
+                    None => bail!("bpf.d_instantiate_ctx_size field has incorrect type: {v:?}"),
+                },
                 "programs" => {
                     let Some(programs) = v.as_hash() else {
                         bail!("bpf.programs field has incorrect type: {v:?}");
@@ -845,6 +863,19 @@ pub struct FactCli {
     #[arg(long, short, env = "FACT_INODES_MAX")]
     inodes_max: Option<u32>,
 
+    /// Sets the maximum number of entries that can be added to the
+    /// d_instantiate_ctx map.
+    ///
+    /// This is an advanced configuration parameter, it can be used to
+    /// increase the amount of in-flight events that use the
+    /// d_instantiate LSM hook for resolving inode numbers.
+    #[arg(
+        long = "d-inst-size",
+        env = "FACT_D_INSTANTIATE_CTX_SIZE",
+        value_parser = clap::value_parser!(u32).range(1..u32::MAX as i64)
+    )]
+    d_instantiate_ctx_size: Option<u32>,
+
     /// Whether configuration should be hotreloaded
     #[arg(long, overrides_with = "no_hotreload", env = "FACT_HOTRELOAD")]
     hotreload: bool,
@@ -904,6 +935,7 @@ impl FactCli {
             bpf: BpfConfig {
                 ringbuf_size: self.ringbuf_size,
                 inodes_max: self.inodes_max,
+                d_instantiate_ctx_size: self.d_instantiate_ctx_size,
                 programs: HashMap::new(),
             },
             skip_pre_flight: resolve_bool_arg(self.skip_pre_flight, self.no_skip_pre_flight),

--- a/fact/src/config/tests.rs
+++ b/fact/src/config/tests.rs
@@ -354,6 +354,19 @@ fn parsing() {
         (
             r#"
             bpf:
+                d_instantiate_ctx_size: 64
+            "#,
+            FactConfig {
+                bpf: BpfConfig {
+                    d_instantiate_ctx_size: Some(64),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            bpf:
                 programs:
                     file_open:
                         enabled: false
@@ -482,6 +495,7 @@ fn parsing() {
             bpf:
                 ringbuf_size: 8192
                 inodes_max: 64
+                d_instantiate_ctx_size: 64
                 programs:
                     file_open:
                         enabled: false
@@ -521,6 +535,7 @@ fn parsing() {
                 bpf: BpfConfig {
                     ringbuf_size: Some(8192),
                     inodes_max: Some(64),
+                    d_instantiate_ctx_size: Some(64),
                     programs: HashMap::from([
                         (
                             "file_open".into(),
@@ -859,6 +874,27 @@ paths:
               inodes_max: true
             "#,
             "inodes_max field has incorrect type: Boolean(true)",
+        ),
+        (
+            r#"
+            bpf:
+              d_instantiate_ctx_size: 0
+            "#,
+            "bpf.d_instantiate_ctx_size field has invalid value: 0",
+        ),
+        (
+            r#"
+            bpf:
+              d_instantiate_ctx_size: 5000000000
+            "#,
+            "bpf.d_instantiate_ctx_size field has invalid value: 5000000000",
+        ),
+        (
+            r#"
+            bpf:
+              d_instantiate_ctx_size: true
+            "#,
+            "bpf.d_instantiate_ctx_size field has incorrect type: Boolean(true)",
         ),
         (
             r#"
@@ -1646,6 +1682,60 @@ fn update() {
         (
             r#"
             bpf:
+              d_instantiate_ctx_size: 16384
+            "#,
+            FactConfig::default(),
+            FactConfig {
+                bpf: BpfConfig {
+                    d_instantiate_ctx_size: Some(16384),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            bpf:
+              d_instantiate_ctx_size: 16384
+            "#,
+            FactConfig {
+                bpf: BpfConfig {
+                    d_instantiate_ctx_size: Some(8192),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                bpf: BpfConfig {
+                    d_instantiate_ctx_size: Some(16384),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            bpf:
+              d_instantiate_ctx_size: 16384
+            "#,
+            FactConfig {
+                bpf: BpfConfig {
+                    d_instantiate_ctx_size: Some(16384),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            FactConfig {
+                bpf: BpfConfig {
+                    d_instantiate_ctx_size: Some(16384),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            r#"
+            bpf:
               programs:
                 file_open:
                   enabled: true
@@ -1837,6 +1927,7 @@ fn update() {
             bpf:
               ringbuf_size: 16384
               inodes_max: 8192
+              d_instantiate_ctx_size: 8192
               programs:
                 file_open:
                   enabled: false
@@ -1871,6 +1962,7 @@ fn update() {
                 bpf: BpfConfig {
                     ringbuf_size: Some(64),
                     inodes_max: Some(4096),
+                    d_instantiate_ctx_size: Some(4096),
                     programs: HashMap::from([(
                         "path_unlink".into(),
                         BpfProgConfig {
@@ -1910,6 +2002,7 @@ fn update() {
                 bpf: BpfConfig {
                     ringbuf_size: Some(16384),
                     inodes_max: Some(8192),
+                    d_instantiate_ctx_size: Some(8192),
                     programs: HashMap::from([
                         (
                             "path_unlink".into(),
@@ -1960,6 +2053,7 @@ fn defaults() {
     assert!(!config.json());
     assert_eq!(config.bpf.ringbuf_size(), 8192);
     assert_eq!(config.bpf.inodes_max(), 65536);
+    assert_eq!(config.bpf.d_instantiate_ctx_size(), 512);
     assert!(config.hotreload());
     assert_eq!(config.grpc.backoff.initial(), Duration::from_secs(1));
     assert_eq!(config.grpc.backoff.max(), Duration::from_secs(60));
@@ -2105,6 +2199,19 @@ fn env_vars() {
             FactConfig {
                 bpf: BpfConfig {
                     ringbuf_size: Some(128),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
+                name: "FACT_D_INSTANTIATE_CTX_SIZE",
+                value: "1024",
+            },
+            FactConfig {
+                bpf: BpfConfig {
+                    d_instantiate_ctx_size: Some(1024),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -2390,6 +2497,20 @@ fn env_vars_override_yaml() {
         ),
         (
             EnvVar {
+                name: "FACT_D_INSTANTIATE_CTX_SIZE",
+                value: "2048",
+            },
+            "bpf:\n  d_instantiate_ctx_size: 1024",
+            FactConfig {
+                bpf: BpfConfig {
+                    d_instantiate_ctx_size: Some(2048),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ),
+        (
+            EnvVar {
                 name: "FACT_URL",
                 value: "https://override:9090",
             },
@@ -2610,6 +2731,13 @@ fn env_vars_invalid_values() {
                 value: "not_a_number",
             },
             "error: invalid value 'not_a_number' for '--ringbuf-size <RINGBUF_SIZE>': invalid digit found in string",
+        ),
+        (
+            EnvVar {
+                name: "FACT_D_INSTANTIATE_CTX_SIZE",
+                value: "not_a_number",
+            },
+            "error: invalid value 'not_a_number' for '--d-inst-size <D_INSTANTIATE_CTX_SIZE>': invalid digit found in string",
         ),
         (
             EnvVar {


### PR DESCRIPTION

## Description

With the changes introduced by #1440, the d_instantiate_ctx map has grown considerably in size. This patch reduces the default size and exposes a method for setting the size at runtime for fine-tweaking.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run fact with `--d-inst-size 65535` and use `bpftool map show` to check the map max_entries is properly set:
```
31236: lru_hash  name d_instantiate_c  flags 0x0
	key 8B  value 12320B  max_entries 655535  memlock 8129679272B
	btf_id 13108
	pids fact(751156)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration support for tuning the BPF context map capacity.
  * The setting can be specified through configuration files, environment variables, and command-line options.
  * Defaults to 512 entries when not configured.
  * Invalid or out-of-range values are rejected with an error.

* **Bug Fixes**
  * Ensured the configured capacity is applied when loading BPF components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->