### PR TITLE
refactor(metrics): improve d_instantiate dispatch metric tracking

### DIFF
--- a/fact-ebpf/src/bpf/main.c
+++ b/fact-ebpf/src/bpf/main.c
@@ -336,7 +336,7 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
   if (m == NULL) {
     return 0;
   }
-  struct submit_event_args_t args = {.metrics = &m->d_instantiate};
+  struct submit_event_args_t args = {.metrics = &m->d_instantiate.base};
 
   args.metrics->total++;
 
@@ -364,6 +364,7 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
         args.metrics->error++;
       }
 
+      m->d_instantiate.added_mkdir++;
       submit_mkdir_event(&args);
       break;
     case FILE_ACTIVITY_SYMLINK:
@@ -375,7 +376,10 @@ int BPF_PROG(trace_d_instantiate, struct dentry* dentry, struct inode* inode) {
       }
 
       if (args.monitored != NOT_MONITORED) {
+        m->d_instantiate.added_symlink++;
         submit_symlink_event(&args, d_inst_ctx->symlink_target);
+      } else {
+        args.metrics->ignored++;
       }
       break;
     default:

--- a/fact-ebpf/src/bpf/types.h
+++ b/fact-ebpf/src/bpf/types.h
@@ -179,6 +179,12 @@ struct metrics_by_hook_t {
   unsigned long long ringbuffer_full;
 };
 
+struct metrics_d_instantiate_t {
+  struct metrics_by_hook_t base;
+  unsigned long long added_mkdir;
+  unsigned long long added_symlink;
+};
+
 struct metrics_t {
   struct metrics_by_hook_t file_open;
   struct metrics_by_hook_t path_unlink;
@@ -186,7 +192,7 @@ struct metrics_t {
   struct metrics_by_hook_t path_chown;
   struct metrics_by_hook_t path_rename;
   struct metrics_by_hook_t path_mkdir;
-  struct metrics_by_hook_t d_instantiate;
+  struct metrics_d_instantiate_t d_instantiate;
   struct metrics_by_hook_t path_rmdir;
   struct metrics_by_hook_t inode_setxattr;
   struct metrics_by_hook_t inode_removexattr;

--- a/fact-ebpf/src/lib.rs
+++ b/fact-ebpf/src/lib.rs
@@ -201,7 +201,25 @@ impl<'de> Deserialize<'de> for monitored_t {
     }
 }
 
-impl metrics_by_hook_t {
+pub enum KernelMetricLabel {
+    Total,
+    Added,
+    Dropped,
+    Ignored,
+    Error,
+    RingbufferFull,
+
+    // d_instantiate specific metrics
+    AddedMkDir,
+    AddedSymlink,
+}
+
+pub trait KernelMetric {
+    fn accumulate(self, other: &Self) -> Self;
+    fn encode(&self) -> impl Iterator<Item = (KernelMetricLabel, u64)>;
+}
+
+impl KernelMetric for metrics_by_hook_t {
     fn accumulate(mut self, other: &metrics_by_hook_t) -> metrics_by_hook_t {
         self.total += other.total;
         self.added += other.added;
@@ -209,6 +227,35 @@ impl metrics_by_hook_t {
         self.ignored += other.ignored;
         self.ringbuffer_full += other.ringbuffer_full;
         self
+    }
+
+    fn encode(&self) -> impl Iterator<Item = (KernelMetricLabel, u64)> {
+        use KernelMetricLabel::*;
+        [
+            (Total, self.total),
+            (Added, self.added),
+            (Error, self.error),
+            (Ignored, self.ignored),
+            (RingbufferFull, self.ringbuffer_full),
+        ]
+        .into_iter()
+    }
+}
+
+impl KernelMetric for metrics_d_instantiate_t {
+    fn accumulate(mut self, other: &metrics_d_instantiate_t) -> metrics_d_instantiate_t {
+        self.base = self.base.accumulate(&other.base);
+        self.added_mkdir += other.added_mkdir;
+        self.added_symlink += other.added_symlink;
+        self
+    }
+
+    fn encode(&self) -> impl Iterator<Item = (KernelMetricLabel, u64)> {
+        use KernelMetricLabel::*;
+        self.base.encode().chain([
+            (AddedSymlink, self.added_symlink),
+            (AddedMkDir, self.added_mkdir),
+        ])
     }
 }
 

--- a/fact/src/config/mod.rs
+++ b/fact/src/config/mod.rs
@@ -869,6 +869,10 @@ pub struct FactCli {
     /// This is an advanced configuration parameter, it can be used to
     /// increase the amount of in-flight events that use the
     /// d_instantiate LSM hook for resolving inode numbers.
+    ///
+    /// Whether this value needs to be tweaked can be determined with
+    /// the metrics exposed for the d_instantiate hook and the ones for
+    /// the originating hooks.
     #[arg(
         long = "d-inst-size",
         env = "FACT_D_INSTANTIATE_CTX_SIZE",

--- a/fact/src/metrics/kernel_metrics.rs
+++ b/fact/src/metrics/kernel_metrics.rs
@@ -1,11 +1,11 @@
 use aya::maps::{MapData, PerCpuArray};
 use prometheus_client::registry::Registry;
 
-use fact_ebpf::{metrics_by_hook_t, metrics_t};
+use fact_ebpf::{KernelMetric, metrics_t};
 
 use crate::metrics::MetricEvents;
 
-use super::{EventCounter, LabelValues};
+use super::EventCounter;
 
 macro_rules! define_kernel_metrics {
     ($($hook:ident),+ $(,)?) => {
@@ -46,17 +46,11 @@ macro_rules! define_kernel_metrics {
                 Ok(())
             }
 
-            fn refresh_labels(ec: &EventCounter, m: &metrics_by_hook_t) {
+            fn refresh_labels(ec: &EventCounter, m: &impl KernelMetric) {
                 ec.counter.clear();
-                for (label, value) in [
-                    (LabelValues::Total, m.total),
-                    (LabelValues::Added, m.added),
-                    (LabelValues::Error, m.error),
-                    (LabelValues::Ignored, m.ignored),
-                    (LabelValues::RingbufferFull, m.ringbuffer_full),
-                ] {
+                for (label, value) in m.encode() {
                     ec.counter
-                        .get_or_create(&MetricEvents { label })
+                        .get_or_create(&MetricEvents{ label: label.into() })
                         .inc_by(value);
                 }
             }

--- a/fact/src/metrics/mod.rs
+++ b/fact/src/metrics/mod.rs
@@ -6,6 +6,7 @@ use prometheus_client::{
 
 use host_scanner::HostScannerMetrics;
 
+use fact_ebpf::KernelMetricLabel;
 pub mod exporter;
 pub mod host_scanner;
 pub mod kernel_metrics;
@@ -18,6 +19,25 @@ enum LabelValues {
     Ignored,
     Error,
     RingbufferFull,
+
+    // d_instantiate specific metrics
+    AddedMkDir,
+    AddedSymlink,
+}
+
+impl From<KernelMetricLabel> for LabelValues {
+    fn from(value: KernelMetricLabel) -> Self {
+        match value {
+            KernelMetricLabel::Total => LabelValues::Total,
+            KernelMetricLabel::Added => LabelValues::Added,
+            KernelMetricLabel::Dropped => LabelValues::Dropped,
+            KernelMetricLabel::Ignored => LabelValues::Ignored,
+            KernelMetricLabel::Error => LabelValues::Error,
+            KernelMetricLabel::RingbufferFull => LabelValues::RingbufferFull,
+            KernelMetricLabel::AddedMkDir => LabelValues::AddedMkDir,
+            KernelMetricLabel::AddedSymlink => LabelValues::AddedSymlink,
+        }
+    }
 }
 
 #[derive(Clone, Hash, Eq, Debug, PartialEq, EncodeLabelSet)]


### PR DESCRIPTION
## Description

Add new metrics to the d_instantiate hook that allow for tracking individual event types dispatched. This is helpful to identify if one of these types are being lost by comparing the `Added` label from the originating hook (like path_mkdir or path_symlink) with the corresponding `Added<hook>` label.

In order for `d_instantiate` to have its own type some trait + iterator gymnastics were necessary. The summary for this is:
* A new `KernelMetric` trait is created which describes how metrics coming from the kernel should be accumulated and encoded using a `KernelMetricLabel` helper type.
* The trait is implemented for `metrics_by_hook_t` and `metrics_d_instantiate_t`.
* The metrics module know how to translate from `KernelMetricLabel` to `LabelValues`, so it does the same `accumulate` process it used to do and then uses the iterator produced by `encode` to add metrics dynamically.

## Checklist
- [x] Patch has a change log entry **OR** does not need one.
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Check metrics generated in tests have the expected values.

Example metrics for d_instantiate from a mkdir test:

```
# HELP stackrox_fact_kernel_d_instantiate_events Events processed by the d_instantiate LSM hook.
# TYPE stackrox_fact_kernel_d_instantiate_events counter
stackrox_fact_kernel_d_instantiate_events_total{label="Total"} 15
stackrox_fact_kernel_d_instantiate_events_total{label="Added"} 3
stackrox_fact_kernel_d_instantiate_events_total{label="AddedSymlink"} 0
stackrox_fact_kernel_d_instantiate_events_total{label="Error"} 0
stackrox_fact_kernel_d_instantiate_events_total{label="AddedMkDir"} 3
stackrox_fact_kernel_d_instantiate_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_d_instantiate_events_total{label="Ignored"} 12
```

<details>
<summary>Full metrics from that same test</summary>

```
# HELP stackrox_fact_bpf_events Events processed by the BPF worker.
# TYPE stackrox_fact_bpf_events counter
stackrox_fact_bpf_events_total{label="Added"} 4
stackrox_fact_bpf_events_total{label="Dropped"} 0
stackrox_fact_bpf_events_total{label="Ignored"} 0
# HELP stackrox_fact_rate_limiter_events Events processed by the rate limiter.
# TYPE stackrox_fact_rate_limiter_events counter
stackrox_fact_rate_limiter_events_total{label="Added"} 1
stackrox_fact_rate_limiter_events_total{label="Dropped"} 0
stackrox_fact_rate_limiter_events_total{label="Error"} 0
# HELP stackrox_fact_output_stdout_events Events processed by the stdout output component.
# TYPE stackrox_fact_output_stdout_events counter
stackrox_fact_output_stdout_events_total{label="Dropped"} 0
stackrox_fact_output_stdout_events_total{label="Added"} 1
# HELP stackrox_fact_output_grpc_events Events processed by the grpc output component.
# TYPE stackrox_fact_output_grpc_events counter
stackrox_fact_output_grpc_events_total{label="Added"} 1
stackrox_fact_output_grpc_events_total{label="Dropped"} 0
# HELP stackrox_fact_output_otel_events Events processed by the otel output component.
# TYPE stackrox_fact_output_otel_events counter
stackrox_fact_output_otel_events_total{label="Added"} 0
stackrox_fact_output_otel_events_total{label="Dropped"} 0
# HELP stackrox_fact_host_scanner_events Events processed by the host scanner component.
# TYPE stackrox_fact_host_scanner_events counter
stackrox_fact_host_scanner_events_total{label="Ignored"} 0
stackrox_fact_host_scanner_events_total{label="Total"} 0
stackrox_fact_host_scanner_events_total{label="Added"} 4
stackrox_fact_host_scanner_events_total{label="Dropped"} 0
# HELP stackrox_fact_host_scanner_scan Counter of events by scans from the host scanner component.
# TYPE stackrox_fact_host_scanner_scan counter
stackrox_fact_host_scanner_scan_total{label="InodeRemoved"} 0
stackrox_fact_host_scanner_scan_total{label="DirectoryScanned"} 1
stackrox_fact_host_scanner_scan_total{label="FileUpdated"} 6
stackrox_fact_host_scanner_scan_total{label="FsItemIgnored"} 0
stackrox_fact_host_scanner_scan_total{label="ElementsScanned"} 4
stackrox_fact_host_scanner_scan_total{label="FileRemoved"} 0
stackrox_fact_host_scanner_scan_total{label="Scans"} 1
stackrox_fact_host_scanner_scan_total{label="InodeHit"} 4
stackrox_fact_host_scanner_scan_total{label="FileScanned"} 1
# HELP stackrox_fact_kernel_file_open_events Events processed by the file_open LSM hook.
# TYPE stackrox_fact_kernel_file_open_events counter
stackrox_fact_kernel_file_open_events_total{label="Ignored"} 28
stackrox_fact_kernel_file_open_events_total{label="Total"} 29
stackrox_fact_kernel_file_open_events_total{label="Added"} 1
stackrox_fact_kernel_file_open_events_total{label="Error"} 0
stackrox_fact_kernel_file_open_events_total{label="RingbufferFull"} 0
# HELP stackrox_fact_kernel_path_unlink_events Events processed by the path_unlink LSM hook.
# TYPE stackrox_fact_kernel_path_unlink_events counter
stackrox_fact_kernel_path_unlink_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_path_unlink_events_total{label="Added"} 0
stackrox_fact_kernel_path_unlink_events_total{label="Ignored"} 0
stackrox_fact_kernel_path_unlink_events_total{label="Error"} 0
stackrox_fact_kernel_path_unlink_events_total{label="Total"} 0
# HELP stackrox_fact_kernel_path_chmod_events Events processed by the path_chmod LSM hook.
# TYPE stackrox_fact_kernel_path_chmod_events counter
stackrox_fact_kernel_path_chmod_events_total{label="Error"} 0
stackrox_fact_kernel_path_chmod_events_total{label="Ignored"} 0
stackrox_fact_kernel_path_chmod_events_total{label="Added"} 0
stackrox_fact_kernel_path_chmod_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_path_chmod_events_total{label="Total"} 0
# HELP stackrox_fact_kernel_path_chown_events Events processed by the path_chown LSM hook.
# TYPE stackrox_fact_kernel_path_chown_events counter
stackrox_fact_kernel_path_chown_events_total{label="Total"} 0
stackrox_fact_kernel_path_chown_events_total{label="Error"} 0
stackrox_fact_kernel_path_chown_events_total{label="Added"} 0
stackrox_fact_kernel_path_chown_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_path_chown_events_total{label="Ignored"} 0
# HELP stackrox_fact_kernel_path_rename_events Events processed by the path_rename LSM hook.
# TYPE stackrox_fact_kernel_path_rename_events counter
stackrox_fact_kernel_path_rename_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_path_rename_events_total{label="Total"} 0
stackrox_fact_kernel_path_rename_events_total{label="Ignored"} 0
stackrox_fact_kernel_path_rename_events_total{label="Error"} 0
stackrox_fact_kernel_path_rename_events_total{label="Added"} 0
# HELP stackrox_fact_kernel_path_mkdir_events Events processed by the path_mkdir LSM hook.
# TYPE stackrox_fact_kernel_path_mkdir_events counter
stackrox_fact_kernel_path_mkdir_events_total{label="Added"} 0
stackrox_fact_kernel_path_mkdir_events_total{label="Error"} 0
stackrox_fact_kernel_path_mkdir_events_total{label="Total"} 3
stackrox_fact_kernel_path_mkdir_events_total{label="Ignored"} 0
stackrox_fact_kernel_path_mkdir_events_total{label="RingbufferFull"} 0
# HELP stackrox_fact_kernel_path_rmdir_events Events processed by the path_rmdir LSM hook.
# TYPE stackrox_fact_kernel_path_rmdir_events counter
stackrox_fact_kernel_path_rmdir_events_total{label="Total"} 0
stackrox_fact_kernel_path_rmdir_events_total{label="Added"} 0
stackrox_fact_kernel_path_rmdir_events_total{label="Error"} 0
stackrox_fact_kernel_path_rmdir_events_total{label="Ignored"} 0
stackrox_fact_kernel_path_rmdir_events_total{label="RingbufferFull"} 0
# HELP stackrox_fact_kernel_d_instantiate_events Events processed by the d_instantiate LSM hook.
# TYPE stackrox_fact_kernel_d_instantiate_events counter
stackrox_fact_kernel_d_instantiate_events_total{label="Total"} 15
stackrox_fact_kernel_d_instantiate_events_total{label="Added"} 3
stackrox_fact_kernel_d_instantiate_events_total{label="AddedSymlink"} 0
stackrox_fact_kernel_d_instantiate_events_total{label="Error"} 0
stackrox_fact_kernel_d_instantiate_events_total{label="AddedMkDir"} 3
stackrox_fact_kernel_d_instantiate_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_d_instantiate_events_total{label="Ignored"} 12
# HELP stackrox_fact_kernel_inode_setxattr_events Events processed by the inode_setxattr LSM hook.
# TYPE stackrox_fact_kernel_inode_setxattr_events counter
stackrox_fact_kernel_inode_setxattr_events_total{label="Ignored"} 0
stackrox_fact_kernel_inode_setxattr_events_total{label="Added"} 0
stackrox_fact_kernel_inode_setxattr_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_inode_setxattr_events_total{label="Total"} 0
stackrox_fact_kernel_inode_setxattr_events_total{label="Error"} 0
# HELP stackrox_fact_kernel_inode_removexattr_events Events processed by the inode_removexattr LSM hook.
# TYPE stackrox_fact_kernel_inode_removexattr_events counter
stackrox_fact_kernel_inode_removexattr_events_total{label="Error"} 0
stackrox_fact_kernel_inode_removexattr_events_total{label="Added"} 0
stackrox_fact_kernel_inode_removexattr_events_total{label="Total"} 0
stackrox_fact_kernel_inode_removexattr_events_total{label="Ignored"} 0
stackrox_fact_kernel_inode_removexattr_events_total{label="RingbufferFull"} 0
# HELP stackrox_fact_kernel_inode_set_acl_events Events processed by the inode_set_acl LSM hook.
# TYPE stackrox_fact_kernel_inode_set_acl_events counter
stackrox_fact_kernel_inode_set_acl_events_total{label="Total"} 0
stackrox_fact_kernel_inode_set_acl_events_total{label="Ignored"} 0
stackrox_fact_kernel_inode_set_acl_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_inode_set_acl_events_total{label="Added"} 0
stackrox_fact_kernel_inode_set_acl_events_total{label="Error"} 0
# HELP stackrox_fact_kernel_sb_mount_events Events processed by the sb_mount LSM hook.
# TYPE stackrox_fact_kernel_sb_mount_events counter
stackrox_fact_kernel_sb_mount_events_total{label="Total"} 0
stackrox_fact_kernel_sb_mount_events_total{label="Error"} 0
stackrox_fact_kernel_sb_mount_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_sb_mount_events_total{label="Added"} 0
stackrox_fact_kernel_sb_mount_events_total{label="Ignored"} 0
# HELP stackrox_fact_kernel_sb_umount_events Events processed by the sb_umount LSM hook.
# TYPE stackrox_fact_kernel_sb_umount_events counter
stackrox_fact_kernel_sb_umount_events_total{label="Total"} 0
stackrox_fact_kernel_sb_umount_events_total{label="Added"} 0
stackrox_fact_kernel_sb_umount_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_sb_umount_events_total{label="Error"} 0
stackrox_fact_kernel_sb_umount_events_total{label="Ignored"} 0
# HELP stackrox_fact_kernel_move_mount_events Events processed by the move_mount LSM hook.
# TYPE stackrox_fact_kernel_move_mount_events counter
stackrox_fact_kernel_move_mount_events_total{label="Total"} 0
stackrox_fact_kernel_move_mount_events_total{label="Added"} 0
stackrox_fact_kernel_move_mount_events_total{label="Ignored"} 0
stackrox_fact_kernel_move_mount_events_total{label="Error"} 0
stackrox_fact_kernel_move_mount_events_total{label="RingbufferFull"} 0
# HELP stackrox_fact_kernel_path_symlink_events Events processed by the path_symlink LSM hook.
# TYPE stackrox_fact_kernel_path_symlink_events counter
stackrox_fact_kernel_path_symlink_events_total{label="Error"} 0
stackrox_fact_kernel_path_symlink_events_total{label="Ignored"} 0
stackrox_fact_kernel_path_symlink_events_total{label="RingbufferFull"} 0
stackrox_fact_kernel_path_symlink_events_total{label="Added"} 0
stackrox_fact_kernel_path_symlink_events_total{label="Total"} 0
# EOF
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kernel metrics now report dedicated counters for directory creation and symbolic-link events.
  - Metric collection supports extensible labels, enabling more detailed event visibility.

- **Improvements**
  - Kernel metric aggregation and reporting now consistently include specialized event counters.
  - Added guidance for determining whether the `d_instantiate_ctx_size` configuration requires adjustment.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->